### PR TITLE
Updating DuckPGQ for DuckDB v1.2.1

### DIFF
--- a/extensions/duckpgq/description.yml
+++ b/extensions/duckpgq/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duckpgq
   description: Extension that adds support for SQL/PGQ and graph algorithms
-  version: 0.2.2
+  version: 0.2.3
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: cwida/duckpgq-extension
-  ref: ef2409adc75c6df67ef3d457abacc06d84cb9740
+  ref: 947eb8ddc91533d552e91b6d56a2a4a48aed7509
 
 docs:
   hello_world: |


### PR DESCRIPTION
Hi there, 

This PR bumps DuckPGQ to be compatible with DuckDB v1.2.1. 
The GH Actions are running here: https://github.com/cwida/duckpgq-extension/actions/runs/13721502329

## Changelog (ef2409a → 947eb8d)

### 🔧 Fixes & Improvements
- **Fix:** Property not defined after reopening connection [cwida/duckpgq-extension#215](https://github.com/cwida/duckpgq-extension/pull/215)
- **Fix:** Impossible to use tables in another schema than `main` in `CREATE PROPERTY GRAPH` [cwida/duckpgq-extension#211](https://github.com/cwida/duckpgq-extension/pull/214)
- **Fix:** Segmentation fault for `get_csr_v` and `get_csr_e` [cwida/duckpgq-extension#206](https://github.com/cwida/duckpgq-extension/pull/207)
- **Fix:** Star expression binding issue [cwida/duckpgq-extension#193](https://github.com/cwida/duckpgq-extension/pull/193)

### 🔀 Merges
- Merge pull request from `hpvd/main` into `cwida/main` [cwida/duckpgq-extension#212](https://github.com/cwida/duckpgq-extension/pull/212)
- Merge branch `main` into `hjiang/fix-star-expression-bind` (dentiny, 2025-01-25)