### PR TITLE
Bump PRQL extension

### DIFF
--- a/extensions/prql/description.yml
+++ b/extensions/prql/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: ywelsch/duckdb-prql
-  ref: 5dedc86da88c35ab219e2e1ba2c54299160484af
+  ref: ed0cd73d02436b33e85ac107f21cb693f18de416
 
 docs:
   hello_world: |


### PR DESCRIPTION
Fixes an issue where corrosion would not find Rust anymore (after Rust toolchain upgrade).