### PR TITLE
netquack - use auto-generated functions

### DIFF
--- a/extensions/netquack/description.yml
+++ b/extensions/netquack/description.yml
@@ -18,15 +18,4 @@ docs:
 
     With Netquack, you can unlock deeper insights from your web-related datasets without the need for external tools or complex workflows.
 
-    ### Functions
-
-    - `extract_domain`: Extracting The Main Domain From A URL
-    - `extract_path`: Extracting The Path From A URL
-    - `extract_host`: Extracting The Hostname From A URL
-    - `extract_schema`: Extracting The Schema From A URL
-    - `extract_query_string`: Extracting The Query String From A URL
-    - `extract_tld`: Extracting The Top-Level Domain From A URL
-    - `extract_subdomain`: Extracting The Subdomain From A URL
-    - `get_tranco_rank`: Getting The Tranco Rank Of A Domain
-
-    Check the [documentation](https://github.com/hatamiarash7/duckdb-netquack) for more details on each function.
+    Check the [documentation](https://github.com/hatamiarash7/duckdb-netquack) for more details and examples on each function.

--- a/extensions/netquack/docs/function_descriptions.csv
+++ b/extensions/netquack/docs/function_descriptions.csv
@@ -1,0 +1,11 @@
+function,description,comment,example
+"extract_domain","Extracting the main domain from a URL","","SELECT extract_domain('a.example.com') as domain;"
+"extract_host","Extracting the hostname from a URL","","SELECT extract_host('https://b.a.example.com/path/path') as host;"
+"extract_path","Extracting the path from a URL","","SELECT extract_path('example.com/path/path/image.png') as path;"
+"extract_query_string","Extracting the query string from a URL","","SELECT extract_query_string('example.com?key=value') as query;"
+"extract_schema","Extracting the schema from a URL","","SELECT extract_schema('mailto:someone@example.com') as schema;"
+"extract_subdomain","Extracting the subdomain from a URL","","SELECT extract_subdomain('test.example.com.ac') as dns_record;"
+"extract_tld","Extracting the top-level domain from a URL","","SELECT extract_tld('a.example.com') as tld;"
+"get_tranco_rank","Getting the Tranco rank of a domain","","SELECT get_tranco_rank('cloudflare.com') as rank;"
+"update_suffixes","Update public suffixes","","SELECT update_suffixes();"
+"update_tranco","Update tranco data","","SELECT update_tranco(true);"


### PR DESCRIPTION
After the recent fixes regarding `Added Functions`, there is no need to list the functions separately anymore.

I removed this extra section for the Netquack extension. Also, a help file was added to complete the documentation of the functions.