### PR TITLE
Bug fix patch for cache httpfs v0.7.1

### DIFF
--- a/extensions/cache_httpfs/description.yml
+++ b/extensions/cache_httpfs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: cache_httpfs
   description: Read cached filesystem for httpfs
-  version: 0.7.0
+  version: 0.7.1
   language: C++
   build: cmake
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: dentiny/duck-read-cache-fs
-  ref: 1a4ec174571c0576bc5dadd7c7d261ca16a44f2e
+  ref: 0f34e568176536cd96226794e24b068a765a0bfb
 
 docs:
   hello_world: |


### PR DESCRIPTION
This PR is a bug fix patch:
- Fix a segfault bug
  + reference: https://github.com/dentiny/duck-read-cache-fs/pull/250
- Disable extended filesystem interfaces which we cannot access in the extension, so no open or list slip through cached filesystem API calls