### PR TITLE
Bump h3 to get fixes for functions accepting lists of H3 indexes

### DIFF
--- a/extensions/h3/description.yml
+++ b/extensions/h3/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: isaacbrodsky/h3-duckdb
-  ref: 444cb06e428976ed9b9e9e133e6effac2870a66d
+  ref: 669d8b2bcab8f3cc86dfa3a35606736a4820e397
 
 docs:
   hello_world: |


### PR DESCRIPTION
Applies https://github.com/isaacbrodsky/h3-duckdb/pull/141

Does this need a new version number / release or is that independent of the ref?