### PR TITLE
fix: add ref_next for lindel

### DIFF
--- a/extensions/lindel/description.yml
+++ b/extensions/lindel/description.yml
@@ -12,6 +12,7 @@ extension:
 repo:
   github: rustyconover/duckdb-lindel-extension
   ref: 76f5bc78e8bfd1a7953c8cc4c284209b65626216
+  ref_next: 43a8ec9dca2f3a9cbda6c23012859c908cbc7c81
 
 docs:
   hello_world: |


### PR DESCRIPTION
For the upcoming DuckDB 1.1.0 release there were changes to calls to LogicalType::ARRAY, these changes live on a branch and add a reference to the latest commit to that branch.