### PR TITLE
Update st_read_multi extension

### DIFF
--- a/extensions/st_read_multi/description.yml
+++ b/extensions/st_read_multi/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: st_read_multi
   description: Read multiple geospatial files
-  version: 0.0.2
+  version: 0.0.3
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: yutannihilation/duckdb-ext-st-read-multi
-  ref: 3dbc23e9ec09df586a02f6f76c07d6c9f9e5ca0e
+  ref: f773079ede3b75e018682771d4f21cf0ade051c7
 
 docs:
   hello_world: |


### PR DESCRIPTION
Update st_read_multi. This version fixes a crash when importing a large dataset.