### PR TITLE
Bump faiss

### DIFF
--- a/extensions/faiss/description.yml
+++ b/extensions/faiss/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: faiss
   description: Provides access to faiss indices from DuckDB.
-  version: 0.10.0
+  version: 0.11.0
   language: C++
   build: cmake
   license: MIT
@@ -15,7 +15,7 @@ extension:
 
 repo:
   github: duckdb-faiss-ext/duckdb-faiss-ext
-  ref: b0ac9446787bf0983d2f0fbdaf1e633b3b589830
+  ref: 065f69843f43e8b1274ee58c598e66083aad6847
 
 docs:
   hello_world: |
@@ -26,6 +26,8 @@ docs:
     -- Create the index and insert data into it
     CALL FAISS_CREATE('name', 5, 'IDMap,HNSW32');
     CALL FAISS_ADD((SELECT id, data FROM input), 'name');
+    -- On linux, with cuda, we can move the index to the GPU
+    -- CALL FAISS_TO_GPU('name', 0);
     -- Get 10 results with uneven id
     SELECT id, UNNEST(FAISS_SEARCH_FILTER('name', 10, data, 'id%2==1', 'rowid', 'input')) FROM queries;
     -- Get 10 results with even id


### PR DESCRIPTION
This updates faiss to support 1.3.1.

I don't think I was tagged this time, but the extension wasn't available so I updated it to work with 1.3.1.

P.S.
I like that the `_gcc4`  was "removed", this makes a lot of sense as it is now!