### PR TITLE
Upgrade cache httpfs extension to 0.4.0

### DIFF
--- a/extensions/cache_httpfs/description.yml
+++ b/extensions/cache_httpfs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: cache_httpfs
   description: Read cached filesystem for httpfs
-  version: 0.3.0
+  version: 0.4.0
   language: C++
   build: cmake
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: dentiny/duck-read-cache-fs
-  ref: da79b5e6f3799abebbacf981a02cb91cb8feeaa9
+  ref: 555ff7828fae1817de5324886470ddcb391adf11
 
 docs:
   hello_world: |


### PR DESCRIPTION
This upgrade contains two main changes:
- Regular upgrade duckdb to v1.3.2 to keep up-to-stream
- Resolve compatibility issue with duckdb internal "external file cache", which leads to double caching.
  + For details, please refer to https://github.com/dentiny/duck-read-cache-fs/pull/210