### PR TITLE
Upgrade curl httpfs to v0.2.2

### DIFF
--- a/extensions/curl_httpfs/description.yml
+++ b/extensions/curl_httpfs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: curl_httpfs
   description: httpfs with connection pool, HTTP/2 and async IO. 
-  version: 0.2.1
+  version: 0.2.2
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: dentiny/duckdb-curl-filesystem
-  ref: 8dead9f6b45250becd2bb4c7b94428a9a6af9e45
+  ref: 378e0698e0636d26834bc7caff0d8e11be805d37
 
 docs:
   hello_world: |


### PR DESCRIPTION
This PR upgrades curl httpfs to v0.2.2, a few key changes:
- Provide options to enable verbose logging via libcurl
- Enable IO multiplexing via libcurl
- Upgrade duckdb and extension-ci-tools to v1.4.2