### PR TITLE
[fuzzycomplete] Skip musl platform

### DIFF
--- a/extensions/fuzzycomplete/description.yml
+++ b/extensions/fuzzycomplete/description.yml
@@ -171,6 +171,7 @@ extension:
   name: fuzzycomplete
   requires_toolchains: rust
   version: 1.0.0
+  excluded_platforms: "linux_amd64_musl"
 repo:
   github: rustyconover/duckdb-fuzzycomplete-extension
   ref: 39a61c1c39a2b028101ef635fcb04856883ab498


### PR DESCRIPTION
There is some problem to be fixed with propagating rust toolchain, skipping to keep distributing elsewhere.

@rustyconover fyi