### PR TITLE
Add workflow to deploy website

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,0 +1,51 @@
+name: Generate and Deploy Website
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/checkout@v4
+      with:
+        repository: 'duckdb/duckdb-web'
+        ref: 'community-extension'
+        path: 'web'
+
+    - name: Set up DuckDB
+      run: |
+        wget https://github.com/duckdb/duckdb/releases/download/v1.0.0/duckdb_cli-linux-amd64.zip
+        unzip duckdb_cli-linux-amd64.zip
+        chmod +x duckdb
+
+    - name: Fetch extensions
+      run: |
+        ./scripts/fetch_extensions.sh ./duckdb
+
+    - name: Generate docs
+      run: |
+        ./scripts/generate_md.sh ./duckdb
+        cp build/docs/* web/extensions/.
+
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+         ruby-version: '3.3' # Not needed with a .ruby-version file
+         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+         cache-version: 0 # Increment this number if you need to re-download cached gems
+
+    - name: Build with Jekyll
+      working-directory: 'web'
+      run: bundle install && bundler exec jekyll build --config _config.yml,_config_exclude_archive.yml
+
+    - name: Deploy website
+      working-directory: 'web'
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.DUCKDB_COMMUNITY_EXTENSION_S3_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.DUCKDB_COMMUNITY_EXTENSION_S3_SECRET }}
+        AWS_DEFAULT_REGION: ${{ secrets.S3_DUCKDB_ORG_REGION }}
+      run: |
+        aws s3 cp --recursive extensions/ s3://duckdb-community-extensions/extensions --acl public-read

--- a/scripts/clean_caches.sh
+++ b/scripts/clean_caches.sh
@@ -15,19 +15,19 @@ CLOUDFRONT_DISTRIBUTION_ID=E2Z28NDMI4PVXP
 
 ouput=$(aws s3 sync s3://$BUCKET . --exclude "*" --include "$PATTERN" --dryrun | awk ' { print $5 } ')
 
-if [ "$DUCKDB_CLEAN_CACHES_SCRIPT_MODE" == "for_real" ]; then
-  echo "CLOUDFRONT INVALIDATION"
-  while IFS= read -r path; do
-    aws cloudfront create-invalidation --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" --paths "$path"
-  done <<< $ouput
-else
+#if [ "$DUCKDB_CLEAN_CACHES_SCRIPT_MODE" == "for_real" ]; then
+#  echo "CLOUDFRONT INVALIDATION"
+#  while IFS= read -r path; do
+#    aws cloudfront create-invalidation --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" --paths "$path"
+#  done <<< $ouput
+#else
   echo "INVALIDATION (DRY RUN)"
   echo "> Domain: $CLOUDFRONT_ORIGINS"
   echo "> Paths:"
   while IFS= read -r path; do
     echo "    $path"
   done <<< $ouput
-fi
+#fi
 
 echo ""
 


### PR DESCRIPTION
Script takes current state of duckdb/community-extensions combined with the latest state of the `community-extension` branch in duckdb-web.

Workflow is to be triggered, either manually or from another worfklow.

Calling mechanism is not yet there, first allowing to iterate on this.