### PR TITLE
Patch observefs to v0.3.1

### DIFF
--- a/extensions/observefs/description.yml
+++ b/extensions/observefs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: observefs
   description: Provides IO observability to filesystem
-  version: 0.3.0
+  version: 0.3.1
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: dentiny/duckdb-filesystem-observability
-  ref: 1c9d190af8077a25f29f450e026b206088cd5908
+  ref: 92ec36ed422205e13f5c9edafdb971abad6eb8ee
 
 docs:
   hello_world: |


### PR DESCRIPTION
This PR patches observefs to v0.3.1, two main changes:
- Fix a bug that all httpfs filesystems are registered twice! One as raw filesystem, one wrapped in observefs
- Add a list filesystem function, so users could know what's available filesystem before they wrap