### PR TITLE
Bump to DuckDB v1.2.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,8 +57,8 @@ jobs:
       COMMUNITY_EXTENSION_VCPKG_URL: ${{ steps.parse.outputs.COMMUNITY_EXTENSION_VCPKG_URL == '' && 'https://github.com/microsoft/vcpkg.git' || steps.parse.outputs.COMMUNITY_EXTENSION_VCPKG_URL }}
       COMMUNITY_EXTENSION_VCPKG_COMMIT: ${{ steps.parse.outputs.COMMUNITY_EXTENSION_VCPKG_COMMIT == '' && '5e5d0e1cd7785623065e77eff011afdeec1a3574' || steps.parse.outputs.COMMUNITY_EXTENSION_VCPKG_COMMIT }}
     env:
-      DUCKDB_LATEST_STABLE: 'v1.2.1'
-      DUCKDB_VERSION: ${{ inputs.duckdb_version || 'v1.2.1' }}
+      DUCKDB_LATEST_STABLE: 'v1.2.2'
+      DUCKDB_VERSION: ${{ inputs.duckdb_version || 'v1.2.2' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -89,7 +89,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     if: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_NAME != '' }}
     with:
-      duckdb_version: ${{ inputs.duckdb_version || 'v1.2.1' }}
+      duckdb_version: ${{ inputs.duckdb_version || 'v1.2.2' }}
       duckdb_tag: ${{ inputs.duckdb_tag || '' }}
       ci_tools_version: 'main'
       exclude_archs: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_EXCLUDE_PLATFORMS }}
@@ -132,7 +132,7 @@ jobs:
     secrets: inherit
     with:
       deploy_latest: true
-      duckdb_version: ${{ inputs.duckdb_version || 'v1.2.1' }}
+      duckdb_version: ${{ inputs.duckdb_version || 'v1.2.2' }}
       exclude_archs: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_EXCLUDE_PLATFORMS }}
       extension_name: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_NAME }}
       repository: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_GITHUB }}

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Set up DuckDB
       run: |
-        wget https://github.com/duckdb/duckdb/releases/download/v1.2.1/duckdb_cli-linux-amd64.zip
+        wget https://github.com/duckdb/duckdb/releases/download/v1.2.2/duckdb_cli-linux-amd64.zip
         unzip duckdb_cli-linux-amd64.zip
         chmod +x duckdb
 
@@ -34,7 +34,7 @@ jobs:
     - uses: actions/download-artifact@v4
       if: ${{ inputs.extension_name != '' }}
       with:
-        name: ${{ inputs.extension_name }}-v1.2.1-extension-linux_amd64_gcc4
+        name: ${{ inputs.extension_name }}-v1.2.2-extension-linux_amd64_gcc4
         path: build/downloaded
 
     - name: Install downloaded extension


### PR DESCRIPTION
Bump to latest released duckdb: v1.2.2

For community extensions maintainers: a bunch of extensions have been built in advance, about 30 of them, the one with a green build AND deploy step at https://github.com/duckdb/community-extensions/actions/runs/14311338606.

I am looking into how to generate the relevant list and keep it updated.

After merging this PR I will re-run CI for all missing extensions and ping relevant mainteiners.