### PR TITLE
Add cloudfront extension

### DIFF
--- a/extensions/cloudfront/description.yml
+++ b/extensions/cloudfront/description.yml
@@ -1,7 +1,7 @@
 extension:
   build: cmake
   description: AWS CloudFront signed cookie authentication for DuckDB httpfs
-  excluded_platforms: linux_amd64_musl
+  excluded_platforms: linux_amd64_musl;windows_amd64_mingw
   language: C++
   license: MIT
   maintainers:


### PR DESCRIPTION
## Summary

Adds `cloudfront` extension that provides AWS CloudFront signed cookie authentication for DuckDB httpfs.

### Features
- `CREATE SECRET` with `TYPE cloudfront` - native secret type integration
- Config provider: `KEY_PAIR_ID`, `PRIVATE_KEY_PATH` or `PRIVATE_KEY`
- Env provider: reads from `CLOUDFRONT_*` environment variables
- Generates RSA-SHA1 signed CloudFront cookies
- Creates `http` type secret compatible with httpfs

### Usage

```sql
LOAD cloudfront;
LOAD httpfs;

CREATE SECRET cf_auth (
    TYPE cloudfront,
    KEY_PAIR_ID 'K2JCJMDEHXQW5F',
    PRIVATE_KEY_PATH '/path/to/private_key.pem',
    SCOPE 'https://d111111.cloudfront.net/'
);

SELECT * FROM read_parquet('https://d111111.cloudfront.net/data.parquet');
```

### Repository

- GitHub: https://github.com/midwork-finds-jobs/duckdb-cloudfront
- License: MIT
- CI: All builds pass (Linux, macOS, Windows)

### Dependencies
- OpenSSL (via vcpkg)