### PR TITLE
Add EEA Reference Grid extension

### DIFF
--- a/extensions/eeagrid/description.yml
+++ b/extensions/eeagrid/description.yml
@@ -1,0 +1,53 @@
+extension:
+  name: eeagrid
+  description: Extension that adds support for working with the EEA Reference Grid System.
+  version: 1.3.1
+  language: C++
+  build: cmake
+  license: MIT
+  maintainers:
+    - ahuarte47
+
+repo:
+  github: ahuarte47/duckdb-eeagrid
+  ref: 6d22b0a910012f4ad391d90207673173a1682881
+
+docs:
+  hello_world: |
+    SELECT EEA_CoordXY2GridNum(5078600, 2871400);
+    ----
+    23090257455218688
+
+    SELECT EEA_GridNum2CoordX(23090257455218688);
+    ----
+    5078600
+
+    SELECT EEA_GridNum2CoordY(23090257455218688);
+    ----
+    2871400
+
+    SELECT EEA_GridNumAt100m(23090257455218688);
+    ----
+    23090257455218688
+
+    SELECT EEA_GridNumAt1km(23090257455218688);
+    ----
+    23090257448665088
+
+    SELECT EEA_GridNumAt10km(23090257455218688);
+    ----
+    23090255284404224
+
+  extended_description: |
+    The EEA Reference Grid extension adds support for working with the [EEA Reference Grid System](https://sdi.eea.europa.eu/catalogue/srv/api/records/aac8379a-5c4e-445c-b2ef-23a6a2701ef0/attachments/eea_reference_grid_v1.pdf).
+
+    The **EEA Reference Grid** is a standardized spatial grid system used across Europe for environmental data analysis and reporting. It is maintained by the [European Environment Agency](https://www.eea.europa.eu/en) (EEA) and forms the basis for aggregating and exchanging geospatial data in a consistent format:
+
+      * `Coordinate Reference System (CRS)`: ETRS89 / LAEA Europe ([EPSG:3035](https://epsg.io/3035)), which minimizes area distortion across Europe. The Geodetic Datum is the European Terrestrial Reference System 1989 (EPSG:6258). The Lambert Azimuthal Equal Area (LAEA) projection is centred at 10°E, 52°N. Coordinates are based on a false Easting of 4321000 meters, and a false Northing of 3210000 meters.
+      * `Supported resolutions`: Typically available at 10 km, 1 km, and 100 m resolutions.
+      * `Structure`: Regular square grid with unique cell codes and identifiers assigned based on position and resolution.
+      * `Purpose`: Enables harmonized spatial analysis, mapping, and cross-border environmental assessments.
+
+    This grid system is widely used in European environmental datasets, including air quality, land use, biodiversity, and climate change indicators.
+
+    The extension provides functions to calculate grid cell identifiers (`INT64`) from XY coordinates based on the `EPSG:3035` coordinate reference system, and vice versa. Please see the [function table](docs/functions.md) for the current implementation status.

--- a/extensions/eeagrid/docs/function_descriptions.csv
+++ b/extensions/eeagrid/docs/function_descriptions.csv
@@ -1,0 +1,7 @@
+function,description,comment,example
+EEA_CoordXY2GridNum,"Returns the EEA Reference Grid code to a given XY coordinate (EPSG:3035).","","SELECT EEA_CoordXY2GridNum(5078600, 2871400);"
+EEA_GridNum2CoordX,"Returns the X-coordinate (EPSG:3035) of the grid cell corresponding to a given EEA Reference Grid code.","","SELECT EEA_GridNum2CoordX(23090257455218688);"
+EEA_GridNum2CoordY,"Returns the Y-coordinate (EPSG:3035) of the grid cell corresponding to a given EEA Reference Grid code.","","SELECT EEA_GridNum2CoordY(23090257455218688);"
+EEA_GridNumAt100m,"Returns the Grid code at 100 m resolution given an EEA reference Grid code.","","SELECT EEA_GridNumAt100m(23090257455218688);"
+EEA_GridNumAt10km,"Returns the Grid code at 10 km resolution given an EEA reference Grid code.","","SELECT EEA_GridNumAt10km(23090257455218688);"
+EEA_GridNumAt1km,"Returns the Grid code at 1 km resolution given an EEA reference Grid code.","","SELECT EEA_GridNumAt1km(23090257455218688);"

--- a/extensions/eeagrid/docs/functions.md
+++ b/extensions/eeagrid/docs/functions.md
@@ -1,0 +1,144 @@
+# DuckDB EEA Reference Grid Function Reference
+
+## Function Index 
+**[Scalar Functions](#scalar-functions)**
+
+| Function | Summary |
+| --- | --- |
+| [`EEA_CoordXY2GridNum`](#eea_coordxy2gridnum) | Returns the EEA Reference Grid code to a given XY coordinate (EPSG:3035). |
+| [`EEA_GridNum2CoordX`](#eea_gridnum2coordx) | Returns the X-coordinate (EPSG:3035) of the grid cell corresponding to a given EEA Reference Grid code. |
+| [`EEA_GridNum2CoordY`](#eea_gridnum2coordy) | Returns the Y-coordinate (EPSG:3035) of the grid cell corresponding to a given EEA Reference Grid code. |
+| [`EEA_GridNumAt100m`](#eea_gridnumat100m) | Returns the Grid code at 100 m resolution given an EEA reference Grid code. |
+| [`EEA_GridNumAt10km`](#eea_gridnumat10km) | Returns the Grid code at 10 km resolution given an EEA reference Grid code. |
+| [`EEA_GridNumAt1km`](#eea_gridnumat1km) | Returns the Grid code at 1 km resolution given an EEA reference Grid code. |
+
+----
+
+## Scalar Functions
+
+### EEA_CoordXY2GridNum
+
+
+#### Signature
+
+```sql
+BIGINT EEA_CoordXY2GridNum (col0 BIGINT, col1 BIGINT)
+```
+
+#### Description
+
+Returns the EEA Reference Grid code to a given XY coordinate (EPSG:3035).
+
+#### Example
+
+```sql
+SELECT CoordXY2GridNum(5078600, 2871400); -> 23090257455218688
+```
+
+----
+
+### EEA_GridNum2CoordX
+
+
+#### Signature
+
+```sql
+BIGINT EEA_GridNum2CoordX (col0 BIGINT)
+```
+
+#### Description
+
+Returns the X-coordinate (EPSG:3035) of the grid cell corresponding to a given EEA Reference Grid code.
+
+#### Example
+
+```sql
+SELECT EEA_GridNum2CoordX(23090257455218688); -> 5078600
+```
+
+----
+
+### EEA_GridNum2CoordY
+
+
+#### Signature
+
+```sql
+BIGINT EEA_GridNum2CoordY (col0 BIGINT)
+```
+
+#### Description
+
+Returns the Y-coordinate (EPSG:3035) of the grid cell corresponding to a given EEA Reference Grid code.
+
+#### Example
+
+```sql
+SELECT EEA_GridNum2CoordY(23090257455218688); -> 2871400
+```
+
+----
+
+### EEA_GridNumAt100m
+
+
+#### Signature
+
+```sql
+BIGINT EEA_GridNumAt100m (col0 BIGINT)
+```
+
+#### Description
+
+Returns the Grid code at 100 m resolution given an EEA reference Grid code.
+
+#### Example
+
+```sql
+SELECT EEA_GridNumAt100m(23090257455218688); -> 23090257455218688
+```
+
+----
+
+### EEA_GridNumAt10km
+
+
+#### Signature
+
+```sql
+BIGINT EEA_GridNumAt10km (col0 BIGINT)
+```
+
+#### Description
+
+Returns the Grid code at 10 km resolution given an EEA reference Grid code.
+
+#### Example
+
+```sql
+SELECT EEA_GridNumAt10km(23090257455218688); -> 23090255284404224
+```
+
+----
+
+### EEA_GridNumAt1km
+
+
+#### Signature
+
+```sql
+BIGINT EEA_GridNumAt1km (col0 BIGINT)
+```
+
+#### Description
+
+Returns the Grid code at 1 km resolution given an EEA reference Grid code.
+
+#### Example
+
+```sql
+SELECT EEA_GridNumAt1km(23090257455218688); -> 23090257448665088
+```
+
+----
+


### PR DESCRIPTION
This is an extension for DuckDB that adds support for working with the [EEA Reference Grid System](https://sdi.eea.europa.eu/catalogue/srv/api/records/aac8379a-5c4e-445c-b2ef-23a6a2701ef0/attachments/eea_reference_grid_v1.pdf).

The EEA Reference Grid is a standardized spatial grid system used across Europe for environmental data analysis and reporting. It is maintained by the [European Environment Agency](https://www.eea.europa.eu/en) (EEA) and forms the basis for aggregating and exchanging geospatial data in a consistent format.