### PR TITLE
Add macos support for duckherder

### DIFF
--- a/extensions/duckherder/description.yml
+++ b/extensions/duckherder/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: dentiny/duckdb-distributed-execution
-  ref: 415a7c9eebc21dfec3f86746942773d29fcf1127
+  ref: d4ceb844557d9762c3435c213f9e9709017badab
 
 docs:
   hello_world: |


### PR DESCRIPTION
This PR adds macos support for duckherder extension, mainly two changes:
- I addressed some flaky local server startup issues, and checked it works on my macos development environment.
- Downgrade the C++ compilation version from 20 to 17, the issue lies in (1) arrow uses forward declared type in vector; but (2) libc++ (clang's default standard library on macos) decorates constexpr, which requires full definition.