### PR TITLE
[lindel] Skip platform linux_amd64_musl

### DIFF
--- a/extensions/lindel/description.yml
+++ b/extensions/lindel/description.yml
@@ -101,6 +101,7 @@ extension:
   description: Linearization/Delinearization, Z-Order, Hilbert and Morton Curves
   language: C++
   license: Apache-2.0
+  excluded_platforms: "linux_amd64_musl"
   maintainers:
   - rustyconover
   name: lindel


### PR DESCRIPTION
Problem is currently:
```
-- Found Rust: /root/.rustup/toolchains/stable-x86_64-unknown-linux-musl/bin/rustc (found version "1.83.0")
CMake Error at /duckdb_build_dir/corrosion/cmake/Corrosion.cmake:79 (message):
  Target x86_64-unknown-linux-gnu is not installed for toolchain
  stable-x86_64-unknown-linux-musl.

  Help: Run `rustup target add --toolchain stable-x86_64-unknown-linux-musl
  x86_64-unknown-linux-gnu` to install the missing target.
Call Stack (most recent call first):
  /duckdb_build_dir/corrosion/CMakeLists.txt:73 (include)
```

Needs to be likely solved at the toolchain level, possibly in the dockerfile for musl in duckdb/extension-ci-tools.

@rustyconover 