### PR TITLE
Add boilstream extension (remote secrets storage)

### DIFF
--- a/extensions/boilstream/description.yml
+++ b/extensions/boilstream/description.yml
@@ -1,0 +1,24 @@
+extension:
+  name: boilstream
+  description: Mounts boilstream server as a secure Remote Secrets Storage
+  version: 0.1.0
+  language: C++
+  build: cmake
+  license: MIT
+  maintainers:
+    - dforsber
+
+repo:
+  github: dforsber/boilstream-extension
+  ref: 0eed4ca61966dcb3c3cffd0c8f7d36e295bc293e
+
+docs:
+  hello_world: |
+    PRAGMA duckdb_secrets_boilstream_endpoint('https://localhost:443/secrets:ffe14a7a000000010000000168e4f9a5bcca736c3adaaf0f63e735f881adc397db6da85f1b9e231f70bbf6f71db4ef9fad837bc8');
+  extended_description: |
+    This extension implements secure remote secrets storage on compatible REST API endpoints.
+    Required REST API on the server endpoint: https://github.com/dforsber/boilstream-extension/blob/main/src/README.md
+    As an example with boilstream server provided REST API:
+    - Download and run boilstream server, go to https://your-server/, register user with MFA
+    - Vend web token and pass it along with the PRAGMA duckdb_secrets_boilstream_endpoint('https://your-server/secrets:TOKEN')
+    - FROM duckdb_secrets();


### PR DESCRIPTION
# `boilstream` DuckDB Extension

This extensions add support for Secure Remote Secrets Storage endpoints. The extension src/README.md describes the required REST API.

Load the extension and use PRAGMA for setting up.

```sql
D INSTALL boilstream;
D LOAD boilstream;
D PRAGMA duckdb_secrets_boilstream_endpoint('https://localhost:443/secrets:ffe14a7a000000010000000168e4f9a5bcca736c3adaaf0f63e735f881adc397db6da85f1b9e231f70bbf6f71db4ef9fad837bc8');
┌─────────────────────────────────────────────┐
│                   result                    │
│                   varchar                   │
├─────────────────────────────────────────────┤
│ Boilstream endpoint configured successfully │
└─────────────────────────────────────────────┘
D FROM duckdb_secrets();
┌──────────────┬─────────┬──────────┬────────────┬────────────┬──────────────────────┬───────────────────────────────────────────────────────────────────────────────────┐
│     name     │  type   │ provider │ persistent │  storage   │        scope         │                                   secret_string                                   │
│   varchar    │ varchar │ varchar  │  boolean   │  varchar   │      varchar[]       │                                      varchar                                      │
├──────────────┼─────────┼──────────┼────────────┼────────────┼──────────────────────┼───────────────────────────────────────────────────────────────────────────────────┤
│ my_s3_secret │ s3      │ config   │ true       │ boilstream │ ['s3://my-test-buc…  │ name=my_s3_secret;type=s3;provider=config;serializable=true;scope=s3://my-test-…  │
│ test_crud    │ s3      │ config   │ true       │ boilstream │ ['s3://', 's3n://'…  │ name=test_crud;type=s3;provider=config;serializable=true;scope=s3://,s3n://,s3a…  │
└──────────────┴─────────┴──────────┴────────────┴────────────┴──────────────────────┴───────────────────────────────────────────────────────────────────────────────────┘

```