### PR TITLE
Update splink_udfs:  wasm now works

### DIFF
--- a/extensions/splink_udfs/description.yml
+++ b/extensions/splink_udfs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: splink_udfs
   description: Phonetic, text normalization and fuzzy matching functions for record linkage.
-  version: 0.0.5
+  version: 0.0.6
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: moj-analytical-services/splink_udfs
-  ref: cb048a1cdb5bf85d1c7db032e7bdaba3fc5876ac
+  ref: b30d5548824af3b2f8f474febde9aca646cc3de9
 
 docs:
   hello_world: |


### PR DESCRIPTION
`splink_udfs` now works in wasm.  Previously was getting `table index out of bounds` error.

I've written some notes on how I got this going here which may be useful if others users run into the same issue:
https://github.com/moj-analytical-services/splink_udfs/pull/16#issuecomment-3178385181

Thank you!