### PR TITLE
Add mlpack as an extension

### DIFF
--- a/extensions/mlpack/description.yml
+++ b/extensions/mlpack/description.yml
@@ -5,8 +5,8 @@ extension:
   language: C++
   build: cmake
   license: MIT
-  exclude_archs: "windows_amd64_mingw;windows_amd64;osx_amd64;osx_arm64;wasm_mvp;wasm_eh;wasm_threads"
-  extra_toolchains: "fortran;omp"    
+  excluded_platforms: "windows_amd64_mingw;windows_amd64;osx_amd64;osx_arm64;wasm_mvp;wasm_eh;wasm_threads"
+  requires_toolchains: "fortran;omp"    
   maintainers:
     - eddelbuettel
 


### PR DESCRIPTION
This is currently an 'MVP' -- a minimally viable product (demo) wrapping two algorithms.  The mlpack build is itself reliant on cmake, and uses a one-word patch in two places to one dependency (cereal).  This currently fails here leading to the two macOS build issues which "should be" fixable but I could not get that addressed yesterday.  Webassembly should also work as it does for the CRAN package of mlpack at r-universe -- we will look into this too and see how we can straighten the 'tail' of lapack/blas coming in via armadillo.  mingw is probably out of scope but standard windows may work as well. To be seen.

/cc @rcurtin 