### PR TITLE
Add system_stats extension

### DIFF
--- a/extensions/system_stats/description.yml
+++ b/extensions/system_stats/description.yml
@@ -1,0 +1,27 @@
+extension:
+  name: system_stats
+  description: Provides table functions to access system-level statistics for monitoring purpose
+  version: 0.1.0
+  language: C++
+  build: cmake
+  license: MIT
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;windows_amd64_mingw"
+  maintainers:
+    - dentiny
+
+repo:
+  github: dentiny/system_stats
+  ref: 10a267467b51acc3a3b5f9da09cff0dfebbea097
+
+docs:
+  hello_world: |
+    -- Get memory information
+    SELECT * FROM sys_memory_info();
+
+    -- Get CPU information
+    SELECT * FROM sys_cpu_info();
+
+    -- Get disk information
+    SELECT * FROM sys_disk_info();
+  extended_description: |
+    The system_stats extension provides table functions to access system-level statistics (including memory, CPU, and disk) that can be used for monitoring.


### PR DESCRIPTION
This PR adds `system_stats` extension, which provides system observability (i.e., CPU/memory/disk) for monitoring purpose.