### PR TITLE
Format example queries in community extension descriptors

### DIFF
--- a/extensions/bigquery/description.yml
+++ b/extensions/bigquery/description.yml
@@ -18,7 +18,7 @@ repo:
 docs:
   hello_world: |
     -- Attach to your BigQuery Project
-    D ATTACH 'project=my_gcp_project' as bq (TYPE bigquery, READ_ONLY);
+    D ATTACH 'project=my_gcp_project' AS bq (TYPE bigquery, READ_ONLY);
 
     -- Show all tables in all datasets in the attached BigQuery project
     D SHOW ALL TABLES;

--- a/extensions/chsql/description.yml
+++ b/extensions/chsql/description.yml
@@ -15,7 +15,7 @@ repo:
 docs:
   hello_world: |
     -- Use ClickHouse SQL function macros in DuckDB SQL queries
-    SELECT toString('world') as hello, toInt8OrZero('world') as zero;
+    SELECT toString('world') AS hello, toInt8OrZero('world') AS zero;
 
     ┌─────────┬───────┐
     │  hello  │ zero  │

--- a/extensions/duckpgq/description.yml
+++ b/extensions/duckpgq/description.yml
@@ -14,8 +14,8 @@ repo:
 
 docs:
   hello_world: |
-    CREATE TABLE Person as select * from 'https://gist.githubusercontent.com/Dtenwolde/2b02aebbed3c9638a06fda8ee0088a36/raw/8c4dc551f7344b12eaff2d1438c9da08649d00ec/person-sf0.003.csv';
-    CREATE TABLE Person_knows_person as select * from 'https://gist.githubusercontent.com/Dtenwolde/81c32c9002d4059c2c3073dbca155275/raw/8b440e810a48dcaa08c07086e493ec0e2ec6b3cb/person_knows_person-sf0.003.csv';
+    CREATE TABLE Person AS SELECT * FROM 'https://gist.githubusercontent.com/Dtenwolde/2b02aebbed3c9638a06fda8ee0088a36/raw/8c4dc551f7344b12eaff2d1438c9da08649d00ec/person-sf0.003.csv';
+    CREATE TABLE Person_knows_person AS SELECT * FROM 'https://gist.githubusercontent.com/Dtenwolde/81c32c9002d4059c2c3073dbca155275/raw/8b440e810a48dcaa08c07086e493ec0e2ec6b3cb/person_knows_person-sf0.003.csv';
 
     CREATE PROPERTY GRAPH snb
       VERTEX TABLES (
@@ -24,7 +24,7 @@ docs:
     EDGE TABLES (
       Person_knows_person 	SOURCE KEY (Person1Id) REFERENCES Person (id)
                             DESTINATION KEY (Person2Id) REFERENCES Person (id)
-      LABEL Knows
+      LABEL knows
     );
 
     FROM GRAPH_TABLE (snb
@@ -52,4 +52,3 @@ docs:
     
 
     *Disclaimer*: As this extension is part of an ongoing research project by the Database Architectures group at CWI, some features may still be under development. We appreciate your understanding and patience as we continue to improve it.
-

--- a/extensions/evalexpr_rhai/description.yml
+++ b/extensions/evalexpr_rhai/description.yml
@@ -51,19 +51,19 @@ docs:
     \ employees (name text, state text, zip integer);\nINSERT INTO employees values\n\
     \  ('Jane', 'FL', 33139),\n  ('John', 'NJ', 08520);\n\n-- Pass the row from the\
     \ employees table in as \"context.row\"\nSELECT evalexpr_rhai(\n  '\n  context.row.name\
-    \ + \" is in \" + context.row.state\n  ',\n  {\n    row: employees\n  }) as result\
+    \ + \" is in \" + context.row.state\n  ',\n  {\n    row: employees\n  }) AS result\
     \ from employees;\n\n┌───────────────────────────────┐\n│            result  \
     \           │\n│ union(ok json, error varchar) │\n├───────────────────────────────┤\n\
     │ \"Jane is in FL\"               │\n│ \"John is in NJ\"               │\n└───────────────────────────────┘\n\
     \n-- To demonstrate how Rhai can be used to implement\n-- a function in DuckDB,\
     \ the next example creates\n-- a macro function that calls a Rhai function\n--\
     \ to calculate the Collatz sequence length.\n\nCREATE MACRO collatz_series_length(n)\
-    \ as\n  evalexpr_rhai('\n    fn collatz_series(n) {\n        let count = 0;\n\
+    \ AS\n  evalexpr_rhai('\n    fn collatz_series(n) {\n        let count = 0;\n\
     \        while n > 1 {\n          count += 1;\n          if n % 2 == 0 {\n   \
     \           n /= 2;\n          } else {\n              n = n * 3 + 1;\n      \
     \    }\n        }\n        return count\n    }\n    collatz_series(context.n)\n\
     \  ', {'n': n});\n\n-- Use the previously defined macro.\nSELECT\n  collatz_series_length(range).ok::bigint\
-    \ as sequence_length,\n  range as starting_value\nFROM\n  range(10000, 20000)\n\
+    \ AS sequence_length,\n  range AS starting_value\nFROM\n  range(10000, 20000)\n\
     ORDER BY 1 DESC limit 10;\n\n┌─────────────────┬────────────────┐\n│ sequence_length\
     \ │ starting_value │\n│      int64      │     int64      │\n├─────────────────┼────────────────┤\n\
     │             278 │          17647 │\n│             278 │          17673 │\n│\

--- a/extensions/faiss/description.yml
+++ b/extensions/faiss/description.yml
@@ -1,6 +1,6 @@
 extension:
   name: faiss
-  description: Provides a subset of the faiss API to duckdb
+  description: Provides a subset of the faiss API to DuckDB
   version: 0.9.0
   language: C++
   build: cmake
@@ -21,8 +21,8 @@ docs:
   hello_world: |
     -- Generate semi-random input data and queries
     -- Note that the dimensionality of our data will be 5
-    CREATE TABLE input AS SELECT i as id, apply(generate_series(1, 5), j-> CAST(hash(i*1000+j) AS FLOAT)/18446744073709551615) as data FROM generate_series(1, 1000) s(i);
-    CREATE TABLE queries AS SELECT i as id, apply(generate_series(1, 5), j-> CAST(hash(i*1000+j+8047329823) AS FLOAT)/18446744073709551615) as data FROM generate_series(1, 10) s(i);
+    CREATE TABLE input AS SELECT i AS id, apply(generate_series(1, 5), j-> CAST(hash(i*1000+j) AS FLOAT)/18446744073709551615) AS data FROM generate_series(1, 1000) s(i);
+    CREATE TABLE queries AS SELECT i AS id, apply(generate_series(1, 5), j-> CAST(hash(i*1000+j+8047329823) AS FLOAT)/18446744073709551615) AS data FROM generate_series(1, 10) s(i);
     -- Create the index and insert data into it
     CALL FAISS_CREATE('name', 5, 'IDMap,HNSW32');
     CALL FAISS_ADD((SELECT id, data FROM input), 'name');
@@ -33,4 +33,4 @@ docs:
     -- Get 10 results
     SELECT id, UNNEST(FAISS_SEARCH('name', 10, data)) FROM queries;
   extended_description: |
-    The FAISS extension allows duckdb users to store vector data in faiss, and query this data, making reliable vector search more accessible.
+    The FAISS extension allows DuckDB users to store vector data in faiss, and query this data, making reliable vector search more accessible.

--- a/extensions/fuzzycomplete/description.yml
+++ b/extensions/fuzzycomplete/description.yml
@@ -49,7 +49,7 @@ docs:
     CREATE TABLE automobile_vehicles(serial_number text);
 
 
-    SELECT suggestion from sql_auto_complete(''SELECT * from veh'');
+    SELECT suggestion FROM sql_auto_complete(''SELECT * FROM veh'');
 
     ┌─────────────────────┐
 
@@ -64,7 +64,7 @@ docs:
     └─────────────────────┘
 
 
-    select suggestion from sql_auto_complete(''SELECT * from auto'');
+    SELECT suggestion FROM sql_auto_complete(''SELECT * FROM auto'');
 
     ┌──────────────────────────────────────┐
 
@@ -89,7 +89,7 @@ docs:
     └──────────────────────────────────────┘
 
 
-    SELECT suggestion from sql_auto_complete(''SELECT * from bar'');
+    SELECT suggestion FROM sql_auto_complete(''SELECT * FROM bar'');
 
     ┌──────────────────────────────────────┐
 
@@ -108,7 +108,7 @@ docs:
 
     -- Demonstrate completion across databases/catalogs and schemas.
 
-    SELECT suggestion from sql_auto_complete(''SELECT * from table'');
+    SELECT suggestion FROM sql_auto_complete(''SELECT * FROM table'');
 
     ┌───────────────────────────────────────────────┐
 

--- a/extensions/lindel/description.yml
+++ b/extensions/lindel/description.yml
@@ -57,10 +57,10 @@ docs:
     \ |\n| `UBIGINT`    | 2 | 1: `UBIGINT`<br/>2: `UHUGEINT` |\n| `FLOAT`      | 4\
     \ | 1: `UINTEGER`<br/>2: `UBIGINT`<br/>3-4: `UHUGEINT` |\n| `DOUBLE`     | 2 |\
     \ 1: `UBIGINT`<br/>2: `UHUGEINT` |\n"
-  hello_world: "WITH elements as (\n  SELECT * as id FROM range(3)\n)\nSELECT\n  a.id\
-    \ as a,\n  b.id as b,\n  hilbert_encode([a.id, b.id]::tinyint[2]) as hilbert,\n\
-    \  morton_encode([a.id, b.id]::tinyint[2]) as morton\nFROM\n  elements as a cross\
-    \ join elements as b;\n┌───────┬───────┬─────────┬────────┐\n│   a   │   b   │\
+  hello_world: "WITH elements AS (\n  SELECT * AS id FROM range(3)\n)\nSELECT\n  a.id\
+    \ AS a,\n  b.id AS b,\n  hilbert_encode([a.id, b.id]::tinyint[2]) AS hilbert,\n\
+    \  morton_encode([a.id, b.id]::tinyint[2]) AS morton\nFROM\n  elements AS a CROSS\
+    \ JOIN elements AS b;\n┌───────┬───────┬─────────┬────────┐\n│   a   │   b   │\
     \ hilbert │ morton │\n│ int64 │ int64 │ uint16  │ uint16 │\n├───────┼───────┼─────────┼────────┤\n\
     │     0 │     0 │       0 │      0 │\n│     0 │     1 │       3 │      1 │\n│\
     \     0 │     2 │       4 │      4 │\n│     1 │     0 │       1 │      2 │\n│\
@@ -68,22 +68,22 @@ docs:
     \     2 │     0 │      14 │      8 │\n│     2 │     1 │      13 │      9 │\n│\
     \     2 │     2 │       8 │     12 │\n└───────┴───────┴─────────┴────────┘\n\n\
     -- Encode two 32-bit floats into one uint64\nSELECT hilbert_encode([37.8, .2]::float[2])\
-    \ as hilbert;\n┌─────────────────────┐\n│       hilbert       │\n│       uint64\
+    \ AS hilbert;\n┌─────────────────────┐\n│       hilbert       │\n│       uint64\
     \        │\n├─────────────────────┤\n│ 2303654869236839926 │\n└─────────────────────┘\n\
     \n-- Since doubles use 64 bits of precision the encoding\n-- must result in a\
-    \ uint128\n\nSELECT hilbert_encode([37.8, .2]::double[2]) as hilbert;\n┌────────────────────────────────────────┐\n\
+    \ uint128\n\nSELECT hilbert_encode([37.8, .2]::double[2]) AS hilbert;\n┌────────────────────────────────────────┐\n\
     │                hilbert                 │\n│                uint128         \
     \        │\n├────────────────────────────────────────┤\n│ 42534209309512799991913666633619307890\
     \ │\n└────────────────────────────────────────┘\n\n-- 3 dimensional encoding.\n\
-    SELECT hilbert_encode([1.0, 5.0, 6.0]::float[3]) as hilbert;\n┌──────────────────────────────┐\n\
+    SELECT hilbert_encode([1.0, 5.0, 6.0]::float[3]) AS hilbert;\n┌──────────────────────────────┐\n\
     │           hilbert            │\n│           uint128            │\n├──────────────────────────────┤\n\
     │ 8002395622101954260073409974 │\n└──────────────────────────────┘\n\n-- Demonstrate\
     \ string encoding\nSELECT hilbert_encode([ord(x) for x in split('abcd', '')]::tinyint[4])\
-    \ as hilbert;\n┌───────────┐\n│  hilbert  │\n│  uint32   │\n├───────────┤\n│ 178258816\
+    \ AS hilbert;\n┌───────────┐\n│  hilbert  │\n│  uint32   │\n├───────────┤\n│ 178258816\
     \ │\n└───────────┘\n\n-- Start out just by encoding two values.\nSELECT hilbert_encode([1,\
-    \ 2]::tinyint[2]) as hilbert;\n┌─────────┐\n│ hilbert │\n│ uint16  │\n├─────────┤\n\
+    \ 2]::tinyint[2]) AS hilbert;\n┌─────────┐\n│ hilbert │\n│ uint16  │\n├─────────┤\n\
     │       7 │\n└─────────┘\n\n-- Decode an encoded value\nSELECT hilbert_decode(7::uint16,\
-    \ 2, false, true) as values;\n┌─────────────┐\n│   values    │\n│ utinyint[2]\
+    \ 2, false, true) AS values;\n┌─────────────┐\n│   values    │\n│ utinyint[2]\
     \ │\n├─────────────┤\n│ [1, 2]      │\n└─────────────┘\n\n-- The decoding functions\
     \ take four parameters:\n-- 1. **Value to be decoded:** This is always an unsigned\
     \ integer type.\n-- 2. **Number of elements to decode:** This is a `TINYINT` specifying\
@@ -94,7 +94,7 @@ docs:
     \ return type of these functions is always an array, with the element type determined\
     \ by the number of elements requested and whether \"float\" handling is enabled\
     \ by the third parameter.\n\nSELECT hilbert_decode(hilbert_encode([1, -2]::bigint[2]),\
-    \ 2, false, false) as values;\n┌───────────┐\n│  values   │\n│ bigint[2] │\n├───────────┤\n\
+    \ 2, false, false) AS values;\n┌───────────┐\n│  values   │\n│ bigint[2] │\n├───────────┤\n\
     │ [1, -2]   │\n└───────────┘\n"
 extension:
   build: cmake

--- a/extensions/scrooge/description.yml
+++ b/extensions/scrooge/description.yml
@@ -16,14 +16,14 @@ repo:
 docs:
   hello_world: |
     -- Set the RPC Provider
-    set eth_node_url= 'https://mempool.merkle.io/rpc/eth/pk_mbs_0b647b195065b3294a5254838a33d062';
+    SET eth_node_url = 'https://mempool.merkle.io/rpc/eth/pk_mbs_0b647b195065b3294a5254838a33d062';
     -- Query Transfer events of USDT from blocks 20034078 - 20034100 while parallelizing on one block per thread
     FROM read_eth(
-    'USDT',
-    'Transfer',
-    20034078,
-    20034100, 
-    blocks_per_thread=1
+        'USDT',
+        'Transfer',
+        20034078,
+        20034100, 
+        blocks_per_thread = 1
     );
   extended_description: |
     Scrooge McDuck is a third-party financial extension for DuckDB. 

--- a/extensions/sheetreader/description.yml
+++ b/extensions/sheetreader/description.yml
@@ -20,14 +20,14 @@ docs:
 
     -- Example usage of available named parameters
     CREATE TABLE data2 AS FROM sheetreader(
-      'data2.xlsx',
-      sheet_index=1,
-      threads=16,
-      skip_rows=0,
-      has_header=TRUE,
-      types=[BOOLEAN,VARCHAR],
-      coerce_to_string=TRUE,
-      force_types=TRUE
+        'data2.xlsx',
+        sheet_index = 1,
+        threads = 16,
+        skip_rows = 0,
+        has_header = true,
+        types = [BOOLEAN, VARCHAR],
+        coerce_to_string = true,
+        force_types = true
     );
 
 
@@ -55,7 +55,7 @@ docs:
 
     SheetReader was published in the [Information Systems Journal](https://www.sciencedirect.com/science/article/abs/pii/S0306437923000194)
 
-    ```
+    ```bibtex
     @article{DBLP:journals/is/GavriilidisHZM23,
       author       = {Haralampos Gavriilidis and
                       Felix Henze and

--- a/extensions/shellfs/description.yml
+++ b/extensions/shellfs/description.yml
@@ -63,7 +63,7 @@ docs:
     \ configuration parameter.\n"
   hello_world: '-- Generate a sequence only return numbers that contain a 2
 
-    SELECT * from read_csv(''seq 1 100 | grep 2 |'');
+    SELECT * FROM read_csv(''seq 1 100 | grep 2 |'');
 
     ┌─────────┐
 
@@ -90,7 +90,7 @@ docs:
 
     -- demonstrate how commands can be chained together
 
-    SELECT * from read_csv(''seq 1 35 | awk "\$1 % 7 == 0" | head -n 2 |'');
+    SELECT * FROM read_csv(''seq 1 35 | awk "\$1 % 7 == 0" | head -n 2 |'');
 
     ┌─────────┐
 
@@ -109,7 +109,7 @@ docs:
 
     -- Do some arbitrary curl
 
-    SELECT abbreviation, unixtime from
+    SELECT abbreviation, unixtime FROM
 
     read_json(''curl -s http://worldtimeapi.org/api/timezone/Etc/UTC  |'');
 

--- a/extensions/tarfs/description.yml
+++ b/extensions/tarfs/description.yml
@@ -18,4 +18,3 @@ docs:
   extended_description: |
     This extension provides a duckdb file-system abstraction to read and glob files within __uncompressed__ tar archives.
     For more information and information regarding usage, limitations and performance, see the [tarfs README](https://github.com/Maxxen/duckdb_tarfs).
-    

--- a/extensions/ulid/description.yml
+++ b/extensions/ulid/description.yml
@@ -14,7 +14,7 @@ repo:
 
 docs:
   hello_world: |
-    SELECT ulid() as result;
+    SELECT ulid() AS result;
   extended_description: |
     This extension adds a new `ULID` data type to DuckDB. 
     A [ULID](https://github.com/ulid/spec) is similar to a UUID except that it also contains a timestamp component, which makes it more suitable for use cases where the order of creation is important. 


### PR DESCRIPTION
This PR applies some basic SQL formatting on the example queries. Chief among these is the consistent use of capitalization of SQL keywords: while many capitalize `SELECT`, they do not do so for `FROM`, `AS`, `JOIN`, etc.
