### PR TITLE
Updates for the rusty_sheet extension v0.3.0

### DIFF
--- a/extensions/rusty_sheet/description.yml
+++ b/extensions/rusty_sheet/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: rusty_sheet
   description: An Excel/WPS/OpenDocument Spreadsheets file reader for DuckDB
-  version: 0.2.0
+  version: 0.3.0
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: redraiment/rusty-sheet
-  ref: b864536c57efdc7da06b63126fe7cbd349000ee7
+  ref: v0.3.0
 
 docs:
   hello_world: |
@@ -48,6 +48,10 @@ docs:
     
     -- Union data by column name instead of position
     FROM read_sheets(['*.xlsx'], union_by_name=true);
+
+    -- With custom HTTP headers: must be a persistent SECRET
+    CREATE PERSISTENT SECRET http_auth (TYPE HTTP, BEARER_TOKEN 'token');
+    FROM read_sheet('https://example.com/data.xlsx');
 
   extended_description: |
     The DuckDB rusty-sheet extension that enables reading Excel, WPS and OpenDocument spreadsheet files directly within SQL queries. This extension provides seamless integration for analyzing spreadsheet data using DuckDB's powerful SQL engine.


### PR DESCRIPTION
feat: add support for reading spreadsheets from remote URLs

- Add support for HTTP, HTTPS, S3, GS, and HF protocols in spreadsheet reader
- Improve error messages in `read_sheets` with complete error context
- Bump `extension-ci-tool` to latest version to resolve CI pytest issues