### PR TITLE
bump zipfs Jan 20

### DIFF
--- a/extensions/zipfs/description.yml
+++ b/extensions/zipfs/description.yml
@@ -11,8 +11,8 @@ extension:
 
 repo:
   github: isaacbrodsky/duckdb-zipfs
-  ref: d2a324fbf8bd3b20aae97c8abeb945589d4bdfc4
-  ref_next: e530fd82fbbd4ee57f87f54b5cc24f39bccf1a04
+  ref: 1998be89bf7f2a464161121661f016e0c8fe1302
+  ref_next: b920e53ded17076af5559c506ab2a871d9bee624
 
 docs:
   hello_world: |


### PR DESCRIPTION
Applies https://github.com/isaacbrodsky/duckdb-zipfs/pull/3/ , cleanup code was unreachable.