### PR TITLE
Duckherder upgrade v0.0.3

### DIFF
--- a/extensions/duckherder/description.yml
+++ b/extensions/duckherder/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: dentiny/duckdb-distributed-execution
-  ref: ccb24330caffab48b5c4da62004da9f0bfabd03f
+  ref: 4a03f33228eac4748172bea5d6834b6839e431ce
 
 docs:
   hello_world: |


### PR DESCRIPTION
This PR upgrades duckherder to v0.0.3, which includes a few features (though still experiment, but more play-able):
- Add metrics for distribution mode, query execution time, task/worker number, etc
- Add functions for users to register worker nodes and driver node, which basically allow them to implement them to their own driver/worker, as long as they speak duckherder dialect (i.e., grpc stubs and arrow flight).

Also add Peter into `observefs` extension maintainer.