### PR TITLE
Add st_read_multi extension

### DIFF
--- a/extensions/st_read_multi/description.yml
+++ b/extensions/st_read_multi/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: yutannihilation/duckdb-ext-st-read-multi
-  ref: a711e3b8b106b9a71cfba25b6fd9495371c62fb4
+  ref: 4a1f50e91ed4f28cbe67977f549a474cc305b2a0
 
 docs:
   hello_world: |

--- a/extensions/st_read_multi/description.yml
+++ b/extensions/st_read_multi/description.yml
@@ -1,0 +1,23 @@
+extension:
+  name: st_read_multi
+  description: Read multiple geospatial files
+  version: 0.0.1
+  language: Rust
+  build: cargo
+  license: MIT
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;linux_amd64_musl"
+  requires_toolchains: "rust;python3"
+  maintainers:
+    - yutannihilation
+
+repo:
+  github: yutannihilation/duckdb-ext-st-read-multi
+  ref: a711e3b8b106b9a71cfba25b6fd9495371c62fb4
+
+docs:
+  hello_world: |
+    LOAD spatial;
+
+    SELECT * REPLACE (ST_GeomFromWkb(geometry) as geometry) FROM ST_Read_Multi('path/to/*.geojson');
+  extended_description: |
+    Read multiple geospatial files. Currently, only GeoJSON is supported.

--- a/extensions/st_read_multi/docs/function_descriptions.csv
+++ b/extensions/st_read_multi/docs/function_descriptions.csv
@@ -1,0 +1,2 @@
+function,description,comment,example
+"st_read_multi","Read multiple geospatial files. Currently, only GeoJSON is supported.","","FROM ST_Read_Multi('path/to/*.geojson');"


### PR DESCRIPTION
Add an experimental extension st_read_multi, which is a workaround until `ST_Read` supports multiple file input.

```sql
SELECT * REPLACE ST_GeomFromWkb(geometry),
FROM ST_Read_Multi('test/data/*.geojson');
```

```
┌──────────────────────────┬────────┬─────────┐
│ st_geomfromwkb(geometry) │  val1  │  val2   │
│         geometry         │ double │ varchar │
├──────────────────────────┼────────┼─────────┤
│ POINT (1 2)              │    1.0 │ a       │
│ POINT (10 20)            │    2.0 │ b       │
│ POINT (100 200)          │    5.0 │ c       │
│ POINT (111 222)          │    6.0 │ d       │
└──────────────────────────┴────────┴─────────┘
```

Repository: https://github.com/yutannihilation/duckdb-ext-st-read-multi