### PR TITLE
Upgrade cache httpfs v0.9.4

### DIFF
--- a/extensions/cache_httpfs/description.yml
+++ b/extensions/cache_httpfs/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: dentiny/duck-read-cache-fs
-  ref: 355d517720d3ce36bb26d50220880e85d73f3754
+  ref: 34441da8814f7ae5f71e553060337c021570fd1a
 
 docs:
   hello_world: |


### PR DESCRIPTION
This PR upgrades cache httpfs to v0.9.4, two main changes:
- Users reports empty local cache files, so I added debug logging message for local file deletion and creation
- Add metrics for bytes to read and bytes to cache, which could be used to decide cache block size