### PR TITLE
cache httpfs extension release v0.2.1

### DIFF
--- a/extensions/cache_httpfs/description.yml
+++ b/extensions/cache_httpfs/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: dentiny/duck-read-cache-fs
-  ref: 444c29071816322eb4b1c71c06cb59aa4b93fb85
+  ref: 1797a09c5ea2c55ffbdd0a619ee29e1209a7c36a
 
 docs:
   hello_world: |

--- a/extensions/cache_httpfs/description.yml
+++ b/extensions/cache_httpfs/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: dentiny/duck-read-cache-fs
-  ref: eb2d7f34eac8db50386a764c06b33182b2592b09
+  ref: 444c29071816322eb4b1c71c06cb59aa4b93fb85
 
 docs:
   hello_world: |

--- a/extensions/cache_httpfs/description.yml
+++ b/extensions/cache_httpfs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: cache_httpfs
   description: Read cached filesystem for httpfs
-  version: 0.0.1
+  version: 0.2.0
   language: C++
   build: cmake
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: dentiny/duck-read-cache-fs
-  ref: 132620cbe75253eaafdb206c8e538903d7b8f9fb
+  ref: 424343e0d9290246e830474246c76dda102faed2
 
 docs:
   hello_world: |
@@ -20,10 +20,11 @@ docs:
   extended_description: |
     This extension adds a read cache filesystem to DuckDB, which acts as a wrapper of httpfs extention. 
     It supports a few key features:
-    - Supports both metadata cache and data block cache
-    - Supports both on-disk cache and in-memory cache, with block size and cache mode tunable
-    - Supports disk cache file eviction based on access timestamp
-    - Supports parallel IO request, with request size tunable
-    - Supports profiling for IO latency and cache hit / miss ratio, which provides an insight on workload characterization
+    - Applies to all duckdb compatible filesystems, including httpfs and other filesystem extensions (i.e. azure)
+    - Supports both file metadata, glob, file handle and data block cache
+    - Supports both on-disk cache and in-memory cache for data blocks, with block size and cache mode tunable
+    - Supports disk cache file eviction based on access timestamp, allows tunable disk space reservation
+    - Supports parallel IO request, with request size and parallelism tunable
+    - Supports profiling for IO latency and cache hit / miss ratio for a few operations (i.e open, read, glob), which provides an insight on workload characterization
     - Exposes function to get cache size and cleanup cache
     - Provides an option to disable / enable cache, which could act as a drop-in replacement for httpfs

--- a/extensions/cache_httpfs/description.yml
+++ b/extensions/cache_httpfs/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: dentiny/duck-read-cache-fs
-  ref: 424343e0d9290246e830474246c76dda102faed2
+  ref: eb2d7f34eac8db50386a764c06b33182b2592b09
 
 docs:
   hello_world: |

--- a/extensions/cache_httpfs/description.yml
+++ b/extensions/cache_httpfs/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: dentiny/duck-read-cache-fs
-  ref: 1797a09c5ea2c55ffbdd0a619ee29e1209a7c36a
+  ref: 1fa250475e0276fc36c21a0d102432f84578bee5
 
 docs:
   hello_world: |
@@ -20,7 +20,6 @@ docs:
   extended_description: |
     This extension adds a read cache filesystem to DuckDB, which acts as a wrapper of httpfs extention. 
     It supports a few key features:
-    - Applies to all duckdb compatible filesystems, including httpfs and other filesystem extensions (i.e. azure)
     - Supports both file metadata, glob, file handle and data block cache
     - Supports both on-disk cache and in-memory cache for data blocks, with block size and cache mode tunable
     - Supports disk cache file eviction based on access timestamp, allows tunable disk space reservation

--- a/extensions/cache_httpfs/description.yml
+++ b/extensions/cache_httpfs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: cache_httpfs
   description: Read cached filesystem for httpfs
-  version: 0.2.0
+  version: 0.2.1
   language: C++
   build: cmake
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: dentiny/duck-read-cache-fs
-  ref: 1fa250475e0276fc36c21a0d102432f84578bee5
+  ref: 20c4e7539463f1f8244cbd92b3531d8a2b12ccee
 
 docs:
   hello_world: |


### PR DESCRIPTION
Hi we could like to release a new version for `cache_httpfs` extension.
I've written a changelog here: https://github.com/dentiny/duck-read-cache-fs/blob/main/CHANGELOG.md

We've tested [unit tests](https://github.com/dentiny/duck-read-cache-fs/tree/main/unit) and [sql test](https://github.com/dentiny/duck-read-cache-fs/tree/main/test/sql) on both macos and linux platform. 