### PR TITLE
Update Snowflake extension refs and add ADBC driver documentation

### DIFF
--- a/extensions/snowflake/description.yml
+++ b/extensions/snowflake/description.yml
@@ -10,8 +10,8 @@ extension:
 
 repo:
   github: iqea-ai/duckdb-snowflake
-  ref: 82a1fac62130046eda51dc75e9e9abdf89e956f5
-  ref_next: eaa953343f5cc0d1e53704b751fea5e70f556bf4
+  ref: 0e0520ca2d54b071922594d8cc9ea56174fb37d2
+  ref_next: c3196bfc034ad7e5390ace326e9df6de1431523d
 
 docs:
   hello_world: |

--- a/extensions/snowflake/description.yml
+++ b/extensions/snowflake/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: iqea-ai/duckdb-snowflake
-  ref: 109fdfdbb94fc4108381a69a00a8292124ee083a
+  ref: 75ab20e7349beaff184fcd3f98efbd90bcd7d812
   ref_next: 75ab20e7349beaff184fcd3f98efbd90bcd7d812
 
 install_notes: |

--- a/extensions/snowflake/description.yml
+++ b/extensions/snowflake/description.yml
@@ -10,8 +10,8 @@ extension:
 
 repo:
   github: iqea-ai/duckdb-snowflake
-  ref: 9f5f5495c97419432795695c228b9feb424acf23
-  ref_next: c6816276ccd58ef860bf0b5d0c97a7174f6c5369
+  ref: 109fdfdbb94fc4108381a69a00a8292124ee083a
+  ref_next: 75ab20e7349beaff184fcd3f98efbd90bcd7d812
 
 install_notes: |
   **Important:** This extension requires the Apache Arrow ADBC Snowflake driver to function properly.

--- a/extensions/snowflake/description.yml
+++ b/extensions/snowflake/description.yml
@@ -10,8 +10,21 @@ extension:
 
 repo:
   github: iqea-ai/duckdb-snowflake
-  ref: 0e0520ca2d54b071922594d8cc9ea56174fb37d2
-  ref_next: c3196bfc034ad7e5390ace326e9df6de1431523d
+  ref: 9f5f5495c97419432795695c228b9feb424acf23
+  ref_next: c6816276ccd58ef860bf0b5d0c97a7174f6c5369
+
+install_notes: |
+  **Important:** This extension requires the Apache Arrow ADBC Snowflake driver to function properly.
+  
+  The driver is not included in the extension package and must be downloaded and installed separately.
+  
+  For complete installation instructions including platform-specific driver setup, please refer to:
+  https://github.com/iqea-ai/duckdb-snowflake#adbc-driver-setup
+  
+  Quick reference for driver placement:
+  - Linux: ~/.duckdb/extensions/v1.3.2/linux_amd64/
+  - macOS: ~/.duckdb/extensions/v1.3.2/osx_arm64/ (or osx_amd64)
+  - Windows: C:\Users\<username>\.duckdb\extensions\v1.3.2\windows_amd64\
 
 docs:
   hello_world: |
@@ -41,4 +54,7 @@ docs:
 
   extended_description: |
     This community-maintained extension allows DuckDB to connect to Snowflake using Arrow ADBC drivers. 
+    It provides both pass-through querying and direct database attachment capabilities for seamless Snowflake integration.
+    
+    **Prerequisites:** The Apache Arrow ADBC Snowflake driver must be installed separately before using this extension.
     For detailed setup and usage instructions, visit the [extension repository](https://github.com/iqea-ai/duckdb-snowflake).


### PR DESCRIPTION
**Changes:**
This PR updates the Snowflake DuckDB extension to use newer commits for stable (ref) and next (ref_next) DuckDB versions and adds documentation on obtaining the Snowflake ADBC drivers.
**Commit updates:**
`ref` → `0e0520c` (was `82a1fac`)
`ref_next` → `c3196bf` (was `eaa9533`)
Ensures stable and next DuckDB builds use the latest tested extension code.
**Documentation:**
Adds instructions for downloading and configuring Snowflake ADBC drivers for new users.
No functional changes to the extension; improves usability and build reliability.