### PR TITLE
Add duckherder extension

### DIFF
--- a/extensions/duckherder/description.yml
+++ b/extensions/duckherder/description.yml
@@ -5,7 +5,7 @@ extension:
   language: C++
   build: cmake
   license: MIT
-  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;windows_amd64_mingw"
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;windows_amd64_mingw;osx_amd64;osx_arm64"
   requires_toolchains: parser_tools
   maintainers:
     - dentiny


### PR DESCRIPTION
This PR adds initial version duckdb community extension `duckherder`, which runs query on remote server.
- `duckherder` storage extension is implemented on client side to communicate with server and observability
- `duckling` storage extension is used on server side to inject and execute queries
- though unimplemented for now, I plan to investigated distributed query via `duckling`
- query results are passed back to client side via arrow flight