### PR TITLE
updated bigquery to v0.2.1

### DIFF
--- a/extensions/bigquery/description.yml
+++ b/extensions/bigquery/description.yml
@@ -5,7 +5,7 @@ extension:
   language: C++
   build: cmake
   license: MIT
-  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64;windows_amd64_rtools;windows_amd64_mingw;osx_amd64;linux_arm64"
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw;osx_amd64;linux_arm64"
   vcpkg_commit: "e01906b2ba7e645a76ee021a19de616edc98d29f"
   requires_toolchains: "parser_tools"
   maintainers:
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: hafenkran/duckdb-bigquery
-  ref: b129dd20f19fa0f9c57497468562456040bb3c33
+  ref: 647348b845c7040b88b08b3a7b2f6a5420be9e49
 
 docs:
   hello_world: |

--- a/extensions/bigquery/description.yml
+++ b/extensions/bigquery/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: bigquery
   description: Integrates DuckDB with Google BigQuery, allowing direct querying and management of BigQuery datasets
-  version: 0.2.0
+  version: 0.2.1
   language: C++
   build: cmake
   license: MIT
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: hafenkran/duckdb-bigquery
-  ref: 94aad3062fbaf2c00aaaef83e5b5a42293637518
+  ref: b129dd20f19fa0f9c57497468562456040bb3c33
 
 docs:
   hello_world: |

--- a/extensions/bigquery/description.yml
+++ b/extensions/bigquery/description.yml
@@ -5,7 +5,7 @@ extension:
   language: C++
   build: cmake
   license: MIT
-  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw;osx_amd64;linux_arm64"
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64;windows_amd64_rtools;windows_amd64_mingw;osx_amd64;linux_arm64"
   vcpkg_commit: "e01906b2ba7e645a76ee021a19de616edc98d29f"
   requires_toolchains: "parser_tools"
   maintainers:


### PR DESCRIPTION
Quick question: Just realized that the BigQuery extension isn't available in the community extension repository. Has the automatic build been disabled? Or were there any problems with the BigQuery extensions?