### PR TITLE
Bump Quack extension for v1.4.0 

### DIFF
--- a/extensions/quack/description.yml
+++ b/extensions/quack/description.yml
@@ -18,6 +18,7 @@ extension:
 repo:
   github: duckdb/extension-template
   ref: c7d9ef3463376dc2b64959abf3a477eae2280142
+  ref_next: e52f46eeca9157124cbc910f52ea8637c95084a1
 
 docs:
   hello_world: |


### PR DESCRIPTION
This PR prepares the quack extension for the v1.4.0 release. The quack extension is based on the [extension template](https://github.com/duckdb/extension-template) and therefore serves as an example for other devs to follow best practices.

See the https://github.com/duckdb/community-extensions/blob/main/UPDATING.md for more details