### PR TITLE
Add html_query extension

### DIFF
--- a/extensions/html_query/description.yml
+++ b/extensions/html_query/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb_html_query
-  ref: 72e8f6ddd8c0c0b9c2685be1440444ab66e2a211
+  ref: 64efcbce6263f7b186997eb6fa8722fa4bd014bf
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary

Add the `html_query` extension for querying HTML using CSS selectors.

**Features:**
- `html_query(html, selector, text_only)` - Extract HTML/text using CSS selectors
- `html_extract_json(html, selector, var_pattern)` - Extract JSON from LD+JSON and JavaScript variables

**Use cases:**
- Extract structured data from HTML pages
- Parse LD+JSON metadata (decodes HTML entities)
- Extract (with regex) JavaScript variables like `var jobs = JSON.parse('...')` and decode if they contain hex/unicode escapes

**Example:**
```sql
-- Extract title
SELECT html_query('<html><title>Hello</title></html>', 'title', true);

-- Extract LD+JSON
SELECT html_extract_json(html, 'script[type="application/ld+json"]') FROM pages;

-- Extract JS variable
SELECT html_extract_json(html, 'script', 'var config') FROM pages;
```

Repository: https://github.com/midwork-finds-jobs/duckdb_html_query