### PR TITLE
Updates for the rusty_sheet extension v0.4.1

### DIFF
--- a/extensions/rusty_sheet/description.yml
+++ b/extensions/rusty_sheet/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: rusty_sheet
   description: An Excel/WPS/OpenDocument Spreadsheets file reader for DuckDB
-  version: 0.4.0
+  version: 0.4.1
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: redraiment/rusty-sheet
-  ref: v0.4.0
+  ref: v0.4.1
 
 docs:
   hello_world: |

--- a/extensions/rusty_sheet/docs/function_description.csv
+++ b/extensions/rusty_sheet/docs/function_description.csv
@@ -1,5 +1,5 @@
-function,fun_type,description,comment,example
-analyze_sheet,table_function,"Analyzes a single spreadsheet sheet to detect column names and data types.",,"FROM analyze_sheet('data.xlsx', analyze_rows=20);"
-analyze_sheets,table_function,"Analyzes multiple spreadsheet sheets across files to detect column structures.",,"FROM analyze_sheets(['*.xls']);"
-read_sheet,table_function,"Reads data from a single spreadsheet sheet into a DuckDB table.",,"FROM read_sheet('data.ods');"
-read_sheets,table_function,"Reads data from multiple spreadsheet sheets across files into DuckDB tables.",,"FROM read_sheets(['*.et'], union_by_name=true);"
+function,description,comment,example
+analyze_sheet,"Analyzes a single spreadsheet sheet to detect column names and data types.","","FROM analyze_sheet('data.xlsx', analyze_rows=20);"
+analyze_sheets,"Analyzes multiple spreadsheet sheets across files to detect column structures.","","FROM analyze_sheets(['*.xls']);"
+read_sheet,"Reads data from a single spreadsheet sheet into a DuckDB table.","","FROM read_sheet('data.ods');"
+read_sheets,"Reads data from multiple spreadsheet sheets across files into DuckDB tables.","","FROM read_sheets(['*.et'], union_by_name=true);"


### PR DESCRIPTION
Release v0.4.1

* Upgrade Rust Edition to 2024.
* Remove duckdb-loadable-macros
* Fix null literals in shared strings issue.
