### PR TITLE
bump bigquery version v0.3.0

### DIFF
--- a/extensions/bigquery/description.yml
+++ b/extensions/bigquery/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: bigquery
   description: Integrates DuckDB with Google BigQuery, allowing direct querying and management of BigQuery datasets
-  version: 0.2.2
+  version: 0.3.0
   language: C++
   build: cmake
   license: MIT
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: hafenkran/duckdb-bigquery
-  ref: d2e6c8d38c97df6ba69a96e6ebd901e0fb28312e
+  ref: 2def6cec97b9e05149aca0c3a66b838ae47f25b0
 
 docs:
   hello_world: |


### PR DESCRIPTION
Quick Note: One of the vcpkg dependencies for the linux extensions is sometimes a bit flaky when downloading. It might be the case that you need to restart those steps.