### PR TITLE
bump bq extension to v0.5.0

### DIFF
--- a/extensions/bigquery/description.yml
+++ b/extensions/bigquery/description.yml
@@ -1,11 +1,11 @@
 extension:
   name: bigquery
   description: Integrates DuckDB with Google BigQuery, allowing direct querying and management of BigQuery datasets
-  version: 0.4.2
+  version: 0.5.0
   language: C++
   build: cmake
   license: MIT
-  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw;osx_amd64;linux_arm64"
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw"
   vcpkg_commit: "ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0"
   requires_toolchains: "parser_tools"
   maintainers:
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: hafenkran/duckdb-bigquery
-  ref: 10882a382d45f941d9672c5030fab22e34660792
+  ref: 621dbb517c11d82c0d7693c362591d156ab3da0c
 
 docs:
   hello_world: |


### PR DESCRIPTION
This PR also enables the `osx_amd64` and `linux_arm64` for the extension.