### PR TITLE
New Extension: open_prompt

### DIFF
--- a/extensions/open_prompt/description.yml
+++ b/extensions/open_prompt/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: quackscience/duckdb-extension-openprompt
-  ref: 07243b8810acb815b138e1bc63f68006e7253074
+  ref: a970029b83a35d8b812765220617d9cc14ca472d
 
 docs:
   hello_world: |

--- a/extensions/open_prompt/description.yml
+++ b/extensions/open_prompt/description.yml
@@ -1,0 +1,32 @@
+extension:
+  name: open_prompt
+  description: Interact with LLMs from a DuckDB Extension
+  version: 0.0.1
+  language: C++
+  build: cmake
+  license: MIT
+  maintainers:
+    - lmangani
+    - akvlad
+
+repo:
+  github: quackscience/duckdb-extension-openprompt
+  ref: 07243b8810acb815b138e1bc63f68006e7253074
+
+docs:
+  hello_world: |
+    -- Configure the required extension parameters
+    SELECT set_api_token('your_api_key_here');
+    SELECT set_api_url('http://localhost:11434/v1/chat/completions');
+    
+    -- Prompt any OpenAI Completions API form your query
+    D SELECT open_prompt('Write a one-line poem about ducks', 'qwen2.5:0.5b') AS response;
+    ┌────────────────────────────────────────────────┐
+    │                    response                    │
+    │                    varchar                     │
+    ├────────────────────────────────────────────────┤
+    │ Ducks quacking at dawn, swimming in the light. │
+    └────────────────────────────────────────────────┘
+
+  extended_description: |
+    This extension is experimental and potentially unstable. Do not use it in production.


### PR DESCRIPTION
Experimental and rudimental `open_prompt()` extension loosely based on the Motherduck demo at DuckDB Meetup

### Functions
- `open_prompt(prompt::VARCHAR, model::VARCHAR)`
- `set_api_url(url::VARCHAR)`
- `set_api_token(token::VARCHAR)`
- `set_model_name(model::VARCHAR)`

### Settings
```sql
SELECT set_api_token('your_api_key_here');
SELECT set_api_url('http://localhost:11434/v1/chat/completions');
```

### Usage
```sql
D SELECT open_prompt('Write a one-line poem about ducks', 'qwen2.5:0.5b') AS response;
┌────────────────────────────────────────────────┐
│                    response                    │
│                    varchar                     │
├────────────────────────────────────────────────┤
│ Ducks quacking at dawn, swimming in the light. │
└────────────────────────────────────────────────┘
```


## Testing
<img src="https://github.com/user-attachments/assets/824bfab2-aca6-4bd9-8a4a-bc01901fcd5b" width=100 />

### Ollama self-hosted
Test the open_prompt extension using a local or remote Ollama with Completions API

#### CPU only
```
docker run -d -v ollama:/root/.ollama -p 11434:11434 --name ollama ollama/ollama
```
#### Nvidia GPU
Install the Nvidia container toolkit. Run Ollama inside a Docker container
```
docker run -d --gpus=all -v ollama:/root/.ollama -p 11434:11434 --name ollama ollama/ollama
```

