### PR TITLE
Upgrade observefs 0.4.1

### DIFF
--- a/extensions/observefs/description.yml
+++ b/extensions/observefs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: observefs
   description: Provides IO observability to filesystem
-  version: 0.3.3
+  version: 0.4.1
   language: C++
   build: cmake
   license: MIT


### PR DESCRIPTION
This PR upgrades observefs to v0.4.1, the main change is to upgrade duckdb and other related dependencies to compatible version.