### PR TITLE
add lua extension

### DIFF
--- a/extensions/lua/description.yml
+++ b/extensions/lua/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: isaacbrodsky/duckdb-lua
-  ref: 06c32cfe02d2590e4f061cfc5b468dad4c1ab542
+  ref: f37579669ddc8ba23fb3a9c0123dd448c72f0bf4
 
 docs:
   hello_world: |


### PR DESCRIPTION
Not sure this makes sense to merge until DuckDB 1.4.0 is released, as the extension is only compatible with that version. But I guess that's what ref_next is for?