### PR TITLE
[lindel] fix: bump version

### DIFF
--- a/extensions/lindel/description.yml
+++ b/extensions/lindel/description.yml
@@ -1,5 +1,6 @@
 docs:
-  extended_description: "This `lindel` extension adds functions for the linearization\
+  extended_description:
+    "This `lindel` extension adds functions for the linearization\
     \ and\ndelinearization of numeric arrays in DuckDB. It allows you to order\nmulti-dimensional\
     \ data using space-filling curves.\n\n## What is linearization?\n\n[Linearization](https://en.wikipedia.org/wiki/Linearization)\
     \ maps multi-dimensional data into a one-dimensional sequence while [preserving\
@@ -57,7 +58,8 @@ docs:
     \ |\n| `UBIGINT`    | 2 | 1: `UBIGINT`<br/>2: `UHUGEINT` |\n| `FLOAT`      | 4\
     \ | 1: `UINTEGER`<br/>2: `UBIGINT`<br/>3-4: `UHUGEINT` |\n| `DOUBLE`     | 2 |\
     \ 1: `UBIGINT`<br/>2: `UHUGEINT` |\n"
-  hello_world: "WITH elements AS (\n  SELECT * AS id FROM range(3)\n)\nSELECT\n  a.id\
+  hello_world:
+    "WITH elements AS (\n  SELECT * AS id FROM range(3)\n)\nSELECT\n  a.id\
     \ AS a,\n  b.id AS b,\n  hilbert_encode([a.id, b.id]::tinyint[2]) AS hilbert,\n\
     \  morton_encode([a.id, b.id]::tinyint[2]) AS morton\nFROM\n  elements AS a CROSS\
     \ JOIN elements AS b;\n┌───────┬───────┬─────────┬────────┐\n│   a   │   b   │\
@@ -103,10 +105,10 @@ extension:
   license: Apache-2.0
   excluded_platforms: "linux_amd64_musl"
   maintainers:
-  - rustyconover
+    - rustyconover
   name: lindel
   requires_toolchains: rust
-  version: 1.0.0
+  version: 1.0.1
 repo:
   github: rustyconover/duckdb-lindel-extension
-  ref: a45b2840e748f4aa0552c599b48c19eba53bdc27
+  ref: b2ad60e4ec0b682f2e0af04a2597ec86885a3d1d

--- a/extensions/lindel/description.yml
+++ b/extensions/lindel/description.yml
@@ -111,4 +111,4 @@ extension:
   version: 1.0.1
 repo:
   github: rustyconover/duckdb-lindel-extension
-  ref: b2ad60e4ec0b682f2e0af04a2597ec86885a3d1d
+  ref: a9cebd1973202afa4357f99e6ed790ea890c65ae


### PR DESCRIPTION
There was a bug with Hilbert and Morton decoding as reported at https://github.com/rustyconover/duckdb-lindel-extension/issues/4

I've fixed that bug and added a test case.  Bumping the extension to version 1.0.1.