### PR TITLE
Update Snowflake extension to DuckDB 1.4.3

### DIFF
--- a/extensions/snowflake/description.yml
+++ b/extensions/snowflake/description.yml
@@ -10,10 +10,10 @@ extension:
 
 repo:
   github: iqea-ai/duckdb-snowflake
-  ref: a30a5c684f19b030f9f56b561fee67ed94b644b1
+  ref: ee2388dc6c32b1231c493be4dacc9897690936de
 
 install_notes: |
-  **Important:** This extension requires DuckDB 1.4.2 and the Apache Arrow ADBC Snowflake driver to function properly.
+  **Important:** This extension requires DuckDB 1.4.3 and the Apache Arrow ADBC Snowflake driver to function properly.
   
   **You must install the ADBC driver separately after installing this extension.** The extension will not work without the driver.
   


### PR DESCRIPTION
## Summary
Update the Snowflake extension to support DuckDB 1.4.3 and sets DuckDB 1.4.3 as the default version for community extensions builds.

## Changes
-  Update DuckDB version defaults from v1.4.0 to v1.4.3 in build workflow
-  Update snowflake extension ref to latest commit (ee2388dc) with DuckDB 1.4.3 support
-  Update install notes to reflect DuckDB 1.4.3 requirement

## Extension Updates
The snowflake extension (iqea-ai/duckdb-snowflake) has been updated to:
- Support DuckDB 1.4.3
- Fix AUTH_TYPE case sensitivity issue (KEY_PAIR now works correctly)
- Add improved logging for auth type detection
- Update workflow to run only Snowflake tests

## Testing
- Extension builds successfully with DuckDB 1.4.3
- All tests passing (9/11, 2 network timeouts unrelated to code)
- Rebased on latest upstream/main