### PR TITLE
Migrate httpserver to query.farm

### DIFF
--- a/extensions/httpserver/description.yml
+++ b/extensions/httpserver/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: httpserver
   description: DuckDB HTTP API Server Extension
-  version: 0.1.8
+  version: 0.1.9
   language: SQL & C++
   build: cmake
   license: MIT
@@ -11,10 +11,11 @@ extension:
     - akvlad
     - niclashaderer
     - gropaul
+    - rustyconover
 
 repo:
-  github: quackscience/duckdb-extension-httpserver
-  ref: db20da882e68941e1edb9927d1596a9024df23cc
+  github: Query-farm/duckdb-extension-httpserver
+  ref: 5ec9292017d03348cf4e91eb2f9cf23c9719a891
 
 docs:
   hello_world: |
@@ -66,3 +67,5 @@ docs:
     - _100% Opensource, ready to use and extend by the Community!_
   
     > This extension is experimental and potentially unstable. Use at your own risk.
+
+    > This DuckDB extension was created by Query.Farm, where we develop and maintain many extensions that expand DuckDB’s capabilities by connecting it to new data sources, formats, and features.


### PR DESCRIPTION
First of many! PR lurkers hear it first - we're migrating all quackscience > query.farm and joining forces on our community extensions with @rustyconover