### PR TITLE
Upgrade observefs to v0.3.0

### DIFF
--- a/extensions/observefs/description.yml
+++ b/extensions/observefs/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: dentiny/duckdb-filesystem-observability
-  ref: bdfe80b65e192ce6d24b64e890c15817120065bb
+  ref: 020a21ea509cfdbf3de2f0092d4f6897319680e6
 
 docs:
   hello_world: |


### PR DESCRIPTION
This PR upgrades observefs to v0.3.0, which includes a few fixes and additions:
- Fix read operations latency record, previous only open operation gets recorded
- Add additional latency collection for glob and get file size, so all read operations get collected
- Add a rough cache access record for duckdb external file cache, including cache hit/miss/partial hit
- Remove TCP connection status query function, which has been removed to another extension `curl_httpfs`