### PR TITLE
chsql_native 0.0.2

### DIFF
--- a/extensions/chsql_native/description.yml
+++ b/extensions/chsql_native/description.yml
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: quackscience/duckdb-extension-clickhouse-native
-  ref: 1c9d08775def3b5a05a7d58590e5924845390657
+  ref: 7d00778fb5f3ba575e33d975faef7f68527d188a
 
 docs:
   hello_world: |

--- a/extensions/chsql_native/description.yml
+++ b/extensions/chsql_native/description.yml
@@ -13,16 +13,15 @@ extension:
 
 repo:
   github: quackscience/duckdb-extension-clickhouse-native
-  ref: 7d00778fb5f3ba575e33d975faef7f68527d188a
+  ref: f2e3b6d0c327d71e0989f078b7fc6d13dbac52b9
 
 docs:
   hello_world: |
     --- This experimental rust extension implements Native Clickhouse formats for DuckDB.
-    --- Native Binary Client for chsql
-    --- CLICKHOUSE_URL="tcp://localhost:9000"
-    --- CLICKHOUSE_USER="default"
-
-    --- Simple Example
+    --- ClickHouse Native Binary Client for chsql
+    --- export CLICKHOUSE_URL="tcp://localhost:9000"
+    --- export CLICKHOUSE_URL="tcp://user:pass@remote:9440/?secure=true&skip_verify=true"
+    --- Simple Query Example
     D SELECT * FROM clickhouse_scan("SELECT version(), 'hello', 123");
     ┌────────────┬─────────┬────────┐
     │ version()  │ 'hello' │  123   │
@@ -31,7 +30,7 @@ docs:
     │ 24.10.2.80 │ hello   │    123 │
     └────────────┴─────────┴────────┘
     
-    --- Wide Example
+    --- Wide Query Example
     D SELECT * FROM clickhouse_scan("SELECT * FROM system.functions WHERE alias_to != '' LIMIT 10");
     ┌────────────────────┬──────────────┬──────────────────┬──────────────────────┬───┬───────────┬────────────────┬──────────┬────────────┐
     │        name        │ is_aggregate │ case_insensitive │       alias_to       │ … │ arguments │ returned_value │ examples │ categories │

--- a/extensions/chsql_native/description.yml
+++ b/extensions/chsql_native/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: chsql_native
-  description: ClickHouse Native File reader for chsql
-  version: 0.0.1
+  description: ClickHouse Native Client & File Reader for chsql
+  version: 0.0.2
   language: Rust
   build: cmake
   license: MIT
@@ -13,12 +13,47 @@ extension:
 
 repo:
   github: quackscience/duckdb-extension-clickhouse-native
-  ref: 0116eb462ec85fa000f1cb15a3b0ee6165711b78
+  ref: 1c9d08775def3b5a05a7d58590e5924845390657
 
 docs:
   hello_world: |
-    --- This experimental rust extension allows reading ClickHouse Native files with DuckDB
-    --- Test files can be generated with clickhouse-local. See README for full examples.
+    --- This experimental rust extension implements Native Clickhouse formats for DuckDB.
+    --- Native Binary Client for chsql
+    --- CLICKHOUSE_URL="tcp://localhost:9000"
+    --- CLICKHOUSE_USER="default"
+
+    --- Simple Example
+    D SELECT * FROM clickhouse_scan("SELECT version(), 'hello', 123");
+    ┌────────────┬─────────┬────────┐
+    │ version()  │ 'hello' │  123   │
+    │  varchar   │ varchar │ uint32 │
+    ├────────────┼─────────┼────────┤
+    │ 24.10.2.80 │ hello   │    123 │
+    └────────────┴─────────┴────────┘
+    
+    --- Wide Example
+    D SELECT * FROM clickhouse_scan("SELECT * FROM system.functions WHERE alias_to != '' LIMIT 10");
+    ┌────────────────────┬──────────────┬──────────────────┬──────────────────────┬───┬───────────┬────────────────┬──────────┬────────────┐
+    │        name        │ is_aggregate │ case_insensitive │       alias_to       │ … │ arguments │ returned_value │ examples │ categories │
+    │      varchar       │    uint32    │      uint32      │       varchar        │   │  varchar  │    varchar     │ varchar  │  varchar   │
+    ├────────────────────┼──────────────┼──────────────────┼──────────────────────┼───┼───────────┼────────────────┼──────────┼────────────┤
+    │ connection_id      │            0 │                1 │ connectionID         │ … │           │                │          │            │
+    │ rand32             │            0 │                0 │ rand                 │ … │           │                │          │            │
+    │ INET6_ATON         │            0 │                1 │ IPv6StringToNum      │ … │           │                │          │            │
+    │ INET_ATON          │            0 │                1 │ IPv4StringToNum      │ … │           │                │          │            │
+    │ truncate           │            0 │                1 │ trunc                │ … │           │                │          │            │
+    │ ceiling            │            0 │                1 │ ceil                 │ … │           │                │          │            │
+    │ replace            │            0 │                1 │ replaceAll           │ … │           │                │          │            │
+    │ from_utc_timestamp │            0 │                1 │ fromUTCTimestamp     │ … │           │                │          │            │
+    │ mapFromString      │            0 │                0 │ extractKeyValuePairs │ … │           │                │          │            │
+    │ str_to_map         │            0 │                1 │ extractKeyValuePairs │ … │           │                │          │            │
+    ├────────────────────┴──────────────┴──────────────────┴──────────────────────┴───┴───────────┴────────────────┴──────────┴────────────┤
+    │ 10 rows                                                                                                         12 columns (8 shown) │
+    └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+    --- Native File Reader for chsql
+    --- Test files can be generated with clickhouse-local. File reads are full-scans.
     
     --- Simple Example
     D SELECT * FROM clickhouse_native('/tmp/numbers.clickhouse');
@@ -59,4 +94,4 @@ docs:
     └─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
     
   extended_description: |
-    This extension is highly experimental and potentially unstable. All reads are full-scans. Do not use in production.
+    This extension is highly experimental and potentially unstable. Do not use in production. See README for full examples.

--- a/extensions/chsql_native/description.yml
+++ b/extensions/chsql_native/description.yml
@@ -1,0 +1,62 @@
+extension:
+  name: chsql_native
+  description: ClickHouse Native File reader for chsql
+  version: 0.0.1
+  language: Rust
+  build: cmake
+  license: MIT
+  excluded_platforms: "windows_amd64_rtools;windows_amd64;wasm_threads;wasm_eh;wasm_mvp"
+  requires_toolchains: "rust;python3"
+  maintainers:
+    - lmangani
+    - adubovikov
+
+repo:
+  github: quackscience/duckdb-extension-clickhouse-native
+  ref: 0116eb462ec85fa000f1cb15a3b0ee6165711b78
+
+docs:
+  hello_world: |
+    --- This experimental rust extension allows reading ClickHouse Native files with DuckDB
+    --- Test files can be generated with clickhouse-local. See README for full examples.
+    
+    --- Simple Example
+    D SELECT * FROM clickhouse_native('/tmp/numbers.clickhouse');
+    ┌──────────────┬─────────┐
+    │  version()   │ number  │
+    │   varchar    │  int32  │
+    ├──────────────┼─────────┤
+    │ 24.12.1.1273 │ 0       │
+    └──────────────┴─────────┘
+    
+    --- Long Example
+    D SELECT count(*), max(number) FROM clickhouse_native('/tmp/100000.clickhouse');
+    ┌──────────────┬─────────────┐
+    │ count_star() │ max(number) │
+    │    int64     │    int32    │
+    ├──────────────┼─────────────┤
+    │       100000 │       99999 │
+    └──────────────┴─────────────┘
+    
+    --- Wide Example
+    D SELECT * FROM clickhouse_native('/tmp/functions.clickhouse') WHERE alias_to != '' LIMIT 10;
+    ┌────────────────────┬──────────────┬──────────────────┬──────────────────────┬──────────────┬─────────┬───┬─────────┬───────────┬────────────────┬──────────┬────────────┐
+    │        name        │ is_aggregate │ case_insensitive │       alias_to       │ create_query │ origin  │ … │ syntax  │ arguments │ returned_value │ examples │ categories │
+    │      varchar       │    int32     │      int32       │       varchar        │   varchar    │ varchar │   │ varchar │  varchar  │    varchar     │ varchar  │  varchar   │
+    ├────────────────────┼──────────────┼──────────────────┼──────────────────────┼──────────────┼─────────┼───┼─────────┼───────────┼────────────────┼──────────┼────────────┤
+    │ connection_id      │            0 │                1 │ connectionID         │              │ System  │ … │         │           │                │          │            │
+    │ rand32             │            0 │                0 │ rand                 │              │ System  │ … │         │           │                │          │            │
+    │ INET6_ATON         │            0 │                1 │ IPv6StringToNum      │              │ System  │ … │         │           │                │          │            │
+    │ INET_ATON          │            0 │                1 │ IPv4StringToNum      │              │ System  │ … │         │           │                │          │            │
+    │ truncate           │            0 │                1 │ trunc                │              │ System  │ … │         │           │                │          │            │
+    │ ceiling            │            0 │                1 │ ceil                 │              │ System  │ … │         │           │                │          │            │
+    │ replace            │            0 │                1 │ replaceAll           │              │ System  │ … │         │           │                │          │            │
+    │ from_utc_timestamp │            0 │                1 │ fromUTCTimestamp     │              │ System  │ … │         │           │                │          │            │
+    │ mapFromString      │            0 │                0 │ extractKeyValuePairs │              │ System  │ … │         │           │                │          │            │
+    │ str_to_map         │            0 │                1 │ extractKeyValuePairs │              │ System  │ … │         │           │                │          │            │
+    ├────────────────────┴──────────────┴──────────────────┴──────────────────────┴──────────────┴─────────┴───┴─────────┴───────────┴────────────────┴──────────┴────────────┤
+    │ 10 rows                                                                                                                                           12 columns (11 shown) │
+    └─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+    
+  extended_description: |
+    This extension is highly experimental and potentially unstable. All reads are full-scans. Do not use in production.


### PR DESCRIPTION
### Changes in chsql_native 0.0.2
Implements a Native ClickHouse binary TCP Client for DuckDB as alternative to the existing HTTP based client macro available in chsql.

- Includes vendored OpenSSL Rust crate to enable TLS

![ducks-ezgif com-optimize](https://github.com/user-attachments/assets/d2676850-a709-4e37-8dcc-fa060d234a76)
