### PR TITLE
[h3] Bump to include https://github.com/isaacbrodsky/h3-duckdb/pull/146

### DIFF
--- a/extensions/h3/description.yml
+++ b/extensions/h3/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: isaacbrodsky/h3-duckdb
-  ref: 669d8b2bcab8f3cc86dfa3a35606736a4820e397
+  ref: fa144887fb090e0757842c0132d7c4477f65622d
 
 docs:
   hello_world: |


### PR DESCRIPTION
This include also a bump in H3 version and submodule bumps (that should not influence compilation here).

Diff is like: https://github.com/isaacbrodsky/h3-duckdb/compare/669d8b2bcab8f3cc86dfa3a35606736a4820e397..fa144887fb090e0757842c0132d7c4477f65622d

@isaacbrodsky: I sent https://github.com/isaacbrodsky/h3-duckdb/pull/146 and now this since H3 can't compile anymore due to toolchain bump to CMake 4.0.0, does this seems reasonable?