### PR TITLE
Upgrade cache httpfs v0.9.0

### DIFF
--- a/extensions/cache_httpfs/description.yml
+++ b/extensions/cache_httpfs/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: dentiny/duck-read-cache-fs
-  ref: 699aab185e0ad151a2589fb46891701ff9499232
+  ref: e4b704f9f73599f0d41791db4c75602fb8ce9c01
 
 docs:
   hello_world: |


### PR DESCRIPTION
This PR upgrades cache httpfs to v0.9.0, which includes two additional features:
- Add an in-memory cache layer to on-disk cache reader, so applications and people don't need to access disk in most cases
- Add a few cache config read table functions, to group related configs together.