### PR TITLE
Add CI to archive repositories source code on deploy

### DIFF
--- a/.github/workflows/_extension_archive.yml
+++ b/.github/workflows/_extension_archive.yml
@@ -1,0 +1,46 @@
+#
+# Reusable workflow that deploys the extensions source code
+
+name: Extension Archieve Sources
+on:
+  workflow_call:
+    inputs:
+      # The name of the extension
+      extension_name:
+        required: true
+        type: string
+      repository:
+        required: false
+        type: string
+        default: ""
+      ref:
+        required: false
+        type: string
+        default: ""
+jobs:
+  fetch_repo:
+    name: Fetch repo and save
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+          submodules: 'true'
+          path: ./repo
+
+      - name: Compress the repository sources
+        run: |
+          zip -9 -r compressed.zip repo
+
+      - name: Deploy the submodule
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.DUCKDB_COMMUNITY_EXTENSION_S3_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.DUCKDB_COMMUNITY_EXTENSION_S3_SECRET }}
+          AWS_DEFAULT_REGION: ${{ secrets.S3_DUCKDB_ORG_REGION }}
+          BUCKET_NAME: duckdb-community-extensions
+        run: |
+          python3 -m pip install pip awscli
+          aws s3 cp compressed.zip s3://$BUCKET_NAME/archieved_repo/${{ inputs.extension_name }}/repo_sources_${{ inputs.ref }}.zip

--- a/.github/workflows/_extension_archive.yml
+++ b/.github/workflows/_extension_archive.yml
@@ -43,4 +43,4 @@ jobs:
           BUCKET_NAME: duckdb-community-extensions
         run: |
           python3 -m pip install pip awscli
-          aws s3 cp compressed.zip s3://$BUCKET_NAME/archieved_repo/${{ inputs.extension_name }}/repo_sources_${{ inputs.ref }}.zip
+          aws s3 cp compressed.zip s3://$BUCKET_NAME/archived_extension_sources/${{ inputs.extension_name }}/repo_sources_${{ inputs.ref }}.zip

--- a/.github/workflows/_extension_deploy.yml
+++ b/.github/workflows/_extension_deploy.yml
@@ -96,12 +96,14 @@ jobs:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
           fetch-depth: 0
-          submodules: 'true'
+          submodules: 'false'
 
-      - name: Checkout DuckDB to version
-        run: |
-          cd duckdb
-          git checkout ${{ inputs.duckdb_version }}
+      - uses: actions/checkout@v3
+        with:
+          repository: 'duckdb/duckdb'
+          ref: ${{ inputs.duckdb_version }}
+          path: duckdb
+          fetch-depth: 0
 
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,19 @@ jobs:
     with:
       extension_name: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_NAME }}
 
+  archive:
+    needs:
+      - doc_test
+      - prepare
+      - build
+    uses: ./.github/workflows/_extension_archive.yml
+    if: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_DEPLOY != '' }}
+    secrets: inherit
+    with:
+      extension_name: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_NAME }}
+      repository: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_GITHUB }}
+      ref: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_REF }}
+
   deploy:
     needs: 
       - doc_test


### PR DESCRIPTION
This would help with testing and reproducibility.

I have not tested properly this (yet), but will do so to the degree in which this is possible in my fork of this repo.