### PR TITLE
Add chsql extension

### DIFF
--- a/extensions/chsql/description.yml
+++ b/extensions/chsql/description.yml
@@ -1,0 +1,19 @@
+extension:
+  name: chsql
+  description: Clickhouse SQL Macros for DuckDB
+  version: 1.0.0
+  language: C++
+  build: cmake
+  license: MIT
+  maintainers:
+    - lmangani
+
+repo:
+  github: lmangani/duckdb-extension-clickhouse-sql
+  ref: 21c240ec0cbef00d5928083f5fc936ec42542911
+
+docs:
+  hello_world: |
+    SELECT toString('world') as hello, toInt8OrZero('world') as zero;
+  extended_description: |
+    This extension provides a growing number of Clickhouse SQL Macros for DuckDB. 

--- a/extensions/chsql/description.yml
+++ b/extensions/chsql/description.yml
@@ -2,7 +2,7 @@ extension:
   name: chsql
   description: Clickhouse SQL Macros for DuckDB
   version: 1.0.0
-  language: C++
+  language: SQL & C++
   build: cmake
   license: MIT
   maintainers:


### PR DESCRIPTION
Adding chsql extension to Community 🤞 

> This extension provides a growing number of Clickhouse SQL Macros for DuckDB. 

Special thanks @carlopi for all the support and assistance backporting the builders to v1.0.0 ⭐ 