### PR TITLE
Quackstore - add extension

### DIFF
--- a/extensions/quackstore/description.yml
+++ b/extensions/quackstore/description.yml
@@ -1,0 +1,19 @@
+extension:
+  name: quackstore
+  description: QuackStore - Smart Block-Based Caching for Remote Files. Speed up repeated queries on remote data with intelligent block-level caching.
+  version: 0.0.1
+  language: C++
+  build: cmake
+  license: MIT
+  maintainers:
+    - dkosmakovcog
+    - mullinsms
+    - rnestertsov
+
+repo:
+  github: coginiti-dev/QuackStore
+  ref: dbe1b1c5c4b37510904c84e1f6ddb4a409e58119
+
+docs:
+  extended_description: |
+    See [README.md](https://github.com/coginiti-dev/QuackStore)


### PR DESCRIPTION
# QuackStore Extension
Speed up your data queries by caching remote files locally. The QuackStore extension uses block-based caching to automatically store frequently accessed file portions in a local cache, reducing load times for repeated queries on the same data.

# What does it do?
When you query remote files (like CSV files from the web), DuckDB normally downloads them every time. With QuackStore, the first query downloads and caches the file locally. Subsequent queries use the cached version, making them much faster.