### PR TITLE
Update `lsh` extension to `v0.2.0`

### DIFF
--- a/extensions/lsh/description.yml
+++ b/extensions/lsh/description.yml
@@ -1,10 +1,10 @@
 extension:
   name: lsh
   description: Extension for locality-sensitive hashing (LSH)
-  version: 0.1.1
+  version: 0.2.0
   language: Rust
   build: cargo
-  license: GPL-3.0
+  license: MIT
   excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;linux_amd64_musl"
   requires_toolchains: "rust;python3"
   maintainers:
@@ -13,14 +13,10 @@ extension:
 
 repo:
   github: princeton-ddss/lsh
-  ref: 6400a7b6ca05e9aaa2300573904e000933a317a8
+  ref: f71843eeea4817ad4555cc989634fa19b845a410
 
 docs:
   hello_world: |
-    -- Install and load the extension
-    INSTALL lsh FROM community;
-    LOAD lsh;
-
     -- Create toy data
     CREATE TEMPORARY TABLE temp_names AS
     SELECT * FROM (
@@ -29,14 +25,6 @@ docs:
             ('Robert Smith'),
             (NULL),
             ('Charlotte Brown'),
-            ('David Martinez'),
-            ('Emily Davis'),
-            ('Michael Wilson'),
-            ('Sophia Taylor'),
-            (NULL),
-            ('James Anderson'),
-            ('Olivia Thomas'),
-            ('Benjamin Lee')
     ) AS t(name);
 
     -- Apply MinHash

--- a/extensions/lsh/docs/function_descriptions.csv
+++ b/extensions/lsh/docs/function_descriptions.csv
@@ -1,5 +1,6 @@
 function,description,comment,example
-lsh_min,"Computes a band hash vector for each input string based on its MinHash signature","lsh_min(string, ngram_width, band_count, band_size, seed)","SELECT lsh_min('Princeton University', 2, 3, 2, 123);"
-lsh_min32,"Computes a band hash vector for each input string based on its MinHash signature","Reduces each band hash to 32 bits","SELECT lsh_min32('Princeton University', 2, 3, 2, 123);"
-lsh_euclidean,"Computes a band hash vector for each input point based on its Euclidean LSH signature","lsh_euclidean(array, bucket_width, band_count, band_size, seed)","SELECT lsh_euclidean(ARRAY[1.1, 2.2, 3.3, 5.8, 3.9], 0.5, 2, 3, 123);"
-lsh_euclidean32,"Computes a band hash vector for each input point based on its Euclidean LSH signature","Reduces each band hash to 32 bits","SELECT lsh_euclidean32(ARRAY[1.1, 2.2, 3.3, 5.8, 3.9], 0.5, 2, 3, 123);"
+lsh_min,"Computes band hashes for each input string (or list of existing shingles) based on its MinHash signature","Produces list of 64-bit band hashes",""
+lsh_min32,"Computes band hashes for each input string (or list of existing shingles) based on its MinHash signature","Reduces each band hash to 32 bits",""
+lsh_euclidean,"Computes band hashes for each input point based on its Euclidean LSH signature","Produces list of 64-bit band hashes",""
+lsh_euclidean32,"Computes band hashes for each input point based on its Euclidean LSH signature","Reduces each band hash to 32 bits",""
+lsh_jaccard,"Computes Jaccard similarity for each input string pair","Accepts ngram argument, unlike core Jaccard function",""


### PR DESCRIPTION
Changes include:

* Relicensed under MIT to facilitate broader reuse
* Added Jaccard similarity function with an `ngram_width` argument
* Overloaded MinHash functions to enable users to hash their own shingles pre-generated based on their unique needs (e.g., word bigrams with particular stemming)

Thanks for your help!