### PR TITLE
fetch_extensions.sh script: handle interrupts

### DIFF
--- a/scripts/fetch_extensions.sh
+++ b/scripts/fetch_extensions.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 
-set -eo pipefail
+set -euo pipefail
+
+trap cleanup SIGINT SIGTERM ERR EXIT
+
+cleanup() {
+    trap - SIGINT SIGTERM ERR EXIT
+    echo "Script interrupted"
+    exit 1
+}
+
 
 if [ $# -lt 1 ]; then
     echo "Usage: ./scripts/fetch_extensions.sh path_to_duckdb_binary"


### PR DESCRIPTION
Previously, interrupting the script with `Ctrl + C` did not work:

```
Installing chsql
^C^C^CMissing chsql
Installing chsql_native
^C^C^CMissing chsql_native
Installing cronjob
^C^C^CMissing cronjob
Installing crypto
^C^C^CMissing crypto
Installing datasketches
^C^C^CMissing datasketches
Installing duckpgq
^C^C^CMissing duckpgq
Installing evalexpr_rhai
^C^C^CMissing evalexpr_rhai
Installing faiss
^C^C^CMissing faiss
```

This PR makes sure the interrupt is trapped and handled properly: quitting the script