### PR TITLE
bump bigquery v0.4.0

### DIFF
--- a/extensions/bigquery/description.yml
+++ b/extensions/bigquery/description.yml
@@ -6,7 +6,7 @@ extension:
   build: cmake
   license: MIT
   excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw;osx_amd64;linux_arm64"
-  vcpkg_commit: "e01906b2ba7e645a76ee021a19de616edc98d29f"
+  vcpkg_commit: "ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0"
   requires_toolchains: "parser_tools"
   maintainers:
     - hafenkran

--- a/extensions/bigquery/description.yml
+++ b/extensions/bigquery/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: bigquery
   description: Integrates DuckDB with Google BigQuery, allowing direct querying and management of BigQuery datasets
-  version: 0.3.1
+  version: 0.4.0
   language: C++
   build: cmake
   license: MIT
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: hafenkran/duckdb-bigquery
-  ref: a9e8440a573b20838a545a41fab6f74737da26c2
+  ref: 3298146b9f6ac4ba86556b9d9dd9935e94498c01
 
 docs:
   hello_world: |

--- a/extensions/bigquery/docs/function_descriptions.csv
+++ b/extensions/bigquery/docs/function_descriptions.csv
@@ -1,6 +1,7 @@
 function,description,comment,example
 bigquery_attach,"Attach to a BigQuery project.","","ATTACH 'project=my_gcp_project' as bq (TYPE bigquery);"
 bigquery_scan,"Scan a single table directly from BigQuery.",,"SELECT * FROM bigquery_scan('my_gcp_project.quacking_dataset.duck_tbl');"
+bigquery_arrow_scan,"Scan a single table directly from BigQuery (more efficient reimplementation).","","SELECT * FROM bigquery_arrow_scan('my_gcp_project.quacking_dataset.duck_tbl');"
 bigquery_query,"Run a custom GoogleSQL query in BigQuery and read the results.",,"SELECT * FROM bigquery_query('bq', 'SELECT * FROM quacking_dataset.duck_tbl WHERE duck_id = 123');"
 bigquery_execute,"Execute an arbitrary GoogleSQL query in BigQuery.",,"CALL bigquery_execute('bq', 'CREATE SCHEMA deluxe_dataset OPTIONS(location=""us"", default_table_expiration_days=3.75);')"
 bigquery_jobs,"List jobs in a BigQuery project.","","SELECT * FROM bigquery_jobs('bq');"


### PR DESCRIPTION
This MR also contains adjustments to fix the Windows build (i.e., `windows-latest`) and support for DuckDB v1.3.1.

**Quick Heads-up**: vcpkg’s dependency downloads on the CI are pretty flaky right now. If the process fails, simply rerun these step.

Thanks a lot!