### PR TITLE
[mlpack] Expanded description.yml with docs, use updated repo

### DIFF
--- a/extensions/mlpack/description.yml
+++ b/extensions/mlpack/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: mlpack
   description: Machine learning library in C++
-  version: 0.0.1
+  version: 0.0.2
   language: C++
   build: cmake
   license: MIT
@@ -12,5 +12,43 @@ extension:
 
 repo:
   github: eddelbuettel/duckdb-mlpack
-  ref: c2d0c83b24501fa6912765ccdb03685f021d2b86
+  ref: 64ce9296ac4189f2c2883928f8e937b8954a8f79
   
+docs:
+  hello_world: |
+    -- Perform adaBoost (using weak learner 'Perceptron' by default)
+    -- Read 'features' into 'X', 'labels' into 'Y', use optional parameters
+    -- from 'Z', and prepare model storage in 'M'
+    CREATE TABLE X AS SELECT * FROM read_csv("https://eddelbuettel.github.io/duckdb-mlpack/data/iris.csv");
+    CREATE TABLE Y AS SELECT * FROM read_csv("https://eddelbuettel.github.io/duckdb-mlpack/data/iris_labels.csv");
+    CREATE TABLE Z (name VARCHAR, value VARCHAR);
+    INSERT INTO Z VALUES ('iterations', '50'), ('tolerance', '1e-7');
+    CREATE TABLE M (json VARCHAR);
+
+    -- Train model for 'Y' on 'X' using parameters 'Z', store in 'M'
+    CREATE TEMP TABLE A AS SELECT * FROM mlpack_adaboost("X", "Y", "Z", "M");
+
+    -- Count by predicted group
+    SELECT COUNT(*) as n, predicted FROM A GROUP BY predicted;
+
+    -- Model 'M' can be used to predict
+    CREATE TABLE N (x1 DOUBLE, x2 DOUBLE, x3 DOUBLE, x4 DOUBLE);
+    -- inserting approximate column mean values
+    INSERT INTO N VALUES (5.843, 3.054, 3.759, 1.199);
+    -- inserting approximate column mean values, min values, max values
+    INSERT INTO N VALUES (5.843, 3.054, 3.759, 1.199), (4.3, 2.0, 1.0, 0.1), (7.9, 4.4, 6.9, 2.5);
+    -- and this predict one element each
+    SELECT * FROM mlpack_adaboost_pred("N", "M");
+
+    EOF
+
+  extended_description: |
+    The mlpack extension allows to fit (or train) and predict (or classify) from the models implemented, currently adaBoost and (regularized) linear regression.
+    The format is the same for both: four tables, say, "X", "Y", "Z" and "M" provide input for, respectively, features "X", labels "Y", optional parameters varying by model in "Z" as well as an output table "M" for the JSON-serialized model.
+    Following a model fit (or training), a prediction (or classification) can be made using "M" and new
+    predictor values as shown in the example.
+
+    The implementation is still stressing the 'minimal' part of 'a MVP demo': currently only Linux is supported.
+    It should be considered experimental, interfaces may change while we work out how to automate interface generation from the mlpack-side.
+
+    For more, see the [repo](https://github.com/eddelbuettel/duckdb-mlpack).


### PR DESCRIPTION
This PR expands the yaml file by adding a `docs` section which should make the now-generated web page less bare :laughing: 

It also rolls forward to a newer commit sha1 as another predict function has been added.