### PR TITLE
feat: add rusty_sheet extension

### DIFF
--- a/extensions/rusty_sheet/description.yml
+++ b/extensions/rusty_sheet/description.yml
@@ -1,0 +1,44 @@
+extension:
+  name: rusty_sheet
+  description: An Excel/OpenDocument Spreadsheets file reader for DuckDB
+  version: 0.1.0
+  language: Rust
+  build: cargo
+  license: MIT
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw;linux_amd64_musl"
+  requires_toolchains: "rust;python3"
+  maintainers:
+    - redraiment
+
+repo:
+  github: redraiment/rusty-sheet
+  ref: 3cc700798071238763b9dc84ed0d16b42ab1e57d
+
+docs:
+  hello_world: |
+    -- Read entire spreadsheet with headers
+    FROM read_sheet('data.xlsx');
+    
+    -- Read specific worksheet
+    FROM read_sheet('workbook.xlsx', sheet_name='Sheet2');
+    
+    -- Override specific column types (others auto-detected)
+    FROM read_sheet('data.xlsx',
+      columns={'id': 'bigint'}
+    );
+    
+    -- Read specific data range (Excel-style notation)
+    FROM read_sheet('data.xlsx', range='A2:E100');
+    
+    -- Read without headers
+    FROM read_sheet('data.xlsx',
+      header=false,
+      columns={'column1': 'varchar', 'column2': 'bigint'}
+    );
+    
+    -- Analyze column types
+    FROM analyze_sheet('data.xlsx', analyze_rows=20);
+
+  extended_description: |
+    The DuckDB rusty-sheet extension that enables reading Excel and OpenDocument spreadsheet files directly within SQL queries. This extension provides seamless integration for analyzing spreadsheet data using DuckDB's powerful SQL engine.
+    For detailed setup and usage instructions, visit the docs at [rusty-sheet](https://github.com/redraiment/rusty-sheet).

--- a/extensions/rusty_sheet/docs/function_description.csv
+++ b/extensions/rusty_sheet/docs/function_description.csv
@@ -1,0 +1,3 @@
+function,description,comment,example
+read_sheet,"Read spreadsheet data and make it available for SQL queries in DuckDB.",,"FROM read_sheet('data.xlsx');"
+analyze_sheet,"Analyze spreadsheet files and return column type information.",,"FROM analyze_sheet('data.xlsx', analyze_rows=20);"


### PR DESCRIPTION
A DuckDB extension that enables reading Excel and OpenDocument spreadsheet files directly within SQL queries. This extension provides seamless integration for analyzing spreadsheet data using DuckDB's powerful SQL engine.

* High Performance: Optimized for large files; e.g., reading a 1M-row XLSX file on MacBook M1 now takes under 13 seconds (down from 140+ seconds).
* Multiple Format Support: Read Excel files (.xls, .xlsx, .xlsm, .xlsb, .xla, .xlam) and OpenDocument Spreadsheet files (.ods)
* Flexible Data Types: Support for boolean, integer, double, varchar, datetime, date, time, and interval (ISO 8601 duration) types
* Excel-Style Data Ranges: Specify data ranges using familiar Excel notation (e.g., "A1:C3")
* Automatic Column Type Detection: Column types are inferred automatically; override specific columns with the columns parameter
* Header Row Handling: Automatic detection and parsing of header rows
* Error Handling: Configurable behavior for parsing errors with precise cell location reporting
* Type Safety: Built-in data type validation and conversion
* Pure Rust Implementation: No C++ dependencies, leveraging Rust's memory safety