### PR TITLE
Upgrade curl-httpfs to v0.1.0

### DIFF
--- a/extensions/curl_httpfs/description.yml
+++ b/extensions/curl_httpfs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: curl_httpfs
   description: httpfs with connection pool, HTTP/2 and async IO. 
-  version: 0.0.1
+  version: 0.1.0
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: dentiny/duckdb-curl-filesystem
-  ref: a27dd4a22280818b07eab67704b90fe3048c835c
+  ref: 23543e03ba46d41e9584db11b098cc6f1e9f424b
 
 docs:
   hello_world: |


### PR DESCRIPTION
This PR upgrades curl_httpfs extension to v0.1.0, a few main changes:
- Resolve a perf issue (https://github.com/dentiny/duckdb-curl-filesystem/pull/22), so it's usable for linux httpfs read scenarios;
- Add readme page and issue report template