### PR TITLE
Update file_dialog

### DIFF
--- a/extensions/file_dialog/description.yml
+++ b/extensions/file_dialog/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: yutannihilation/duckdb-ext-file-dialog
-  ref: d5a59513f4f9788fdc8d736c218771eaad5291c0
+  ref: 98e8a095fa4d37aedac7c96d45af29065ad15569
 
 docs:
   hello_world: |


### PR DESCRIPTION
Update file_dialog extension to let it be built for DuckDB v1.3.0 (just updated extension-ci-tools submodule).