### PR TITLE
Update file_dialog and st_read_multi

### DIFF
--- a/extensions/file_dialog/description.yml
+++ b/extensions/file_dialog/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: yutannihilation/duckdb-ext-file-dialog
-  ref: 98e8a095fa4d37aedac7c96d45af29065ad15569
+  ref: 51df4969343b3a01925b08e1f68cb733dda97cdc
 
 docs:
   hello_world: |

--- a/extensions/st_read_multi/description.yml
+++ b/extensions/st_read_multi/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: yutannihilation/duckdb-ext-st-read-multi
-  ref: f773079ede3b75e018682771d4f21cf0ade051c7
+  ref: 20d2edc051ad378f823274f386837ec211fe8f28
 
 docs:
   hello_world: |


### PR DESCRIPTION
Update file_dialog extension and st_read_multi extension.

While duckdb-rs v1.3.1 is not out yet, I believe my extensions doesn't require the updated source because there are no API changes related to the extension API. I quickly confirmed this can be loaded on DuckDB v1.3.1 on my local.