### PR TITLE
Upgrade cache-httpfs to duckdb v1.3.1

### DIFF
--- a/extensions/cache_httpfs/description.yml
+++ b/extensions/cache_httpfs/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: dentiny/duck-read-cache-fs
-  ref: 39bf7bb325d022ceb4f38c41cab43c48e7dc3793
+  ref: da79b5e6f3799abebbacf981a02cb91cb8feeaa9
 
 docs:
   hello_world: |


### PR DESCRIPTION
Regular upgrade duckdb to v1.3.1 to keep up-to-date.