### PR TITLE
Avoid failures due to missing permissions to upload docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,9 +137,3 @@ jobs:
       extension_name: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_NAME }}
       repository: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_GITHUB }}
       ref: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_REF }}
-
-  docs_all:
-    if: ${{ (github.head_ref || github.ref_name) == 'main' }}
-    needs:
-     - deploy
-    uses: ./.github/workflows/generate_docs.yml

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -31,6 +31,7 @@ jobs:
         cp build/docs/extensions_list.md.tmp web/_includes/list_of_community_extensions.md
 
     - name: Upload to duckdb/duckdb-web
+      if: github.repository != 'duckdb/duckdb-web'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |


### PR DESCRIPTION
Currently CI jobs connected to docs fails due to missing permissions (token has the right permissions only when invoked from duckdb/duckdb-web).

This has no real impact on the rest, but should remove some red crosses that do introduce noise.