### PR TITLE
Update http_client to v0.0.3

### DIFF
--- a/extensions/http_client/description.yml
+++ b/extensions/http_client/description.yml
@@ -1,26 +1,33 @@
 extension:
   name: http_client
   description: DuckDB HTTP Client Extension
-  version: 0.0.2
+  version: 0.0.3
   language: C++
   build: cmake
   license: MIT
+  excluded_platforms: "windows_amd64_mingw"
   maintainers:
     - lmangani
     - ahuarte47
 
 repo:
   github: quackscience/duckdb-extension-httpclient
-  ref: db0ebb7f8c2688ff7a785b83a387bf782d13afd1
+  ref: 9b006341fa0fe9ade344620c40d867babe359645
 
 docs:
   hello_world: |
     -- GET Request Example w/ JSON Parsing
     WITH __input AS (
-    SELECT
-      http_get(
-          'https://httpbin.org/delay/0'
-      ) AS res
+      SELECT
+        http_get(
+            'https://httpbin.org/delay/0',
+            headers => MAP {
+              'accept': 'application/json',
+            },
+            params => MAP {
+              'limit': 1
+            }
+        ) AS res
     ),
     __response AS (
       SELECT
@@ -33,7 +40,7 @@ docs:
     SELECT
       __response.status,
       __response.reason,
-      __response.Host AS host,
+      __response.Host AS host
     FROM
       __response
     ;
@@ -53,6 +60,7 @@ docs:
             'accept': 'application/json',
           },
           params => MAP {
+            'limit': 1
           }
       ) AS res
     ),


### PR DESCRIPTION
## http_client v0.0.3
### What's Changed
- Add new http_get extra function with header & params by @ahuarte47 in https://github.com/quackscience/duckdb-extension-httpclient/pull/8
- Excluded `windows_amd64_mingw` from targets due to incompatibilities we'll address if there's demand