### PR TITLE
fix: enable lindel for wasm

### DIFF
--- a/extensions/lindel/description.yml
+++ b/extensions/lindel/description.yml
@@ -5,10 +5,9 @@ extension:
   language: C++
   build: cmake
   license: Apache-2.0
-  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads"
   maintainers:
     - rustyconover
 
 repo:
   github: rustyconover/duckdb-lindel-extension
-  ref: 295963d5513642d94511fae10081f0acea508db5
+  ref: 76f5bc78e8bfd1a7953c8cc4c284209b65626216


### PR DESCRIPTION
I got the build working for WASM, so let's publish that too please.