### PR TITLE
Upgrade observefs v0.4.3

### DIFF
--- a/extensions/observefs/description.yml
+++ b/extensions/observefs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: observefs
   description: Provides IO observability to filesystem
-  version: 0.4.2
+  version: 0.4.3
   language: C++
   build: cmake
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: dentiny/duckdb-filesystem-observability
-  ref: 21ed69f492d5b6c5b7c6bd34aca98f115b817d35
+  ref: 4f505aadb7835475300ede1e49eced1e65ca8a2a
 
 docs:
   hello_world: |


### PR DESCRIPTION
This PR upgrades observefs to v0.4.3, which allows multiple duckdb instances and extensions into one single process.