### PR TITLE
Update zipfs

### DIFF
--- a/extensions/zipfs/description.yml
+++ b/extensions/zipfs/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: isaacbrodsky/duckdb-zipfs
-  ref: 6d4f61fb15cb1d6b258492631c885887bed4de14
+  ref: 806ef52bfb52cb7c3359d77b96de478e93d2cf1c
 
 docs:
   hello_world: |


### PR DESCRIPTION
* The extension should now trigger extension autoload for file URLs
* It is now possible to configure how the extension splits the zip / file paths
* Updates extension description