### PR TITLE
Bump yardstick version to 0.3.1

### DIFF
--- a/extensions/yardstick/description.yml
+++ b/extensions/yardstick/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: yardstick
   description: Measure-aware SQL implementing Julian Hyde's "Measures in SQL" paper
-  version: 0.3.0
+  version: 0.3.1
   language: C++
   build: cmake
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: sidequery/yardstick
-  ref: d367006b40e54d4fa29e278f75e917467667726f
+  ref: 025ac64a3540d822eb9dfff7a236e495d860c440
 
 docs:
   hello_world: |


### PR DESCRIPTION
Removes the need to specify `GROUP BY`