### PR TITLE
Skip `_mingw` whenever skipping `_rtools`

### DIFF
--- a/extensions/avro/description.yml
+++ b/extensions/avro/description.yml
@@ -5,7 +5,7 @@ extension:
   language: C++
   build: cmake
   license: MIT
-  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools"
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw"
 
   maintainers:
     - hannes

--- a/extensions/bigquery/description.yml
+++ b/extensions/bigquery/description.yml
@@ -5,7 +5,7 @@ extension:
   language: C++
   build: cmake
   license: MIT
-  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;osx_amd64;linux_arm64"
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw;osx_amd64;linux_arm64"
   vcpkg_commit: "e01906b2ba7e645a76ee021a19de616edc98d29f"
   requires_toolchains: "parser_tools"
   maintainers:

--- a/extensions/chsql_native/description.yml
+++ b/extensions/chsql_native/description.yml
@@ -5,7 +5,7 @@ extension:
   language: Rust
   build: cmake
   license: MIT
-  excluded_platforms: "windows_amd64_rtools;windows_amd64;wasm_threads;wasm_eh;wasm_mvp"
+  excluded_platforms: "windows_amd64_rtools;windows_amd64_mingw;windows_amd64;wasm_threads;wasm_eh;wasm_mvp"
   requires_toolchains: "rust;python3"
   maintainers:
     - lmangani

--- a/extensions/crypto/description.yml
+++ b/extensions/crypto/description.yml
@@ -43,7 +43,7 @@ docs:
 extension:
   build: cmake
   description: Cryptographic hash functions and HMAC
-  excluded_platforms: windows_amd64_rtools;windows_amd64
+  excluded_platforms: windows_amd64_rtools;windows_amd64_mingw;windows_amd64
   language: C++
   license: MIT
   maintainers:

--- a/extensions/evalexpr_rhai/description.yml
+++ b/extensions/evalexpr_rhai/description.yml
@@ -75,7 +75,7 @@ docs:
 extension:
   build: cmake
   description: Evaluate the Rhai scripting language in DuckDB
-  excluded_platforms: windows_amd64_rtools;windows_amd64
+  excluded_platforms: windows_amd64_rtools;windows_amd64_mingw;windows_amd64
   language: C++
   license: Apache-2.0
   maintainers:

--- a/extensions/h3/description.yml
+++ b/extensions/h3/description.yml
@@ -7,7 +7,7 @@ extension:
   license: Apache-2.0
   maintainers:
     - isaacbrodsky
-  excluded_platforms: "windows_amd64_rtools"
+  excluded_platforms: "windows_amd64_rtools;windows_amd64_mingw"
 
 repo:
   github: isaacbrodsky/h3-duckdb

--- a/extensions/pcap_reader/description.yml
+++ b/extensions/pcap_reader/description.yml
@@ -5,7 +5,7 @@ extension:
   language: Rust
   build: cmake
   license: MIT
-  excluded_platforms: "windows_amd64_rtools;windows_amd64"
+  excluded_platforms: "windows_amd64_rtools;windows_amd64_mingw;windows_amd64"
   requires_toolchains: "rust;python3"
   maintainers:
     - lmangani

--- a/extensions/pyroscope/description.yml
+++ b/extensions/pyroscope/description.yml
@@ -5,7 +5,7 @@ extension:
   language: Rust
   build: cmake
   license: MIT
-  excluded_platforms: "windows_amd64_rtools;windows_amd64;wasm_threads;wasm_eh;wasm_mvp"
+  excluded_platforms: "windows_amd64_rtools;windows_amd64_mingw;windows_amd64;wasm_threads;wasm_eh;wasm_mvp"
   requires_toolchains: "rust;python3"
   maintainers:
     - lmangani

--- a/extensions/rusty_quack/description.yml
+++ b/extensions/rusty_quack/description.yml
@@ -5,7 +5,7 @@ extension:
   language: Rust
   build: cargo
   license: MIT
-  excluded_platforms: "windows_amd64_rtools"
+  excluded_platforms: "windows_amd64_rtools;windows_amd64_mingw"
   requires_toolchains: "rust;python3"
   maintainers:
     - samansmink

--- a/extensions/scrooge/description.yml
+++ b/extensions/scrooge/description.yml
@@ -3,7 +3,7 @@ extension:
   description: Provides functionality for financial data-analysis, including data scanners for the Ethereum Blockchain and Yahoo Finance
   version: 0.0.2
   language: C++
-  excluded_platforms: "windows_amd64_rtools"
+  excluded_platforms: "windows_amd64_rtools;windows_amd64_mingw"
   build: cmake
   license: MIT
   maintainers:

--- a/extensions/sheetreader/description.yml
+++ b/extensions/sheetreader/description.yml
@@ -4,7 +4,7 @@ extension:
   version: 0.1.0
   language: C++
   build: cmake
-  excluded_platforms: windows_amd64_rtools
+  excluded_platforms: "windows_amd64_rtools;windows_amd64_mingw"
   license: MIT
   maintainers:
     - freddie-freeloader


### PR DESCRIPTION
Platform selection changed a bit between `v1.1.3` and the upcoming `v1.2.0`:

* `windows_amd64_rtools` has been removed, replaced by `windows_amd64_mingw`
* `linux_amd64_musl` has been added

The first change is relevant here, where whenever `_rools` is mentioned `_mingw` is added.

This should have no real impact, unless you are downloading extenisions manually or builing a duckdb-client. Details are in https://github.com/duckdb/duckdb/pull/14368.