### PR TITLE
curl httpfs add macos support

### DIFF
--- a/extensions/curl_httpfs/description.yml
+++ b/extensions/curl_httpfs/description.yml
@@ -1,17 +1,17 @@
 extension:
   name: curl_httpfs
   description: httpfs with connection pool, HTTP/2 and async IO. 
-  version: 0.1.0
+  version: 0.2.0
   language: C++
   build: cmake
   license: MIT
-  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;windows_amd64_mingw;osx_amd64;osx_arm64"
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;windows_amd64_mingw"
   maintainers:
     - dentiny
 
 repo:
   github: dentiny/duckdb-curl-filesystem
-  ref: 23543e03ba46d41e9584db11b098cc6f1e9f424b
+  ref: b177bb28cf4aa2b71ef691a77b5be5a5f6392e3f
 
 docs:
   hello_world: |


### PR DESCRIPTION
This PR adds macos support for curl httpfs, essentially use `kqueue` as polling engine.