### PR TITLE
Webdavfs: Update to 1.0.1

### DIFF
--- a/extensions/webdavfs/description.yml
+++ b/extensions/webdavfs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: webdavfs
   description: Allows reading and writing files over WebDAV protocol
-  version: 1.0.0
+  version: 1.0.1
   language: C++
   build: cmake
   license: MIT
@@ -12,7 +12,7 @@ extension:
   vcpkg_commit: 'dd3097e305afa53f7b4312371f62058d2e665320'
 repo:
   github: midwork-finds-jobs/duckdb-webdavfs
-  ref: 0dbab4e028831abab3c09eff67a4168269a9d8df
+  ref: 00894c37e652a256a26299b7023fc000d47a85c5
 
 docs:
   hello_world: |


### PR DESCRIPTION
I found that if one uses this extension and `sshfs` simultaneously then this extension tries to anyway take over the requests to the Hetzner Storagebox even if the resource prefix is 'ssh://'. This should fix it.