### PR TITLE
[evalexpr_rhai] Skip platform linux_amd64_musl

### DIFF
--- a/extensions/evalexpr_rhai/description.yml
+++ b/extensions/evalexpr_rhai/description.yml
@@ -75,7 +75,7 @@ docs:
 extension:
   build: cmake
   description: Evaluate the Rhai scripting language in DuckDB
-  excluded_platforms: windows_amd64_rtools;windows_amd64_mingw;windows_amd64
+  excluded_platforms: windows_amd64_rtools;windows_amd64_mingw;windows_amd64;linux_amd64_musl
   language: C++
   license: Apache-2.0
   maintainers:


### PR DESCRIPTION
Problem is currently:
```
-- Found Rust: /root/.rustup/toolchains/stable-x86_64-unknown-linux-musl/bin/rustc (found version "1.83.0")
CMake Error at /duckdb_build_dir/corrosion/cmake/Corrosion.cmake:79 (message):
  Target x86_64-unknown-linux-gnu is not installed for toolchain
  stable-x86_64-unknown-linux-musl.

  Help: Run `rustup target add --toolchain stable-x86_64-unknown-linux-musl
  x86_64-unknown-linux-gnu` to install the missing target.
Call Stack (most recent call first):
  /duckdb_build_dir/corrosion/CMakeLists.txt:73 (include)
```

Needs to be likely solved at the toolchain level, possibly in the dockerfile for musl in duckdb/extension-ci-tools.