### PR TITLE
Upgrade cache httpfs to v0.8.0

### DIFF
--- a/extensions/cache_httpfs/description.yml
+++ b/extensions/cache_httpfs/description.yml
@@ -16,7 +16,7 @@ repo:
 
 docs:
   hello_world: |
-    SELECT cache_httpfs_get_cache_size();
+    SELECT cache_httpfs_get_ondisk_data_cache_size();
   extended_description: |
     This extension adds a read cache filesystem to DuckDB, which acts as a wrapper of httpfs extention. 
     It supports a few key features:


### PR DESCRIPTION
This PR upgrades cache httpfs extension to v0.8.0, quite a few additions and fixes.
Changelog reference: https://github.com/dentiny/duck-read-cache-fs/blob/main/CHANGELOG.md#080