### PR TITLE
Add OpenTelemetry (OTLP) Extension v0.1.0

### DIFF
--- a/extensions/otlp/description.yml
+++ b/extensions/otlp/description.yml
@@ -5,6 +5,8 @@ extension:
   language: C++
   build: cmake
   license: MIT
+  # needed for protobuf
+  vcpkg_commit: 35c82bb582adab830e1d14f9c4100d251b30aff4
   excluded_platforms: ""
   maintainers:
     - smithclay
@@ -86,4 +88,3 @@ docs:
 
     - [OpenTelemetry Protocol (OTLP)](https://opentelemetry.io/docs/specs/otlp/)
     - [OpenTelemetry ClickHouse Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/clickhouseexporter)
-  


### PR DESCRIPTION
This adds a new community extension for [OpenTelemetry protocol (OTLP)](https://opentelemetry.io/docs/specs/otel/protocol/) data from protobuf or JSON.  OTLP is a popular open-source standard operations teams use for transporting logs, metrics, and traces.

The v0.1.0 extensions reads data into duckdb from files with a schema designed for easy operational queries (what are the slowest operations for the frontend service, what are the error logs in the last 5 minutes, etc).

Note that this has nothing to do with instrumentation or observability of duckdb itself: similar to other community extensions it just pulls in external data in a specific format (OTLP).

In-browser WASM demo @ https://github.com/smithclay/duckdb-otlp 