### PR TITLE
Upgrade cache httpfs to v0.3.0

### DIFF
--- a/extensions/cache_httpfs/description.yml
+++ b/extensions/cache_httpfs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: cache_httpfs
   description: Read cached filesystem for httpfs
-  version: 0.2.1
+  version: 0.3.0
   language: C++
   build: cmake
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: dentiny/duck-read-cache-fs
-  ref: 20c4e7539463f1f8244cbd92b3531d8a2b12ccee
+  ref: 39bf7bb325d022ceb4f38c41cab43c48e7dc3793
 
 docs:
   hello_world: |


### PR DESCRIPTION
This PR upgrades community extension cache httpfs to v0.3.0
The biggest feature released is filesystem wrapper re-enabled, which allows caching and parallel IO for all duckdb-compatible filesystems.

I have a few other TODO items in mind (will followup when I have more time):
- Check file open info returned from glob, whether we could leverage it as stat cache;
- Check whether we could return file open info for other APIs' return value;
- Check a few github issues on cache effectiveness, toolchain and improvements;
- Check whether to integrate with duckdb native external cache.
