### PR TITLE
Scrooge to skip 'windows_amd64_rtools' target for now

### DIFF
--- a/extensions/scrooge/description.yml
+++ b/extensions/scrooge/description.yml
@@ -3,6 +3,7 @@ extension:
   description: Provides functionality for financial data-analysis. Including data scanners for the Ethereum Blockchain and Yahoo Finance.
   version: 0.0.1
   language: C++
+  excluded_platforms: "windows_amd64_rtools"
   build: cmake
   license: MIT
   maintainers:


### PR DESCRIPTION
Scrooge own CI do not runs on windows_amd64_rtools target (https://github.com/pdet/Scrooge-McDuck/blob/main/.github/workflows/MainDistributionPipeline.yml#L21), so disabling also here given it fails.

@pdet: feel free to send a PR re-enabling whenever you get it to work