### PR TITLE
Upgrade cache httpfs to 0.9.3

### DIFF
--- a/extensions/cache_httpfs/description.yml
+++ b/extensions/cache_httpfs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: cache_httpfs
   description: Read cached filesystem for httpfs
-  version: 0.9.2
+  version: 0.9.3
   language: C++
   build: cmake
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: dentiny/duck-read-cache-fs
-  ref: 075e8f7c04bd2c4ea1cab2d655b0fee3826a37a5
+  ref: 5ce80d5df7d737256d9fd021cbf14b23e7783ad0
 
 docs:
   hello_world: |


### PR DESCRIPTION
This PR upgrades duckdb, httpfs and extension-ci-tools to v1.4.2.
The tricky thing is, main branch for httpfs extension is not compatible with duckdb v1.4.2, so I stole it from Carlo's ongoing PR. :)