### PR TITLE
Add 'ranges' extension

### DIFF
--- a/extensions/ranges/description.yml
+++ b/extensions/ranges/description.yml
@@ -1,0 +1,13 @@
+extension:
+  name: ranges
+  description: A DuckDB extension for range operations
+  version: 1.0.0
+  language: C++
+  build: cmake
+  license: MIT
+  maintainers:
+    - abelcha
+repo:
+  github: abelcha/duckdb-ranges
+  ref: main
+


### PR DESCRIPTION
This PR adds the `ranges` extension to the community registry.

**Extension Details:**
*   **Name:** ranges
*   **Description:** A DuckDB extension for range operations
*   **Repository:** https://github.com/abelcha/duckdb-ranges