### PR TITLE
bump blockduck to v0.6.0

### DIFF
--- a/extensions/blockduck/description.yml
+++ b/extensions/blockduck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: blockduck
   description: Live SQL Queries on Blockchain
-  version: 0.5.0
+  version: 0.6.0
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: luohaha/BlockDuck
-  ref: b7d432f8d9145d6228043c30487c77c8b2d1714a
+  ref: a3b9dd692ff06488e1b85c1f74220d21bda9ab67
 
 docs:
   https://yixins-organization.gitbook.io/blockduck-docs


### PR DESCRIPTION
bump `blockduck` to v0.6.0, contains these changes:
1. Add `eth_traces_v2_rpc` table function.
2. Add more fields to `eth_blocks_rpc`.
3. Add correctness test.
4. bump submodules to v1.2.0.
5. Some bugfix.