### PR TITLE
Try to use a different .nullvalue

### DIFF
--- a/scripts/generate_md.sh
+++ b/scripts/generate_md.sh
@@ -9,7 +9,7 @@ if [ $# -lt 1 ]; then
     exit 1
 fi
 
-DUCKDB_BINARY="$1 -init /dev/null"
+DUCKDB_BINARY="$1 --nullvalue - --init /dev/null"
 
 curl -s https://community-extensions.duckdb.org/downloads-last-week.json -o build/downloads-last-week.json
 


### PR DESCRIPTION
Maybe @szarnyasg know how to specify an empty nullvalue through strings in bash or in some other way.

Also noted, that `duckdb -help` says:
```
   -nullvalue TEXT      set text string for NULL values. Default ''
```
while current default is `NULL`.

This is likely relevant also in docs generation, whether NULL and empty are not always the same.