### PR TITLE
Add webdavfs 1.0.0

### DIFF
--- a/extensions/webdavfs/description.yml
+++ b/extensions/webdavfs/description.yml
@@ -1,0 +1,54 @@
+extension:
+  name: webdavfs
+  description: Allows reading and writing files over WebDAV protocol
+  version: 1.0.0
+  language: C++
+  build: cmake
+  license: MIT
+  excluded_platforms: "windows_amd64_rtools;windows_amd64_mingw;windows_amd64;wasm_threads;wasm_eh;wasm_mvp;linux_amd64_musl;"
+  requires_toolchains: "vcpkg"
+  maintainers:
+    - onnimonni
+  vcpkg_commit: 'dd3097e305afa53f7b4312371f62058d2e665320'
+repo:
+  github: midwork-finds-jobs/duckdb-webdavfs
+  ref: 0dbab4e028831abab3c09eff67a4168269a9d8df
+
+docs:
+  hello_world: |
+    -- Load the extension
+    INSTALL webdavfs FROM community;
+    LOAD webdavfs;
+
+    -- Authenticate with any WebDAV server eg nextcloud or owncloud
+    CREATE SECRET my_storagebox (
+      TYPE WEBDAV,
+      USERNAME 'u123456',
+      PASSWORD 'password',
+      SCOPE 'webdav://webdav-server.example.com/'
+    );
+
+    -- or with Hetzner specific Storage Box
+    CREATE SECRET my_storagebox (
+      TYPE WEBDAV,
+      USERNAME 'u123456',
+      PASSWORD 'password',
+      SCOPE 'storagebox://u123456'
+    );
+
+    -- Convert local csv into parquet and upload it using WebDAV
+    COPY (
+        FROM 'local.csv'
+    ) TO 'storagebox://u123456/remote.parquet';
+    
+    -- Read The uploaded parquet file using WebDAV
+    SELECT * FROM 'storagebox://u123456/remote.parquet';
+
+  extended_description: |
+    DuckDB WebDAVfs extension enables seamless integration with WebDAV servers, allowing users to read from and write to remote file systems directly within DuckDB. This extension supports authentication mechanisms compatible with various WebDAV services, including Hetzner Storage Boxes.
+
+    WebDAV is nice because it builds on top of HTTP/HTTPS protocols. This enables DuckDB to leverage http 1.1 range feature to only download parts of files when needed, making it efficient for working with large datasets stored remotely.
+
+    Hetzner Storage Boxes are a popular choice for WebDAV storage being one of the cheapest storage options available.
+
+    See: https://github.com/midwork-finds-jobs/webdavfs/blob/main/README.md for more examples and details.


### PR DESCRIPTION
Hey!

I asked if httpfs extension could directly support Hetzner Storage Boxes in https://github.com/duckdb/duckdb-httpfs/issues/160.

I'm not very fluent with C++ but luckily Claude Code did an great job with this.

This community extension allows users to use Hetzner Storage Boxes, Nextcloud and Owncloud directly from DuckDB allowing hobbyists to use self-hosted or cheap storage options. 