### PR TITLE
Test extensions also against main, adding optional ref_next

### DIFF
--- a/.github/workflows/build_next.yml
+++ b/.github/workflows/build_next.yml
@@ -1,0 +1,21 @@
+name: Community Extension with latest DuckDB
+on:
+  pull_request:
+    paths-ignore:
+      - '**'
+      - '!scripts/build.py'
+      - '!.github/workflows/build_next.yml'
+      - '!extensions/*/description.yml'
+  push:
+    paths-ignore:
+      - '**'
+      - '!scripts/build.py'
+      - '!.github/workflows/build_next.yml'
+      - '!extensions/*/description.yml'
+
+jobs:
+  test_against_latst:
+    uses: ./.github/workflows/build.yml 
+    with:
+      duckdb_version: 'main'
+      deploy: 'false'

--- a/.github/workflows/build_next.yml
+++ b/.github/workflows/build_next.yml
@@ -14,7 +14,7 @@ on:
       - '!extensions/*/description.yml'
 
 jobs:
-  test_against_latst:
+  test_against_latest:
     uses: ./.github/workflows/build.yml 
     with:
       duckdb_version: 'main'

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -34,4 +34,3 @@ jobs:
       extension_name: ${{ matrix.extension_name }}
       duckdb_version: ${{ inputs.duckdb_version }}
       deploy: 'false'
-      more_excluded: 'windows_amd64_rtools;windows_amd64;wasm_threads;wasm_mvp;linux_arm64;linux_amd64;osx_arm64'

--- a/extensions/quack/description.yml
+++ b/extensions/quack/description.yml
@@ -18,6 +18,7 @@ extension:
 repo:
   github: duckdb/extension-template
   ref: 0a25cb5d883d2ddf0fc414986936976837494c86
+  ref_next: f89d2663d9788dc27f3a77bcdf638ace6357a459
 
 docs:
   hello_world: |


### PR DESCRIPTION
This PR, together with initial work in https://github.com/duckdb/community-extensions/pull/81, makes Community Extensions ready to be built and tested against what would become DuckDB v1.1.0.

The version has not been tagged (yet, see https://duckdb.org/docs/dev/release_calendar#upcoming-releases for the calendar), so the second best thing is checking what happens when building (and testing) against duckdb current main branch.

Given some extensions might not be compatible at the same time with both latest stable DuckDB (`v1.0.0`) and current main, say due to non-stable API changes, the descriptor gets an additional optional field `ref_next`, that if present is assumed to be the `ref` to be used when building against duckdb next.

There will be also a CI job testing again all currently distributed extensions, and building and testing them on all platforms against duckdb main version, using either `ref_next`, if present, or `ref` (that has to be always present).

Also any changes to extensions descriptor will, in the run-up to v1.1.0, both build `ref` against `v1.0.0` AND `ref_next` or `ref` against `main`.

#### Close to releases
Decision tree that we envision for maintainers is as follow:
1. extension you maintain is compatible with both `v1.0.0` and main:
    - great! congratulations, you are set
2. extension is NOT compatible with both at the same time:
    - keep ref to whatever you have now (that should keep working)
    - add changes / iterate to the extension repository so that it's compatible with latest duckdb
    - send a PR against community_extension with that git reference as `ref_next`
    - possibly iterate, now 

#### Release
As part of the release process, community extensions `ref_next` will be swapped to `ref`, and extensions that successfully build and test will now be distributed for `v1.1.0`.

#### After release
Improve the extension you maintain, targeting the latest duckdb stable release. This would allow you to distribute changes to users.