### PR TITLE
Upgrade observefs to v0.3.3

### DIFF
--- a/extensions/observefs/description.yml
+++ b/extensions/observefs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: observefs
   description: Provides IO observability to filesystem
-  version: 0.3.2
+  version: 0.3.3
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: dentiny/duckdb-filesystem-observability
-  ref: 794153053909bfb407c73362d029aead78838cb1
+  ref: 4af6cecdeddefeb5c3352bc52c24044fce2ca724
 
 docs:
   hello_world: |


### PR DESCRIPTION
Two changes:
- (major) Fix issues where `cache_httpfs` cannot be used together with `observefs`
  + cache httpfs upgrade will follow through later this week, have some other updates I would like to check in together
- (minor) Update filesystem list function from scalar function to table function for better display without `unnest`