### PR TITLE
Upgrade cache httpfs

### DIFF
--- a/extensions/cache_httpfs/description.yml
+++ b/extensions/cache_httpfs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: cache_httpfs
   description: Read cached filesystem for httpfs
-  version: 0.6.0
+  version: 0.7.0
   language: C++
   build: cmake
   license: MIT


### PR DESCRIPTION
This PR upgrades cache-httpfs extension, which includes a few updates:
- Upgrade duckdb and httpfs to v1.4 and its compatible version
- Add LRU-based on-disk cache block eviction