### PR TITLE
Create the first release (v1.2.0) of the Substrait extension

### DIFF
--- a/extensions/substrait/description.yml
+++ b/extensions/substrait/description.yml
@@ -9,7 +9,7 @@ extension:
     - anshuldata
     - cgkiran
     - EpsilonPrime
-  excluded_platforms: "windows_amd64_rtools;windows_amd64_mingw"
+  excluded_platforms: "windows_amd64_rtools;windows_amd64_mingw;windows_amd64"
 
 repo:
   github: substrait-io/duckdb-substrait-extension

--- a/extensions/substrait/description.yml
+++ b/extensions/substrait/description.yml
@@ -1,0 +1,23 @@
+extension:
+  name: substrait
+  description: Allows conversion execution of Substrait query plans
+  version: 1.2.0
+  language: C++
+  build: cmake
+  license: Apache-2.0
+  maintainers:
+    - anshuldata
+    - cgkiran
+    - EpsilonPrime
+  excluded_platforms: "windows_amd64_rtools;windows_amd64_mingw"
+
+repo:
+  github: substrait-io/duckdb-substrait-extension
+  ref: 52a0db8f14b4000ec031ca65671f7b2057327a57
+
+docs:
+  hello_world: |
+    .mode line
+    CALL get_substrait('SELECT count(exercise) AS exercise FROM crossfit WHERE difficulty_level <= 5');
+  extended_description: |
+    DuckDB has extensive documentation for the [Substrait extension on their website](https://duckdb.org/docs/extensions/substrait.html).

--- a/extensions/substrait/description.yml
+++ b/extensions/substrait/description.yml
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: substrait-io/duckdb-substrait-extension
-  ref: 52a0db8f14b4000ec031ca65671f7b2057327a57
+  ref: a1b341cc3df16c55535c12acce375040ffe50347
 
 docs:
   hello_world: |

--- a/extensions/substrait/docs/function_descriptions.csv
+++ b/extensions/substrait/docs/function_descriptions.csv
@@ -1,0 +1,5 @@
+function,description,comment,example
+get_substrait,Converts the provided query into a binary Substrait plan,"",""
+get_substrait_json,Converts the provided query into a Substrait plan in JSON,"",""
+from_substrait,Executes a binary Substrait plan (provided as bytes) against DuckDB and returns the results,"","" 
+from_substrait_json,Executes a Substrait plan written in JSON against DuckDB and returns the results,"",""


### PR DESCRIPTION
The Substrait extension previously was a DuckDB core extension.  This is the first release of the Substrait extension as a community extension.
