### PR TITLE
Fix WASM linking for PSQL extension

### DIFF
--- a/extensions/psql/description.yml
+++ b/extensions/psql/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: ywelsch/duckdb-psql
-  ref: 6a29f40d8a3f00a5b60faea0b345c33d1c863edf
+  ref: 119c6a7b0e044853e7503e3d004009d76e39ce20
 
 docs:
   hello_world: |


### PR DESCRIPTION
The PSQL extension is not working correctly in WASM yet. This is an attempt at addressing the situation via https://github.com/ywelsch/duckdb-psql/commit/119c6a7b0e044853e7503e3d004009d76e39ce20