### PR TITLE
Publish avro in wasm

### DIFF
--- a/extensions/avro/description.yml
+++ b/extensions/avro/description.yml
@@ -5,14 +5,14 @@ extension:
   language: C++
   build: cmake
   license: MIT
-  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw"
+  excluded_platforms: "windows_amd64_rtools;windows_amd64_mingw"
 
   maintainers:
     - hannes
 
 repo:
   github: hannes/duckdb_avro
-  ref: 80fee540409f85fdb9473700bec0d5ca95eb74de
+  ref: ed18629fa56a97e0796a3582110b51ddd125159d
 
 docs:
   hello_world: |


### PR DESCRIPTION
Avro is in the process of being migrated to a core extension.

Starting in 1.2.2, it will be updated there, and NOT be publised in the `community` endpoint anymore.

For 1.2.1 idea is that `core` and `community` both are valid endpoints for avro, and this PR makes so they functionally identical.

This is very minor, and likely the last update for avro as a community extension.