### PR TITLE
Update splink_udfs to 0.0.2

### DIFF
--- a/extensions/splink_udfs/description.yml
+++ b/extensions/splink_udfs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: splink_udfs
-  description: Record linkage functions for use in Splink
-  version: 0.0.1
+  description: Phonetic and text normalization functions for record linkage.
+  version: 0.0.2
   language: C++
   build: cmake
   license: MIT
@@ -10,14 +10,14 @@ extension:
 
 repo:
   github: moj-analytical-services/splink_udfs
-  ref: 08cc43c05af5cfeaa885f4fcad2da335e2e3856f
+  ref: 6e4ccbe4d0a92d134fc16ef19503a20663299d75
 
 docs:
   hello_world: |
     LOAD splink_udfs;
-    SELECT soundex('Robert');  -- returns 'R163'
+    SELECT soundex(unaccent('Jürgen'));  -- returns 'J625'
   extended_description: |
-    The initial version of the splink_udfs extension provides
-    a scalar function `soundex(VARCHAR) → VARCHAR` implementing
-    the Soundex phonetic algorithm. Other record linkage-related
-    functions will be added to this extension as it develops.
+    The splink_udfs extension provides functions for data cleaning and phonetic matching.
+
+    Includes `soundex(str)`, `strip_diacritics(str)`, and `unaccent(str)`. For best
+    results, it is recommended to combine them, e.g. `soundex(unaccent(str))`.


### PR DESCRIPTION
I have added two more functions to this extension.

I note that the builds all passed on https://github.com/moj-analytical-services/splink_udfs/pull/4 see [here](https://github.com/moj-analytical-services/splink_udfs/actions/runs/16368072181)

but that the 'Tidy check' failed.  I've done a bit of research that suggests this isn't a problem, but I'm not very experienced with c++, so I'm not sure.

If this is a problem I'd appreciate any tips/pointers on what I'm doing wrong.  I had quite a few issues getting `CMakeLists.txt` correct with the new `utf8proc` dependency, so this is the most likely cause of the issue.  

Everything works locally on my macbook (M4).

Thank you!