### PR TITLE
Minor update and fix for `cache_httpfs` extension

### DIFF
--- a/extensions/cache_httpfs/description.yml
+++ b/extensions/cache_httpfs/description.yml
@@ -1,6 +1,6 @@
 extension:
   name: cache_httpfs
-  description: Read cached filesystem for httfs
+  description: Read cached filesystem for httpfs
   version: 0.0.1
   language: C++
   build: cmake


### PR DESCRIPTION
Sorry to the code reviewer, I made two typos in my previous PR.
- The extension folder should be named `cache_httpfs` to better match the extension name
- Fix a small type, which should be `httpfs`

The extension supports duckdb latest v1.2.0, I'm wondering if it's possible to put us on the community extension list?
https://duckdb.org/community_extensions/list_of_extensions.html