### PR TITLE
add requires_toolchains options

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,6 @@ jobs:
     if: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_NAME != '' }}
     with:
       duckdb_version: v1.0.0
-      enable_rust: true
       exclude_archs: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_EXCLUDE_PLATFORMS }}
       extra_toolchains: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_REQUIRES_TOOLCHAINS }}
       extension_name: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_NAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
       COMMUNITY_EXTENSION_REF: ${{ steps.parse.outputs.COMMUNITY_EXTENSION_REF }}
       COMMUNITY_EXTENSION_DEPLOY: ${{ steps.parse.outputs.COMMUNITY_EXTENSION_DEPLOY }}
       COMMUNITY_EXTENSION_EXCLUDE_PLATFORMS: ${{ steps.parse.outputs.COMMUNITY_EXTENSION_EXCLUDE_PLATFORMS }}
+      COMMUNITY_EXTENSION_REQUIRES_TOOLCHAINS: ${{ steps.parse.outputs.COMMUNITY_EXTENSION_REQUIRES_TOOLCHAINS }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -46,6 +47,7 @@ jobs:
       duckdb_version: v1.0.0
       enable_rust: true
       exclude_archs: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_EXCLUDE_PLATFORMS }}
+      extra_toolchains: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_REQUIRES_TOOLCHAINS }}
       extension_name: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_NAME }}
       override_repository: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_GITHUB }}
       override_ref: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_REF }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,6 @@ jobs:
       matrix: ${{fromJson(needs.prepare.outputs.matrix)}}
     with:
       duckdb_version: v1.0.0
-      enable_rust: true
       extension_name: ${{ matrix.COMMUNITY_EXTENSION_NAME }}
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools'
       repository: ${{ matrix.COMMUNITY_EXTENSION_GITHUB }}

--- a/extensions/crypto/description.yml
+++ b/extensions/crypto/description.yml
@@ -3,6 +3,7 @@ extension:
   description: Cryptographic hash functions and HMAC
   version: 1.0.0
   language: C++
+  requires_toolchains: "rust"
   build: cmake
   license: MIT
   excluded_platforms: "windows_amd64_rtools;windows_amd64"

--- a/extensions/evalexpr_rhai/description.yml
+++ b/extensions/evalexpr_rhai/description.yml
@@ -4,6 +4,7 @@ extension:
   version: 1.0.0
   language: C++
   build: cmake
+  requires_toolchains: "rust"
   license: Apache-2.0
   maintainers:
     - rustyconover

--- a/extensions/prql/description.yml
+++ b/extensions/prql/description.yml
@@ -4,6 +4,7 @@ extension:
   version: 1.0.0
   language: C++
   build: cmake
+  requires_toolchains: "rust"
   license: MIT
   maintainers:
     - ywelsch

--- a/extensions/quack/description.yml
+++ b/extensions/quack/description.yml
@@ -4,6 +4,8 @@ extension:
   version: 0.0.1
   language: C++
   build: cmake
+  # Note that quack doesn't actually need any extra toolchains, but they are added since quack is used to test community-extensions CI
+  requires_toolchains: "rust"
   license: MIT
   maintainers:
     - hannes

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -35,7 +35,10 @@ with open('env.sh', 'w+') as hdl:
 	hdl.write(f"COMMUNITY_EXTENSION_REF={desc['repo']['ref']}\n")
 	hdl.write(f"COMMUNITY_EXTENSION_NAME={desc['extension']['name']}\n")
 	excluded_platforms = desc['extension'].get('excluded_platforms')
+	requires_toolchains = desc['extension'].get('requires_toolchains')
 	if excluded_platforms:
 		hdl.write(f"COMMUNITY_EXTENSION_EXCLUDE_PLATFORMS={excluded_platforms}\n")
+	if requires_toolchains:
+		hdl.write(f"COMMUNITY_EXTENSION_REQUIRES_TOOLCHAINS={requires_toolchains}\n")
 	if deploy:
 		hdl.write(f"COMMUNITY_EXTENSION_DEPLOY=1\n")


### PR DESCRIPTION
This option allows specifying optional extra toolchains that are required for building. So far we have only the rust toolchain. But we would like to be able to add more.

it can be specified as a `;` separated list of toolchain names, that are passed straight down into `duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml`.

I've enabled the option for the existing extensions that depend on rust, and removed the now deprecated `enable_rust` option. This means that every extension added to the community extensions that needs rust, will need to specify it in its description file