### PR TITLE
duckdb_mcp: bump to v1.2.0

### DIFF
--- a/extensions/duckdb_mcp/description.yml
+++ b/extensions/duckdb_mcp/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duckdb_mcp
   description: Model Context Protocol (MCP) extension for DuckDB that enables seamless integration between SQL databases and MCP servers. Provides both client capabilities for accessing remote MCP resources via SQL and server capabilities for exposing database content as MCP resources.
-  version: 1.1.0
+  version: 1.2.0
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
     - teaguesterling
 repo:
   github: teaguesterling/duckdb_mcp
-  ref: 440ef9e852a806def5783c7ca4f7fdb3d1021881
+  ref: 17d83c3f82a0a47110a1787f451d6b5fc053c3d7
 
 docs:
   hello_world: |
@@ -43,6 +43,8 @@ docs:
 
   extended_description: |
     DuckDB MCP Extension bridges SQL databases with the Model Context Protocol (MCP), enabling bidirectional integration between DuckDB and MCP servers. The extension operates in dual modes: as an MCP client for accessing remote resources and as an MCP server for exposing database content.
+
+    See the [README.md](https://github.com/teaguesterling/duckdb_mcp/blob/main/README.md) for more details.
     
     **MCP Client Capabilities**: Connect to MCP servers using multiple transport protocols (stdio, TCP, WebSocket) and access remote resources directly in SQL queries. Use the `mcp://` URI scheme with standard DuckDB functions like `read_csv()`, `read_parquet()`, and `read_json()` to seamlessly query remote data sources. Execute remote tools with `mcp_call_tool()` and discover available resources with `mcp_list_resources()`.
     


### PR DESCRIPTION
Updated version number to 1.2.0 and modified the extended description to include a link to the README.