### PR TITLE
Add QuickJS Extension v0.0.1

### DIFF
--- a/extensions/quickjs/description.yml
+++ b/extensions/quickjs/description.yml
@@ -5,6 +5,7 @@ extension:
   language: C++
   build: cmake
   license: MIT
+  excluded_platforms: "windows_amd64_mingw"
   maintainers:
     - lmangani
 

--- a/extensions/quickjs/description.yml
+++ b/extensions/quickjs/description.yml
@@ -1,0 +1,53 @@
+extension:
+  name: quickjs
+  description: DuckDB QuickJS Runtime Extension
+  version: 0.0.1
+  language: C++
+  build: cmake
+  license: MIT
+  maintainers:
+    - lmangani
+
+repo:
+  github: quackscience/duckdb-quickjs
+  ref: 869bf9d0f21262cee77f39745f9b93a22c6ac6ab
+
+docs:
+  hello_world: |
+    -- Scalar
+    D SELECT quickjs('2+2');
+    ┌────────────────┐
+    │ quickjs('2+2') │
+    │    varchar     │
+    ├────────────────┤
+    │ 4              │
+    └────────────────┘
+    
+    -- Scalar Eval
+    D SELECT quickjs_eval('(a, b) => a + b', 5, 3);
+    ┌───────────────────────────────────────┐
+    │ quickjs_eval('(a, b) => a + b', 5, 3) │
+    │                 json                  │
+    ├───────────────────────────────────────┤
+    │ 8                                     │
+    └───────────────────────────────────────┘
+
+    -- Table Eval
+    D SELECT * FROM quickjs('[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].filter(x => x % 2 === 0)');
+    ┌────────┐
+    │ result │
+    │  json  │
+    ├────────┤
+    │ 2      │
+    │ 4      │
+    │ 6      │
+    │ 8      │
+    │ 10     │
+    └────────┘
+
+  extended_description: |
+    ## QuickJS DuckDB Extension
+    This extension provides an embedded QuickJS engine for DuckDB. It allows you to execute JavaScript code directly within your SQL queries. 
+    > QuickJS is a small, fast, and embeddable JavaScript engine that supports modern JavaScript features including ES2020.
+    
+    This extension is experimental and potentially unstable. Do not use it in production.

--- a/extensions/quickjs/description.yml
+++ b/extensions/quickjs/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: quackscience/duckdb-quickjs
-  ref: 66b28ca6c9037fdc1ed3daac979448a9dcf39e34
+  ref: 393d79ef3c552d7420c661fa2167a0da25610470
 
 docs:
   hello_world: |

--- a/extensions/quickjs/description.yml
+++ b/extensions/quickjs/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: quackscience/duckdb-quickjs
-  ref: 869bf9d0f21262cee77f39745f9b93a22c6ac6ab
+  ref: 66b28ca6c9037fdc1ed3daac979448a9dcf39e34
 
 docs:
   hello_world: |

--- a/extensions/quickjs/description.yml
+++ b/extensions/quickjs/description.yml
@@ -10,10 +10,11 @@ extension:
 
 repo:
   github: quackscience/duckdb-quickjs
-  ref: 393d79ef3c552d7420c661fa2167a0da25610470
+  ref: 83906e2486de7823b10aabcca931533feadfe23c
 
 docs:
   hello_world: |
+    -- Quack JS with QuickJS
     -- Scalar
     D SELECT quickjs('2+2');
     ┌────────────────┐
@@ -33,21 +34,21 @@ docs:
     └───────────────────────────────────────┘
 
     -- Table Eval
-    D SELECT * FROM quickjs('[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].filter(x => x % 2 === 0)');
+    D SELECT * FROM quickjs('parsed_arg0.map(x => x * arg1)', '[1, 2, 3, 4, 5]', 3);
     ┌────────┐
     │ result │
     │  json  │
     ├────────┤
-    │ 2      │
-    │ 4      │
+    │ 3      │
     │ 6      │
-    │ 8      │
-    │ 10     │
+    │ 9      │
+    │ 12     │
+    │ 15     │
     └────────┘
 
   extended_description: |
     ## QuickJS DuckDB Extension
-    This extension provides an embedded QuickJS engine for DuckDB. It allows you to execute JavaScript code directly within your SQL queries. 
-    > QuickJS is a small, fast, and embeddable JavaScript engine that supports modern JavaScript features including ES2020.
+    This extension provides an embedded QuickJS-NG engine for DuckDB. It allows executing JavaScript code directly within your SQL queries. 
+    > QuickJS-NG is a small, fast, and embeddable JavaScript engine that supports modern JavaScript features including ES2020.
     
     This extension is experimental and potentially unstable. Do not use it in production.


### PR DESCRIPTION
Useless but fun: A tiny QuickJS Runtime inside a DuckDB Extension. 

PR to check if builder passes all platforms. 