### PR TITLE
fix(nats_js): prevent UTF-8 validation error on binary payload (v0.1.1)

### DIFF
--- a/extensions/nats_js/description.yml
+++ b/extensions/nats_js/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: nats_js
   description: Query NATS JetStream message streams directly with SQL
-  version: 0.1.0
+  version: 0.1.1
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: brannn/duckdb-nats-jetstream
-  ref: v0.1.0
+  ref: v0.1.1
 
 docs:
   hello_world: |
@@ -47,3 +47,4 @@ docs:
     Perfect for ETL workflows, analytics, and ad-hoc querying of message streams.
     
     GitHub: https://github.com/brannn/duckdb-nats-jetstream
+


### PR DESCRIPTION
Payload column now returns BLOB instead of VARCHAR when no extraction parameters specified, preventing UTF-8 validation errors on binary data (e.g., protobuf).

**Changes:**
- Update nats_js from v0.1.0 to v0.1.1
- Fixes UTF-8 validation error when querying streams with binary messages

**Ref:** https://github.com/brannn/duckdb-nats-jetstream/releases/tag/v0.1.1