### PR TITLE
Add blockduck extension

### DIFF
--- a/extensions/blockduck/description.yml
+++ b/extensions/blockduck/description.yml
@@ -5,6 +5,7 @@ extension:
   language: C++
   build: cmake
   license: MIT
+  excluded_platforms: "windows_amd64_rtools;windows_amd64;wasm_mvp;wasm_eh;wasm_threads"
   maintainers:
     - luohaha
 

--- a/extensions/blockduck/description.yml
+++ b/extensions/blockduck/description.yml
@@ -1,0 +1,16 @@
+extension:
+  name: blockduck
+  description: Live SQL Queries on Blockchain
+  version: 0.5.0
+  language: C++
+  build: cmake
+  license: MIT
+  maintainers:
+    - luohaha
+
+repo:
+  github: luohaha/BlockDuck
+  ref: aed5fcd9c4e980991b93d017b07991105846212f
+
+docs:
+  https://yixins-organization.gitbook.io/blockduck-docs

--- a/extensions/blockduck/description.yml
+++ b/extensions/blockduck/description.yml
@@ -5,13 +5,13 @@ extension:
   language: C++
   build: cmake
   license: MIT
-  excluded_platforms: "windows_amd64_rtools;windows_amd64;wasm_mvp;wasm_eh;wasm_threads"
+  excluded_platforms: "windows_amd64_rtools;windows_amd64;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads"
   maintainers:
     - luohaha
 
 repo:
   github: luohaha/BlockDuck
-  ref: aed5fcd9c4e980991b93d017b07991105846212f
+  ref: b7d432f8d9145d6228043c30487c77c8b2d1714a
 
 docs:
   https://yixins-organization.gitbook.io/blockduck-docs


### PR DESCRIPTION
Add blockduck extension to community.
> BlockDuck is a tool for blockchain data analysis, and it allows users to query blockchain directly in a way that is similar to querying a traditional SQL database.

More info:
Repo: https://github.com/luohaha/BlockDuck
Docs: https://yixins-organization.gitbook.io/blockduck-docs