### PR TITLE
Flockmtl

### DIFF
--- a/extensions/flockmtl/description.yml
+++ b/extensions/flockmtl/description.yml
@@ -13,10 +13,12 @@ extension:
 
 repo:
   github: dsg-polymtl/flockmtl
-  ref: f46ba8f9c2538e994373ead0f103859316048682
+  ref: 86e32ae7ac5ea4743067d2ddae9a96c7d3a2cd23
 
 docs:
   hello_world: |
+    -- The library loads successfully if an OPENAI_API_KEY is set in the environment
+
     -- Call an OpenAI model with a predefined prompt ('Tell me hello world') and default model ('gpt-4o-mini')
     D SELECT llm_complete('hello-world', 'default');
     ┌──────────────────────────────────────────┐

--- a/extensions/flockmtl/description.yml
+++ b/extensions/flockmtl/description.yml
@@ -27,8 +27,8 @@ docs:
     └──────────────────────────────────────────┘
 
     -- Check the prompts and supported models
-    D SHOW ALL PROMPTS;
-    D SHOW ALL MODELS;
+    D GET PROMPTS;
+    D GET MODELS;
 
     -- Create a new prompt for summarizing text
     D CREATE PROMPT(summarize, 'summarize the text into 1 word: {{text}}');

--- a/extensions/flockmtl/description.yml
+++ b/extensions/flockmtl/description.yml
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: dsg-polymtl/flockmtl
-  ref: 86e32ae7ac5ea4743067d2ddae9a96c7d3a2cd23
+  ref: 2450acd2b04a4a81342965b6c7eed6fb5899181f
 
 docs:
   hello_world: |

--- a/extensions/flockmtl/description.yml
+++ b/extensions/flockmtl/description.yml
@@ -1,6 +1,6 @@
 extension:
   name: flockmtl
-  description: DuckDB HTTP API Server Extension
+  description: DuckDB LLM Extension
   version: 0.1.0
   language: SQL & C++
   build: cmake
@@ -13,12 +13,12 @@ extension:
 
 repo:
   github: dsg-polymtl/flockmtl
-  ref: XX
+  ref: f46ba8f9c2538e994373ead0f103859316048682
 
 docs:
   hello_world: |
-    -- Call an OpenAI model with a predefined prompt 'Tell me hello world' and default model 'gpt-4o-mini'
-    D SELECT llm_complete(hello_world, default_model);
+    -- Call an OpenAI model with a predefined prompt ('Tell me hello world') and default model ('gpt-4o-mini')
+    D SELECT llm_complete('hello-world', 'default');
     ┌──────────────────────────────────────────┐
     │ llm_complete(hello_world, default_model) │
     │                 varchar                  │
@@ -31,13 +31,13 @@ docs:
     D GET MODELS;
 
     -- Create a new prompt for summarizing text
-    D CREATE PROMPT(summarize, 'summarize the text into 1 word: {{text}}');
+    D CREATE PROMPT('summarize', 'summarize the text into 1 word: {{text}}');
 
     -- Create a variable name for the model to do the summarizing
-    D CREATE MODEL(summarizer-model, 'gpt-4o');
+    D CREATE MODEL('summarizer-model', 'gpt-4o', 128000);
 
     -- Summarize text and pass it as parameter 
-    D SELECT llm_complete(summarize, summarizer-model, {'text': 'We support more functions and approaches to combine relational analytics and semantic analysis. Check our repo for documentation and examples.'});
+    D SELECT llm_complete('summarize', 'summarizer-model', {'text': 'We support more functions and approaches to combine relational analytics and semantic analysis. Check our repo for documentation and examples.'});
 
   extended_description: |
     This extension is experimental and potentially unstable. Do not use it in production.

--- a/extensions/flockmtl/description.yml
+++ b/extensions/flockmtl/description.yml
@@ -1,0 +1,43 @@
+extension:
+  name: flockmtl
+  description: DuckDB HTTP API Server Extension
+  version: 0.1.0
+  language: SQL & C++
+  build: cmake
+  license: MIT
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads"
+  maintainers:
+    - dorbanianas
+    - SunnyYasser
+    - queryproc
+
+repo:
+  github: dsg-polymtl/flockmtl
+  ref: XX
+
+docs:
+  hello_world: |
+    -- Call an OpenAI model with a predefined prompt 'Tell me hello world' and default model 'gpt-4o-mini'
+    D SELECT llm_complete(hello_world, default_model);
+    ┌──────────────────────────────────────────┐
+    │ llm_complete(hello_world, default_model) │
+    │                 varchar                  │
+    ├──────────────────────────────────────────┤
+    │                Hello world               │
+    └──────────────────────────────────────────┘
+
+    -- Check the prompts and supported models
+    D SHOW ALL PROMPTS;
+    D SHOW ALL MODELS;
+
+    -- Create a new prompt for summarizing text
+    D CREATE PROMPT(summarize, 'summarize the text into 1 word: {{text}}');
+
+    -- Create a variable name for the model to do the summarizing
+    D CREATE MODEL(summarizer-model, 'gpt-4o');
+
+    -- Summarize text and pass it as parameter 
+    D SELECT llm_complete(summarize, summarizer-model, {'text': 'We support more functions and approaches to combine relational analytics and semantic analysis. Check our repo for documentation and examples.'});
+
+  extended_description: |
+    This extension is experimental and potentially unstable. Do not use it in production.

--- a/extensions/flockmtl/description.yml
+++ b/extensions/flockmtl/description.yml
@@ -12,7 +12,7 @@ extension:
     - queryproc
 
 repo:
-  github: dsg-polymtl/flockmtl
+  github: dsg-polymtl/duckdb-flockmtl
   ref: 2450acd2b04a4a81342965b6c7eed6fb5899181f
 
 docs:

--- a/extensions/flockmtl/description.yml
+++ b/extensions/flockmtl/description.yml
@@ -5,7 +5,6 @@ extension:
   language: SQL & C++
   build: cmake
   license: MIT
-  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads"
   maintainers:
     - dorbanianas
     - SunnyYasser
@@ -13,11 +12,11 @@ extension:
 
 repo:
   github: dsg-polymtl/duckdb-flockmtl
-  ref: 2450acd2b04a4a81342965b6c7eed6fb5899181f
+  ref: 1bd8ac0f54f8bf4c7da1c3793b88e73daa127653
 
 docs:
   hello_world: |
-    -- The library loads successfully if an OPENAI_API_KEY is set in the environment
+    -- After loading, any function call will throw an error if an OPENAI_API_KEY environment variable is not set
 
     -- Call an OpenAI model with a predefined prompt ('Tell me hello world') and default model ('gpt-4o-mini')
     D SELECT llm_complete('hello-world', 'default');


### PR DESCRIPTION
This PR adds `FlockMTL`, a DuckDB extension, as a community supported extension. 

`FlockMTL` introduce `PROMPT`(s) and `MODEL`(s) as DDL constructs and multiple LLM scalar functions, namely `llm_complete`, `llm_complete_json`, `llm_filter`, and `llm_embedding`.

The current ref points to the following release: https://github.com/dsg-polymtl/duckdb-flockmtl/releases/tag/v0.1.0