### PR TITLE
Add mooncake extension

### DIFF
--- a/extensions/mooncake/description.yml
+++ b/extensions/mooncake/description.yml
@@ -1,0 +1,22 @@
+extension:
+  name: mooncake
+  description: Read Iceberg tables written by moonlink in real time
+  version: 0.0.1
+  language: C++
+  build: cmake
+  license: MIT
+  maintainers:
+    - dpxcc
+  excluded_platforms: windows_amd64;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads
+  requires_toolchains: rust
+
+repo:
+  github: Mooncake-Labs/duckdb_mooncake
+  ref: 44a4dc49b3b0fa677955f7427232d98736d48115
+
+docs:
+  hello_world: |
+    ATTACH DATABASE 'mooncake' (TYPE mooncake, URI '/var/lib/postgresql/data/pg_mooncake/moonlink.sock', DATABASE 'postgres');
+    SELECT * FROM mooncake.public.c;
+  extended_description: |
+    For more information regarding usage, see [README.md](https://github.com/Mooncake-Labs/duckdb_mooncake/blob/v0.0.1/README.md).


### PR DESCRIPTION
Add mooncake extension to community extensions repository
This extension allows reading Iceberg tables written by [moonlink](https://github.com/Mooncake-Labs/moonlink) in real time
It works with both standalone DuckDB and embedded DuckDB in Postgres ([pg_duckdb](https://github.com/duckdb/pg_duckdb)) via [pg_mooncake](https://github.com/Mooncake-Labs/pg_mooncake)