### PR TITLE
Remove double install instructions

### DIFF
--- a/extensions/psyduck/description.yml
+++ b/extensions/psyduck/description.yml
@@ -15,10 +15,6 @@ repo:
  
 docs:
   hello_world: |
-    -- Install the Psyduck Extension
-    INSTALL psyduck
-    LOAD psyduck
-    
     -- Create a table of pokémon and return... A duck
     CREATE TABLE pokemon AS SELECT * FROM list_pokemon();
     SELECT name FROM pokemon WHERE is_duck = 1 AND name LIKE '%Psyduck%';


### PR DESCRIPTION
Hi DuckDB, please merge this PR to avoid confusion in the psyduck docs. I didn't realize that install / load would be taken care of in the `Installing and Loading` section of the page: 

https://duckdb.org/community_extensions/extensions/psyduck.html

<img width="2211" height="1500" alt="image" src="https://github.com/user-attachments/assets/63e81cc6-2920-4bea-b60b-428505690f76" />

