### PR TITLE
GSheets v0.0.2

### DIFF
--- a/extensions/gsheets/description.yml
+++ b/extensions/gsheets/description.yml
@@ -5,7 +5,7 @@ extension:
   language: C++
   build: cmake
   license: MIT
-  excluded_platforms: "windows_amd64_rtools"
+  excluded_platforms: "windows_amd64_rtools;wasm_mvp;wasm_eh;wasm_threads"
   maintainers:
     - archiewood
 

--- a/extensions/gsheets/description.yml
+++ b/extensions/gsheets/description.yml
@@ -1,25 +1,29 @@
 extension:
   name: gsheets
   description: Read and write Google Sheets using SQL
-  version: 0.0.1
+  version: 0.0.2
   language: C++
   build: cmake
   license: MIT
-  excluded_platforms: "windows_amd64_rtools;wasm_mvp;wasm_eh;wasm_threads"
+  excluded_platforms: "windows_amd64_rtools"
   maintainers:
     - archiewood
 
 repo:
   github: evidence-dev/duckdb_gsheets
-  ref: 7f7c6e2f85edd9ad9c2f16f2075818627fca8405
+  ref: 01bdf2872b78af1b9234792766392840fc4a91b7
 
 docs:
   hello_world: |
     -- Authenticate with Google Account in the browser (easiest)
-    CREATE SECRET (TYPE gsheet, PROVIDER oauth);
+    CREATE SECRET (TYPE gsheet);
     
     -- OR create a secret with your Google API access token (boring, see extension docs)
-    CREATE SECRET (TYPE gsheet, TOKEN '<your_token>');
+    CREATE SECRET (
+      TYPE gsheet, 
+      PROVIDER access_token, 
+      TOKEN '<your_token>'
+    );
     
     -- Read a spreadsheet by full URL
     FROM read_gsheet('https://docs.google.com/spreadsheets/d/11QdEasMWbETbFVxry-SsD8jVcdYIT1zBQszcF84MdE8/edit');


### PR DESCRIPTION
Updates DuckDB GSheets to v0.0.2
- Makes OAuth default provider
- Fixes bugs with reading
- Support for writing all types