### PR TITLE
miniplot/plotly.js

### DIFF
--- a/extensions/miniplot/description.yml
+++ b/extensions/miniplot/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: nkwork9999/miniplot
-  ref: 16a2abcccad15f203b9645788e85b94d83622fbc
+  ref: 2f3c5f14f168e753ea7ea5d0780ea0dff5ee67e8
 
 docs:
   hello_world: |
@@ -48,10 +48,17 @@ docs:
 
     **Mission: Replace pandas + matplotlib with just DuckDB**
 
-    Features:
+    **New in v0.0.2:**
+    - 🔄 Complete rewrite using Plotly.js for better compatibility
+    - 🌐 Charts open in browser (no native window dependencies)
+    - 📦 Fully offline - Plotly.js embedded (no internet required)
+    - ✨ Interactive features: zoom, pan, hover, export to PNG
+
+    **Features:**
     - Bar, Line, Scatter, and Area charts
-    - Native GUI rendering using Rust/Iced
+    - Interactive Plotly.js-based rendering
     - Simple SQL interface for direct visualization
     - Cross-platform support (macOS, Linux, Windows)
+    - Fully offline operation
 
-    Note: Requires graphical environment. Charts open in separate native windows.
+    **Note:** Charts open in your default web browser.


### PR DESCRIPTION
## Summary
Complete rewrite of miniplot extension using Plotly.js instead of Iced for better compatibility and easier deployment as a community extension.

## What Changed
- Replaced Iced GUI with Plotly.js + HTML rendering
- Reduced from 2 binaries (13.8MB) to 1 binary (9.2MB)　and  Single-file distribution ready for community extensions
- Charts open in browser instead of native window

## Why This Change?
**v0.0.1 (Iced)** required external binary + manual setup:It cannot to open window from community extension,because community extension go as worker thread.
Worker thread limitation: Community extensions can't create GUI windows (requires main thread)

So I adopt Generate HTML with embedded Plotly.js, open in system browser

**v0.0.2 (Plotly.js)** works immediately after `INSTALL miniplot FROM community`

This aligns with DuckDB community extension requirements: single binary, no external dependencies.

Thank you for maintaining the community extensions repository!  
Looking forward to feedback.