### PR TITLE
Create observefs extension

### DIFF
--- a/extensions/observefs/description.yml
+++ b/extensions/observefs/description.yml
@@ -1,0 +1,24 @@
+extension:
+  name: observefs
+  description: Provides IO observability to filesystem
+  version: 0.0.1
+  language: C++
+  build: cmake
+  license: MIT
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;windows_amd64_mingw"
+  maintainers:
+    - dentiny
+
+repo:
+  github: dentiny/duckdb-filesystem-observability
+  ref: b99ce0f19b35b79ab17ed197836ff0af8cdb38ca
+
+docs:
+  hello_world: |
+    COPY (SELECT observefs_get_profile()) TO '/tmp/output.txt';
+  extended_description: |
+    This extension provides observability to duckdb filesystems.
+    It supports a few key features:
+    - 100% compatible with duckdb httpfs
+    - Provides both process-wise and bucket-wise latency stats
+    - Allows registering ANY duckdb compatible filesystems (i.e., azure filesystem)

--- a/extensions/observefs/description.yml
+++ b/extensions/observefs/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: dentiny/duckdb-filesystem-observability
-  ref: b99ce0f19b35b79ab17ed197836ff0af8cdb38ca
+  ref: fca3e0b5cadcd61a6039d714d9250ea2c06a625a
 
 docs:
   hello_world: |


### PR DESCRIPTION
This PR creates duckdb observefs extension.

Motivation:
As a developer, I feel painful when debugging duckdb IO perf issues. For example, it's hard to tell whether a slow query comes from query execution itself, or it's from slow IO.
`EXPLAIN ANALYZIZ` only tells the number of IOs, or verbose logging is also not helpful here.
The issue becomes larger when I'm accessing different objects scattered around different buckets at different regions.

So in initial extension release, 
- I add very basic latency stats to open and read operations (the two I care about most)
- Bucket-level stats are accessible -- overall it doesn't make sense to mix all stats for different buckets together
- IO latency outliers are recorded separately
- I tried my best to keep the good parts for cache httpfs: compatible with https

The extension is written in half a day, so still in very basic stage. A few TODO items:
- Better quantile stats; current implementation is built upon histogram which is very coarse especially when data points small
- More IO operations supports, list will be my next
- Error stats report, also aggregate by `errno` if possible
- No support for v1.4 for now, since it's introducing breaking API changes, I will take a look later