### PR TITLE
Add nats_js extension

### DIFF
--- a/extensions/nats_js/description.yml
+++ b/extensions/nats_js/description.yml
@@ -6,7 +6,6 @@ extension:
   build: cmake
   license: MIT
   excluded_platforms: "linux_amd64_musl;windows_amd64_mingw"
-  vcpkg_commit: "a42af01b72c28a8e1d7b48107b33e4f286a55ef6"
   maintainers:
     - brannn
 


### PR DESCRIPTION
## Extension: nats_js

Query NATS JetStream persistent message buses with JSON and Protocol Buffers support.

### Features
- Sequence-based and timestamp-based range queries
- Subject filtering
- JSON payload extraction with dot notation
- Protocol Buffers support with runtime schema parsing
- Multi-platform support (Linux, macOS, Windows, WebAssembly)

### Repository
https://github.com/brannn/duckdb-nats-jetstream

### Release
v0.1.0 (pre-release)

### CI Status
8/9 platforms building successfully (excluded: linux_amd64_musl, windows_amd64_mingw)

### Dependencies
- cnats (NATS C client)
- protobuf (Protocol Buffers)

Managed via vcpkg.