### PR TITLE
Add cache_httpfs extension

### DIFF
--- a/extensions/curl_httpfs/description.yml
+++ b/extensions/curl_httpfs/description.yml
@@ -5,7 +5,7 @@ extension:
   language: C++
   build: cmake
   license: MIT
-  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;windows_amd64_mingw"
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;windows_amd64_mingw;osx_amd64;osx_arm64"
   maintainers:
     - dentiny
 

--- a/extensions/curl_httpfs/description.yml
+++ b/extensions/curl_httpfs/description.yml
@@ -1,0 +1,24 @@
+extension:
+  name: curl_httpfs
+  description: httpfs with connection pool, HTTP/2 and async IO. 
+  version: 0.0.1
+  language: C++
+  build: cmake
+  license: MIT
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;windows_amd64_mingw"
+  maintainers:
+    - dentiny
+
+repo:
+  github: dentiny/duckdb-curl-filesystem
+  ref: a27dd4a22280818b07eab67704b90fe3048c835c
+
+docs:
+  hello_world: |
+    SELECT length(content) AS char_count FROM read_text('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/main/test/data/stock-exchanges.csv');
+  extended_description: |
+    This extension rewrites HTTP layer for httpfs based on libcurl and epoll, it provides a few features:
+    - 100% compatible with httpfs; use curl-based implementation by default, but also allows users to fallback to httplib.
+    - Enable HTTP/2 by default.
+    - Implements TCP connection pool.
+    - All network IO operations are performed in asynchronously.


### PR DESCRIPTION
I found a lot of people in duckdb community is asking for connection pool feature, I also met the same issue in my work, so I wrote this extension based upon httpfs to resolve the problem.

Some high-level ideas:
- 100% compatible with httpfs, so there's no migration pain point for users
- I rewrite (or say, plan to rewrite) the whole duckdb http layer and build everything upon libcurl and a polling engine; right now I'm using epoll and leverage reactor model;
- A few key features have been implemented, including http/2, TCP connection pool, async IO (future/promise style), etc.

There're several TODOs which I will very likely finish within the week:
- As of now, only HEAD and GET HTTP requests have been integrated into multi-curl, which I think are the two most important ones; I will do the later this week.
- Resolve known perf issue: https://github.com/dentiny/duckdb-curl-filesystem/issues/14
