### PR TITLE
Improve docs markdown generation, allow example and extended 

### DIFF
--- a/extensions/quack/description.yml
+++ b/extensions/quack/description.yml
@@ -11,3 +11,9 @@ extension:
 repo:
   github: hannes/quack
   ref: 09680a975bcf9e93b5a2f46d3eeb68792d5239c6
+
+docs:
+  hello_world: |
+    SELECT quack(i::VARCHAR) FROM range(10) tbl(i);
+  extended_description: |
+    The quack extension is based on DuckDB's [Extension Template](https://duckdb/extension_template/), and it's a great starting point to get started building more advanced extensions.

--- a/extensions/quack/description.yml
+++ b/extensions/quack/description.yml
@@ -14,6 +14,6 @@ repo:
 
 docs:
   hello_world: |
-    SELECT quack(i::VARCHAR) FROM range(10) tbl(i);
+    SELECT quack('world');
   extended_description: |
     The quack extension is based on DuckDB's [Extension Template](https://duckdb/extension_template/), and it's a great starting point to get started building more advanced extensions.

--- a/layout/default.md
+++ b/layout/default.md
@@ -3,8 +3,13 @@
 ```sql
 INSTALL {{ page.extension.name }} FROM community;
 LOAD {{ page.extension.name }};
+```
+
 {% if page.docs.hello_world %}
-{{ page.docs.hello_world }}{% endif %}```
+### Example
+```sql
+{{ page.docs.hello_world }}```
+{% endif %}
 
 {% if page.docs.extended_description %}
 ### About {{ page.extension.name }}

--- a/layout/default.md
+++ b/layout/default.md
@@ -1,0 +1,13 @@
+
+### Installing and Loading
+```sql
+INSTALL {{ page.extension.name }} FROM community;
+LOAD {{ page.extension.name }};
+{% if page.docs.hello_world %}
+{{ page.docs.hello_world }}{% endif %}```
+
+{% if page.docs.extended_description %}
+### About {{ page.extension.name }}
+{{ page.docs.extended_description }}
+{% endif %}
+

--- a/scripts/generate_md.sh
+++ b/scripts/generate_md.sh
@@ -61,38 +61,44 @@ do
     rm -f pre.db
     rm -f post.db
 
-    if [ -s "$DOCS/$extension/extension.md" ]; then
-       echo "## $extension" > $EXTENSION_README
+    echo "---" > $EXTENSION_README
+    echo "layout: community_extension" >> $EXTENSION_README
+    echo "title: $extension" >> $EXTENSION_README
+    if [ -s "extensions/$extension/description.yml" ]; then
+       cat extensions/$extension/description.yml >> $EXTENSION_README
        echo "" >> $EXTENSION_README
-       cat $DOCS/$extension/extension.md >> $EXTENSION_README
-       echo "" >> $EXTENSION_README
+       echo -n "extension_star_count: " >> $EXTENSION_README
+       python3 scripts/get_stars.py extensions/$extension/description.yml $1 >> $EXTENSION_README
+    fi
+    echo "---" >> $EXTENSION_README
+    cat layout/default.md >> $EXTENSION_README
 
-       if [ -s "$DOCS/$extension/functions.md" ]; then
-          echo "### Added functions" >> $EXTENSION_README
-          echo "" >> $EXTENSION_README
-          cat $DOCS/$extension/functions.md >> $EXTENSION_README
-          echo "" >> $EXTENSION_README
-       fi
-       if [ -s "$DOCS/$extension/functions_overloads.md" ]; then
-          echo "### Added function overloads" >> $EXTENSION_README
-          echo "" >> $EXTENSION_README
-          cat $DOCS/$extension/functions_overloads.md >> $EXTENSION_README
-          echo "" >> $EXTENSION_README
-       fi
-       if [ -s "$DOCS/$extension/types.md" ]; then
-          echo "### Added types" >> $EXTENSION_README
-          echo "" >> $EXTENSION_README
-          cat $DOCS/$extension/types.md >> $EXTENSION_README
-          echo "" >> $EXTENSION_README
-       fi
-       if [ -s "$DOCS/$extension/settings.md" ]; then
-          echo "### Added settings" >> $EXTENSION_README
-          echo "" >> $EXTENSION_README
-          cat $DOCS/$extension/settings.md >> $EXTENSION_README
-          echo "" >> $EXTENSION_README
-       fi
+    if [ -s "$DOCS/$extension/functions.md" ]; then
+       echo "### Added functions" >> $EXTENSION_README
+       echo "" >> $EXTENSION_README
+       cat $DOCS/$extension/functions.md >> $EXTENSION_README
        echo "" >> $EXTENSION_README
     fi
+    if [ -s "$DOCS/$extension/functions_overloads.md" ]; then
+       echo "### Added function overloads" >> $EXTENSION_README
+       echo "" >> $EXTENSION_README
+       cat $DOCS/$extension/functions_overloads.md >> $EXTENSION_README
+       echo "" >> $EXTENSION_README
+    fi
+    if [ -s "$DOCS/$extension/types.md" ]; then
+       echo "### Added types" >> $EXTENSION_README
+       echo "" >> $EXTENSION_README
+       cat $DOCS/$extension/types.md >> $EXTENSION_README
+       echo "" >> $EXTENSION_README
+    fi
+    if [ -s "$DOCS/$extension/settings.md" ]; then
+       echo "### Added settings" >> $EXTENSION_README
+       echo "" >> $EXTENSION_README
+       cat $DOCS/$extension/settings.md >> $EXTENSION_README
+       echo "" >> $EXTENSION_README
+    fi
+    echo "" >> $EXTENSION_README
+
     rm -rf $DOCS/$extension
 done
 

--- a/scripts/get_stars.py
+++ b/scripts/get_stars.py
@@ -1,0 +1,14 @@
+import os
+import sys
+import yaml
+import subprocess
+
+desc_file = sys.argv[1]
+duckdb = sys.argv[2]
+
+with open(desc_file, 'r') as stream:
+	desc = yaml.safe_load(stream)
+
+subprocess.run([duckdb, "-c", "COPY (SELECT ' ') TO 'build/stars.csv' (HEADER FALSE);"])
+subprocess.run([duckdb, "-c", "COPY (SELECT stargazers_count FROM read_json('https://api.github.com/repos/" + desc['repo']['github'] + "')) TO 'build/stars.csv' (HEADER FALSE);"])
+subprocess.run(["cat", "build/stars.csv"])


### PR DESCRIPTION
Add possibility for extension to have two extra fields in the descriptor file:
* docs.hello_world: an optional SQL based example of what capabilities the extension provides
* docs.extension_description: allow to pass an optional extra paragraph (markdown enabled) to describe / provide additional context on the extension

That allows to generate markdown files, that once passed down to the website generation outputs something like:
![image](https://github.com/duckdb/community-extensions/assets/842657/e974a648-3f6c-4121-bef1-5c3271b31d45)

HTML side improvements have to be made, but those are orthogonal on deciding what content should be there.