### PR TITLE
Fix csv list generation and avoid unnecessary rebuilds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,17 @@
 name: Community Extension Build
 on:
   pull_request:
+    paths-ignore:
+      - '**'
+      - '!scripts/build.py'
+      - '!.github/workflows/build.yml'
+      - '!extensions/*/description.yml'
   push:
+    paths-ignore:
+      - '**'
+      - '!scripts/build.py'
+      - '!.github/workflows/build.yml'
+      - '!extensions/*/description.yml'
   workflow_dispatch:
     inputs:
       extension_name:

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -47,4 +47,4 @@ jobs:
       with:
         name: generated_markdowns
         path: |
-          build/docs/*.md
+          build/docs/*

--- a/scripts/generate_md.sh
+++ b/scripts/generate_md.sh
@@ -71,7 +71,8 @@ do
     if [ -s "extensions/$extension/description.yml" ]; then
        echo -n "  " >> $EXTENSION_README
        cat extensions/$extension/description.yml | yq -r ".extension.description" >> $EXTENSION_README
-       cat extensions/$extension/description.yml | yq '.extension.name, .repo.github, .repo.ref, .extension.description' | xargs printf "%s,%s,%s,\"%s\"\n" >> $EXTENSIONS_CSV
+       cat extensions/$extension/description.yml | yq '.extension.name, .repo.github, .repo.ref' | xargs printf '%s,%s,%s,"' >> $EXTENSIONS_CSV
+       cat extensions/$extension/description.yml | yq -r '.extension.description' | sed 's/$/"/'  >> $EXTENSIONS_CSV
        echo "" >> $EXTENSION_README
        cat extensions/$extension/description.yml >> $EXTENSION_README
        echo "" >> $EXTENSION_README


### PR DESCRIPTION
Fix script that automatically populates `http://community-extensions.duckdb.org/extensions/community_extensions.csv` (cached version is off due to incompatibilities between linux and macos behaviour of the script).

Also avoid rebuild extension pipeline if no relevant changes are detected.

Next up: changes to docs.hello_world or docs.extended_description should not trigger rebuild.