### PR TITLE
Update `read_stat` extension to v0.2.1

### DIFF
--- a/extensions/read_stat/description.yml
+++ b/extensions/read_stat/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: read_stat
   description: Read data sets from SAS, Stata, and SPSS with ReadStat
-  version: 0.2.0
+  version: 0.2.1
   language: C
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: mettekou/duckdb-read-stat
-  ref: 4894e6273fb15292990b2651f7fd45cc7f0953b5
+  ref: b25f43fc46835b87dcf5f322a68057a16de2c007
 
 docs:
   hello_world: |


### PR DESCRIPTION
@carlopi I fixed a segmentation fault for `.sas7bdat` files which have columns with a null format.