### PR TITLE
Upgrade sysem stats extension to v0.2.0

### DIFF
--- a/extensions/system_stats/description.yml
+++ b/extensions/system_stats/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: dentiny/system_stats
-  ref: b00d6206fe26fc5ebf88448629438b25bcb14b31
+  ref: b35d487f03c9ba6773c859a5f1a42602740750a0
 
 docs:
   hello_world: |


### PR DESCRIPTION
This PR upgrades system_stats extension to v0.2.0, which accomplishes all stats I want to expose at the moment.