### PR TITLE
Add web_archive extension

### DIFF
--- a/extensions/web_archive/description.yml
+++ b/extensions/web_archive/description.yml
@@ -9,7 +9,7 @@ extension:
     - onnimonni
 
 repo:
-  github: midwork-finds-jobs/duckdb-web-archive-cdx
+  github: midwork-finds-jobs/duckdb-web-archive
   ref: v0.2.0
 
 docs:
@@ -49,4 +49,4 @@ docs:
     - **Response fetching**: Download archived page content via `response.body`
     - **Virtual columns**: `year` and `month` extracted from timestamp
 
-    For full documentation, visit the [extension repository](https://github.com/midwork-finds-jobs/duckdb-web-archive-cdx).
+    For full documentation, visit the [extension repository](https://github.com/midwork-finds-jobs/duckdb-web-archive).


### PR DESCRIPTION
## Summary
- Add `web_archive` extension to query web archive CDX APIs from SQL
- Provides `common_crawl_index()` and `wayback_machine()` table functions
- Supports WHERE/LIMIT/SELECT/DISTINCT ON pushdown to CDX API

## Extension Repository
https://github.com/midwork-finds-jobs/duckdb-web-archive

## Sample query

Here's a sample use case with the `INSTALL html_query FROM community`:

```sql
SELECT DISTINCT ON(year)
        url[9:] as url,
        strftime(timestamp::TIMESTAMP, '%Y-%m-%d') AS date,
        html_query(response.body, '#repo-stars-counter-star','@text') AS stars,
        html_query(response.body, '#repo-network-counter','@text') AS forks,
        html_query(response.body, 'a[href="/duckdb/duckdb/releases"] span','@text') AS releases,
        html_query(response.body, 'a[href="/duckdb/duckdb/graphs/contributors"] span','@text') AS contributors
FROM wayback_machine()
WHERE url = 'github.com/duckdb/duckdb'
  AND timestamp > '2018-01-01'
  AND statuscode = 200
  AND mimetype = 'text/html'
ORDER BY date
LIMIT 10;
100% ▕██████████████████████████████████████▏ (00:01:49.81 elapsed)
┌──────────────────────────┬────────────┬─────────┬─────────┬──────────┬──────────────┐
│           url            │    date    │  stars  │  forks  │ releases │ contributors │
│         varchar          │  varchar   │ varchar │ varchar │ varchar  │   varchar    │
├──────────────────────────┼────────────┼─────────┼─────────┼──────────┼──────────────┤
│ github.com/duckdb/duckdb │ 2021-04-06 │ NULL    │ NULL    │ 17       │ 59           │
│ github.com/duckdb/duckdb │ 2022-01-07 │ 4.1k    │ 358     │ 22       │ 91           │
│ github.com/duckdb/duckdb │ 2023-01-08 │ 7.9k    │ 745     │ 29       │ 170          │
│ github.com/duckdb/duckdb │ 2024-01-23 │ 14k     │ 1.3k    │ 36       │ 277          │
│ github.com/duckdb/duckdb │ 2025-01-04 │ 25.5k   │ 2k      │ 45       │ 389          │
└──────────────────────────┴────────────┴─────────┴─────────┴──────────┴──────────────┘
```

This causes duckdb to do following queries into the [wayback machine cdx](https://github.com/internetarchive/wayback/tree/master/wayback-cdx-server) and the content urls:
```
https://web.archive.org/cdx/search/cdx?url=github.com/duckdb/duckdb&output=csv&fl=timestamp,original&from=20180101&limit=10&filter=statuscode:200&filter=mimetype:text/html&collapse=timestamp:4
https://web.archive.org/web/20240123174647id_/https://github.com/duckdb/duckdb
https://web.archive.org/web/20220107043832id_/https://github.com/duckdb/duckdb
https://web.archive.org/web/20230108004457id_/https://github.com/duckdb/duckdb
https://web.archive.org/web/20250104235948id_/https://github.com/duckdb/duckdb
https://web.archive.org/web/20210406135953id_/https://github.com/duckdb/duckdb
```

## Features
- Query Common Crawl (2008-present) and Wayback Machine (1996-present)
- Push WHERE clauses (statuscode, mimetype, urlkey) to CDX API
- Push LIMIT to CDX API for efficient queries
- Push DISTINCT ON(year/month) as collapse parameter
- Fetch archived page content via `response.body`
- Virtual year/month columns from timestamp