### PR TITLE
Update chsql extension ref

### DIFF
--- a/extensions/chsql/description.yml
+++ b/extensions/chsql/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: chsql
   description: ClickHouse SQL Macros for DuckDB
-  version: 1.0.0
+  version: 1.0.1
   language: SQL & C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: lmangani/duckdb-extension-clickhouse-sql
-  ref: 21c240ec0cbef00d5928083f5fc936ec42542911
+  ref: 17c249ba08a9b88338e77c7f2d6e5dd2040b4590
 
 docs:
   hello_world: |


### PR DESCRIPTION
The version field is not used but has been updated simply for tracking purposes.
If this blocks other processes or pairing w/ DuckDB v1.0.0 we can remove it.