### PR TITLE
Fixup autogeneration list

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -30,7 +30,8 @@ jobs:
     - name: Generate docs
       run: |
         ./scripts/generate_md.sh ./duckdb
-        cp build/docs/* web/extensions/.
+        cp build/docs/*.md web/extensions/.
+        cat build/docs/extensions_list.md.tmp >> web/list_of_extensions.md
 
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1

--- a/extensions/tarfs/description.yml
+++ b/extensions/tarfs/description.yml
@@ -1,6 +1,6 @@
 extension:
   name: tarfs
-  description: glob, open and read files within ".tar" archives
+  description: glob, open and read files within `.tar` archives
   version: 1.0.0
   language: C++
   build: cmake

--- a/scripts/generate_md.sh
+++ b/scripts/generate_md.sh
@@ -123,3 +123,6 @@ do
     rm -rf $DOCS/$extension
     rm -rf $DOCS/$extension.db
 done
+
+cd $DOCS
+$1 x.db -markdown -c "SELECT '['||#1||']({% link extensions/'||#1||'.md %})' as Name, '[<span class=github>GitHub</span>](https://github.com/'||#2||')' as GitHub , #4 as Description FROM read_csv('community_extensions.csv');" > extensions_list.md.tmp


### PR DESCRIPTION
Remove the "" quotes from tarfs, since they interact weirdly with CSV generation, we might eventually want to fix that or check descriptors files.