### PR TITLE
upgrade QuackStore to v1.0.0 - switches to duckdb 1.4.1

### DIFF
--- a/extensions/quackstore/description.yml
+++ b/extensions/quackstore/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: quackstore
   description: QuackStore - Smart Block-Based Caching for Remote Files. Speed up repeated queries on remote data with intelligent block-level caching.
-  version: 0.0.1
+  version: 1.0.0
   language: C++
   build: cmake
   license: MIT
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: coginiti-dev/QuackStore
-  ref: ca159369965095be7efcd480548eba2ecc48213d
+  ref: 0cf83e4024b5fa0e45d8475f152b4166cf938001
 
 docs:
   extended_description: |


### PR DESCRIPTION
Changes are: 
* upgrade from duckdb 1.4.0 to 1.4.1
* minor fix to incorrect unit-test