### PR TITLE
Add snowflake extension

### DIFF
--- a/extensions/snowflake/description.yml
+++ b/extensions/snowflake/description.yml
@@ -10,7 +10,8 @@ extension:
 
 repo:
   github: iqea-ai/duckdb-snowflake
-  ref: 6b80fdc34cd3715a8c6167dfac2f662001351e60
+  ref: 82a1fac62130046eda51dc75e9e9abdf89e956f5
+  ref_next: eaa953343f5cc0d1e53704b751fea5e70f556bf4
 
 docs:
   hello_world: |


### PR DESCRIPTION
- Adds the DuckDB Snowflake extension to the community extensions repository.

- The extension integrates DuckDB with Snowflake using Arrow ADBC drivers, providing both table functions (snowflake_scan) and storage extension capabilities (ATTACH).

- Extension details and usage examples are included in the description.yml file.