### PR TITLE
Updates for the rusty_sheet extension v0.4.0

### DIFF
--- a/extensions/rusty_sheet/description.yml
+++ b/extensions/rusty_sheet/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: rusty_sheet
   description: An Excel/WPS/OpenDocument Spreadsheets file reader for DuckDB
-  version: 0.3.1
+  version: 0.4.0
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: redraiment/rusty-sheet
-  ref: v0.3.1
+  ref: v0.4.0
 
 docs:
   hello_world: |


### PR DESCRIPTION
Release v0.4.0

* Add support for DuckDB v1.4.2
* Introduce `nulls` parameter for custom null literal handling
* Upgrade duckdb-loadable-macros to v0.1.12
* Upgrade quick-xml to v0.38.4
* Upgrade url to v2.5.7
* Upgrade zip to v6.0.0
