### PR TITLE
Allow specifying different git_ref depending on DuckDB version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,14 @@ on:
     inputs:
       extension_name:
         type: string
+      duckdb_version:
+        type: string
+  workflow_call:
+    inputs:
+      extension_name:
+        type: string
+      duckdb_version:
+        type: string
 
 jobs:
   prepare:
@@ -55,7 +63,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     if: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_NAME != '' }}
     with:
-      duckdb_version: v1.0.0
+      duckdb_version: ${{ inputs.duckdb_version || 'v1.0.0' }}
       exclude_archs: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_EXCLUDE_PLATFORMS }}
       extra_toolchains: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_REQUIRES_TOOLCHAINS }}
       extension_name: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_NAME }}
@@ -81,7 +89,7 @@ jobs:
     secrets: inherit
     with:
       deploy_latest: true
-      duckdb_version: v1.0.0
+      duckdb_version: ${{ inputs.duckdb_version || 'v1.0.0' }}
       exclude_archs: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_EXCLUDE_PLATFORMS }}
       extension_name: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_NAME }}
       repository: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_GITHUB }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,8 @@ jobs:
       COMMUNITY_EXTENSION_EXCLUDE_PLATFORMS: ${{ steps.parse.outputs.COMMUNITY_EXTENSION_EXCLUDE_PLATFORMS }}
       COMMUNITY_EXTENSION_REQUIRES_TOOLCHAINS: ${{ steps.parse.outputs.COMMUNITY_EXTENSION_REQUIRES_TOOLCHAINS }}
       COMMUNITY_EXTENSION_VCPKG_COMMIT: ${{ steps.parse.outputs.COMMUNITY_EXTENSION_VCPKG_COMMIT == '' && 'a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6' || steps.parse.outputs.COMMUNITY_EXTENSION_VCPKG_COMMIT }}
+    env:
+      DUCKDB_VERSION: ${{ inputs.duckdb_version || 'v1.0.0' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -54,6 +56,7 @@ jobs:
         ALL_CHANGED_FILES: ${{ github.event_name == 'workflow_dispatch' && format('extensions/{0}/description.yml', inputs.extension_name) || steps.changed-files.outputs.all_changed_files }}
       run: |
         pip install pyyaml
+        # scripts/build.py takes DUCKDB_VERSION from environment
         python scripts/build.py
         cat env.sh >> $GITHUB_OUTPUT
         echo `cat $GITHUB_OUTPUT`

--- a/extensions/quack/description.yml
+++ b/extensions/quack/description.yml
@@ -15,7 +15,8 @@ extension:
 
 repo:
   github: hannes/quack
-  ref: 09680a975bcf9e93b5a2f46d3eeb68792d5239c6
+  ref:
+    main: 09680a975bcf9e93b5a2f46d3eeb68792d5239c6
 
 docs:
   hello_world: |


### PR DESCRIPTION
Two semantics are supported for the repo.ref field:

1. string representing the extension ref, currently used by all extensions already, example:
```yaml
  ref: 09680a975bcf9e93b5a2f46d3eeb68792d5239c6
```

2. map duckdb_version -> extension_ref, example:
```yaml
  ref:
    v1.0.0: 09680a975bcf9e93b5a2f46d3eeb68792d5239c6
    main: 09680a975bcf9e93b5a2f46d3eeb68792d5239c6
```

When the lookup is performed in `scripts/build.py`, implementations is:
If string, string is used.
If dictionary, and `DUCKDB_VERSION in dictionary`, use `dictionary[DUCKDB_VERSION]`
Otherwise, if dictionary, and `main in dictionary`, use `dictionary[main]`

Else: raise an Error.

#### Why?
In the run-up to v1.1.0, we want to both allow extensions to keep developing / test for v1.0.0 AND allow extensions to test and get ready for the switch to v1.1.0, possibly providing a different git ref if the one currently in use is not compatible with `main/v1.1.0`.

#### Expected usage
We will set-up automatic testing versus main, but I am aware that a few extensions that, as is for our own extensions, will not be compatible on the same git_ref with both v1.0.0 and main (that will become `v1.1.0` in a few weeks).

Expected usage is that extensions that needs fixing around API changes or equivalent can fix those in the extension repo, and submit a dictionary-version for the `repo.ref` with the current reference pointed to `v1.0.0` and the upcoming version for `main`.

#### Versioning
This is not a shortcut to versioning: if multiple hashes are provided they need to be semantically offer the same feature-set. Once a given duckdb version is not actively supported it has to be dropped from the dictionary.

#### Adding workflow_call
`workflow_call` section would allow to implement testing on multiple version on top of this, once this PR lands this can be already doable manually via `workflow_dispatch`, with the other pieces to be added by a subsequent PR.