### PR TITLE
Patch release cache-httpfs v0.6.1

### DIFF
--- a/extensions/cache_httpfs/description.yml
+++ b/extensions/cache_httpfs/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: dentiny/duck-read-cache-fs
-  ref: 2f2709cbcf594029559aba69706b31b70d6578aa
+  ref: 04bd8cfafa0149c8628da7dfd2f90a29b0b62bf1
 
 docs:
   hello_world: |


### PR DESCRIPTION
Release a patch version to fix segfault, see PR for details: https://github.com/dentiny/duck-read-cache-fs/pull/240