### PR TITLE
No excluded platform for observefs

### DIFF
--- a/extensions/observefs/description.yml
+++ b/extensions/observefs/description.yml
@@ -5,7 +5,6 @@ extension:
   language: C++
   build: cmake
   license: MIT
-  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;windows_amd64_mingw"
   maintainers:
     - dentiny
 


### PR DESCRIPTION
For `observefs`, everything should be pretty standard C++ and non-platform-dependent syscalls.