### PR TITLE
fix: Sync the default vcpkg commit match the commit specified extension-ci-tools for 1.2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
       COMMUNITY_EXTENSION_EXCLUDE_PLATFORMS: ${{ inputs.more_excluded }}${{ steps.parse.outputs.COMMUNITY_EXTENSION_EXCLUDE_PLATFORMS }}
       COMMUNITY_EXTENSION_REQUIRES_TOOLCHAINS: ${{ steps.parse.outputs.COMMUNITY_EXTENSION_REQUIRES_TOOLCHAINS }}
       COMMUNITY_EXTENSION_VCPKG_URL: ${{ steps.parse.outputs.COMMUNITY_EXTENSION_VCPKG_URL == '' && 'https://github.com/microsoft/vcpkg.git' || steps.parse.outputs.COMMUNITY_EXTENSION_VCPKG_URL }}
-      COMMUNITY_EXTENSION_VCPKG_COMMIT: ${{ steps.parse.outputs.COMMUNITY_EXTENSION_VCPKG_COMMIT == '' && 'a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6' || steps.parse.outputs.COMMUNITY_EXTENSION_VCPKG_COMMIT }}
+      COMMUNITY_EXTENSION_VCPKG_COMMIT: ${{ steps.parse.outputs.COMMUNITY_EXTENSION_VCPKG_COMMIT == '' && '5e5d0e1cd7785623065e77eff011afdeec1a3574' || steps.parse.outputs.COMMUNITY_EXTENSION_VCPKG_COMMIT }}
     env:
       DUCKDB_LATEST_STABLE: 'v1.2.0'
       DUCKDB_VERSION: ${{ inputs.duckdb_version || 'v1.2.0' }}
@@ -124,7 +124,7 @@ jobs:
       ref: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_REF }}
 
   deploy:
-    needs: 
+    needs:
       - prepare
       - build
     uses: ./.github/workflows/_extension_deploy.yml


### PR DESCRIPTION
If an extension didn't specify a `vcpkg` commit, the default was being used, but the default was not changed to match the default specified in `extension-ci-tools` for 1.2.0.