### PR TITLE
Update duckpgq to DuckDB v1.3.2

### DIFF
--- a/extensions/duckpgq/description.yml
+++ b/extensions/duckpgq/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duckpgq
   description: Extension that adds support for SQL/PGQ and graph algorithms
-  version: 0.2.4
+  version: 0.2.5
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: cwida/duckpgq-extension
-  ref: 97a0c6532192c6ebf84733589e78bf8238b08b4b 
+  ref: 942455f5e99c2ed9caa1b654785e87ef7aa82949
 
 docs:
   hello_world: |


### PR DESCRIPTION
Makes DuckPGQ available again as a community extension for DuckDB v1.3.2. 

