### PR TITLE
Update rusty_quack extension

### DIFF
--- a/extensions/rusty_quack/description.yml
+++ b/extensions/rusty_quack/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: duckdb/extension-template-rs
-  ref: ecd8397290ce9f788dc9b6e81d8bb54ce03a32bb
+  ref: 3dd3adbeb84f617ebc44619d8b1a8fe6416fd214
 
 docs:
   hello_world: |

--- a/extensions/rusty_quack/description.yml
+++ b/extensions/rusty_quack/description.yml
@@ -9,6 +9,7 @@ extension:
   requires_toolchains: "rust;python3"
   maintainers:
     - samansmink
+    - mlafeldt
 
 repo:
   github: duckdb/extension-template-rs


### PR DESCRIPTION
To include https://github.com/duckdb/extension-ci-tools/pull/252 which was added in https://github.com/duckdb/extension-template-rs/pull/29