### PR TITLE
add custom toolchain script option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
       duckdb_version: v1.0.0
       exclude_archs: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_EXCLUDE_PLATFORMS }}
       extra_toolchains: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_REQUIRES_TOOLCHAINS }}
-      custom_toolchain_script: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_CUSTOM_TOOLCHAIN_SCRIPT == true}}
+      custom_toolchain_script: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_CUSTOM_TOOLCHAIN_SCRIPT == 'true'}}
       extension_name: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_NAME }}
       override_repository: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_GITHUB }}
       override_ref: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_REF }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
       duckdb_version: v1.0.0
       exclude_archs: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_EXCLUDE_PLATFORMS }}
       extra_toolchains: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_REQUIRES_TOOLCHAINS }}
-      custom_toolchain_script: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_CUSTOM_TOOLCHAIN_SCRIPT }}
+      custom_toolchain_script: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_CUSTOM_TOOLCHAIN_SCRIPT == true}}
       extension_name: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_NAME }}
       override_repository: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_GITHUB }}
       override_ref: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_REF }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
       COMMUNITY_EXTENSION_DEPLOY: ${{ steps.parse.outputs.COMMUNITY_EXTENSION_DEPLOY }}
       COMMUNITY_EXTENSION_EXCLUDE_PLATFORMS: ${{ steps.parse.outputs.COMMUNITY_EXTENSION_EXCLUDE_PLATFORMS }}
       COMMUNITY_EXTENSION_REQUIRES_TOOLCHAINS: ${{ steps.parse.outputs.COMMUNITY_EXTENSION_REQUIRES_TOOLCHAINS }}
+      COMMUNITY_EXTENSION_CUSTOM_TOOLCHAIN_SCRIPT: ${{ steps.parse.outputs.COMMUNITY_EXTENSION_CUSTOM_TOOLCHAIN_SCRIPT }}
       COMMUNITY_EXTENSION_VCPKG_COMMIT: ${{ steps.parse.outputs.COMMUNITY_EXTENSION_VCPKG_COMMIT == '' && 'a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6' || steps.parse.outputs.COMMUNITY_EXTENSION_VCPKG_COMMIT }}
     runs-on: ubuntu-latest
     steps:
@@ -58,6 +59,7 @@ jobs:
       duckdb_version: v1.0.0
       exclude_archs: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_EXCLUDE_PLATFORMS }}
       extra_toolchains: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_REQUIRES_TOOLCHAINS }}
+      custom_toolchain_script: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_CUSTOM_TOOLCHAIN_SCRIPT }}
       extension_name: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_NAME }}
       override_repository: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_GITHUB }}
       override_ref: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_REF }}

--- a/extensions/quack/description.yml
+++ b/extensions/quack/description.yml
@@ -12,6 +12,8 @@ extension:
   requires_toolchains: "rust"
   # (Optional) param that specifies a precise vcpkg commit to use
   vcpkg_commit: "a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6"
+  # (Optional) this extension requires additional custom toolchain setup
+  custom_toolchain_script: true
 
 repo:
   github: hannes/quack

--- a/extensions/quack/description.yml
+++ b/extensions/quack/description.yml
@@ -16,8 +16,8 @@ extension:
   custom_toolchain_script: true
 
 repo:
-  github: hannes/quack
-  ref: 09680a975bcf9e93b5a2f46d3eeb68792d5239c6
+  github: duckdb/extension-template
+  ref: main
 
 docs:
   hello_world: |

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -46,7 +46,7 @@ with open('env.sh', 'w+') as hdl:
 		hdl.write(f"COMMUNITY_EXTENSION_VCPKG_COMMIT={vcpkg_commit}\n")
 	if deploy:
 		hdl.write(f"COMMUNITY_EXTENSION_DEPLOY=1\n")
-	if custom_toolchain_script:
+	if custom_toolchain_script and custom_toolchain_script != "false":
 		hdl.write(f"COMMUNITY_EXTENSION_CUSTOM_TOOLCHAIN_SCRIPT=true\n")
 	else:
 		hdl.write(f"COMMUNITY_EXTENSION_CUSTOM_TOOLCHAIN_SCRIPT=false\n")

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -46,8 +46,7 @@ with open('env.sh', 'w+') as hdl:
 		hdl.write(f"COMMUNITY_EXTENSION_VCPKG_COMMIT={vcpkg_commit}\n")
 	if deploy:
 		hdl.write(f"COMMUNITY_EXTENSION_DEPLOY=1\n")
-
 	if custom_toolchain_script:
-		hdl.write(f"COMMUNITY_EXTENSION_CUSTOM_TOOLCHAIN_SCRIPT={custom_toolchain_script}\n")
+		hdl.write(f"COMMUNITY_EXTENSION_CUSTOM_TOOLCHAIN_SCRIPT=trues\n")
 	else:
 		hdl.write(f"COMMUNITY_EXTENSION_CUSTOM_TOOLCHAIN_SCRIPT=false\n")

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -36,6 +36,7 @@ with open('env.sh', 'w+') as hdl:
 	hdl.write(f"COMMUNITY_EXTENSION_NAME={desc['extension']['name']}\n")
 	excluded_platforms = desc['extension'].get('excluded_platforms')
 	requires_toolchains = desc['extension'].get('requires_toolchains')
+	custom_toolchain_script = desc['extension'].get('custom_toolchain_script')
 	vcpkg_commit = desc['extension'].get('vcpkg_commit')
 	if excluded_platforms:
 		hdl.write(f"COMMUNITY_EXTENSION_EXCLUDE_PLATFORMS={excluded_platforms}\n")
@@ -45,3 +46,8 @@ with open('env.sh', 'w+') as hdl:
 		hdl.write(f"COMMUNITY_EXTENSION_VCPKG_COMMIT={vcpkg_commit}\n")
 	if deploy:
 		hdl.write(f"COMMUNITY_EXTENSION_DEPLOY=1\n")
+
+	if custom_toolchain_script:
+		hdl.write(f"COMMUNITY_EXTENSION_CUSTOM_TOOLCHAIN_SCRIPT={custom_toolchain_script}\n")
+	else:
+		hdl.write(f"COMMUNITY_EXTENSION_CUSTOM_TOOLCHAIN_SCRIPT=false\n")

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -47,6 +47,6 @@ with open('env.sh', 'w+') as hdl:
 	if deploy:
 		hdl.write(f"COMMUNITY_EXTENSION_DEPLOY=1\n")
 	if custom_toolchain_script:
-		hdl.write(f"COMMUNITY_EXTENSION_CUSTOM_TOOLCHAIN_SCRIPT=trues\n")
+		hdl.write(f"COMMUNITY_EXTENSION_CUSTOM_TOOLCHAIN_SCRIPT=true\n")
 	else:
 		hdl.write(f"COMMUNITY_EXTENSION_CUSTOM_TOOLCHAIN_SCRIPT=false\n")


### PR DESCRIPTION
Follow up from https://github.com/duckdb/extension-ci-tools/pull/61

Now community extensions can extend the default toolchain by using the script https://github.com/duckdb/extension-template/blob/main/scripts/setup-custom-toolchain.sh and setting the `custom_toolchain_script` param in the extension descriptor.

Fixes https://github.com/duckdb/community-extensions/issues/73

