### PR TITLE
Update cache httpfs to v0.10.0

### DIFF
--- a/extensions/cache_httpfs/description.yml
+++ b/extensions/cache_httpfs/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: dentiny/duck-read-cache-fs
-  ref: ebd70f12d7d3911115701212aa200b0bed69d8ea
+  ref: 3595bba8b674a7a4e7eb0e7fd3a04b4af66eedde
 
 docs:
   hello_world: |


### PR DESCRIPTION
Two main changes:
- Fix a chunk calculation bug, which would lead to an extra unnecessary empty IO request
- Add options to validate in-memory or on-disk cache entries with version tag, by default off