### PR TITLE
Upgrade cache httpfs to 0.6.0

### DIFF
--- a/extensions/cache_httpfs/description.yml
+++ b/extensions/cache_httpfs/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: dentiny/duck-read-cache-fs
-  ref: 5f3930cd66edee8756b9069c2e749fc6079f2f85
+  ref: 2f2709cbcf594029559aba69706b31b70d6578aa
 
 docs:
   hello_world: |


### PR DESCRIPTION
Upgrade cache httpfs to v0.6.0, changelog see https://github.com/dentiny/duck-read-cache-fs/blob/main/CHANGELOG.md#060

The biggest change is to provide observability for cache miss count by in-use exclusive resource.