### PR TITLE
Update `read_stat` extension to v0.2.2

### DIFF
--- a/extensions/read_stat/description.yml
+++ b/extensions/read_stat/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: read_stat
   description: Read data sets from SAS, Stata, and SPSS with ReadStat
-  version: 0.2.1
+  version: 0.2.2
   language: C
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: mettekou/duckdb-read-stat
-  ref: b25f43fc46835b87dcf5f322a68057a16de2c007
+  ref: 11f170f350c53bf0c614813b3aebf61841cdec2c
 
 docs:
   hello_world: |


### PR DESCRIPTION
@samansmink @carlopi Updated to use the latest version of ReadStat straight from its GitHub repository, rather than the release which is now 2 years out-of-date.