### PR TITLE
Update html_query to v0.1.1

### DIFF
--- a/extensions/html_query/description.yml
+++ b/extensions/html_query/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: html_query
   description: Query HTML using CSS selectors, extract JSON from LD+JSON and JavaScript variables
-  version: 0.1.0
+  version: 0.1.1
   language: Rust
   build: cargo
   license: MIT
@@ -12,12 +12,12 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb_html_query
-  ref: 64efcbce6263f7b186997eb6fa8722fa4bd014bf
+  ref: c7c101b27a0123ccb87526e9aa2e7c6b512e3b0a
 
 docs:
   hello_world: |
-    -- Extract first matching element
-    SELECT html_query('<html><title>Hello World</title></html>', 'title', true);
+    -- Extract text from first matching element
+    SELECT html_query('<html><title>Hello World</title></html>', 'title', '@text');
     ┌─────────────┐
     │ html_query  │
     │   varchar   │
@@ -25,14 +25,14 @@ docs:
     │ Hello World │
     └─────────────┘
 
-    -- Extract all matching elements as JSON array
-    SELECT html_query_all('<div><p>First</p><p>Second</p></div>', 'p', true);
-    ┌────────────────────┐
-    │   html_query_all   │
-    │      varchar       │
-    ├────────────────────┤
-    │ ["First","Second"] │
-    └────────────────────┘
+    -- Extract all matching elements as VARCHAR[]
+    SELECT html_query_all('<div><p>First</p><p>Second</p></div>', 'p', '@text');
+    ┌────────────────┐
+    │ html_query_all │
+    │   varchar[]    │
+    ├────────────────┤
+    │ [First,Second] │
+    └────────────────┘
 
     -- Extract JSON from LD+JSON scripts (returns array)
     SELECT html_extract_json(
@@ -53,38 +53,50 @@ docs:
 
     | Function | Returns | Description |
     |----------|---------|-------------|
-    | `html_query(html, selector?, text_only?)` | VARCHAR | First matching element |
-    | `html_query_all(html, selector?, text_only?)` | JSON array | All matching elements |
+    | `html_query(html, selector?, extract?)` | VARCHAR | First matching element |
+    | `html_query_all(html, selector?, extract?)` | VARCHAR[] | All matching elements as list |
     | `html_extract_json(html, selector, var_pattern?)` | JSON array | JSON from script tags |
 
-    ### `html_query(html, selector, text_only)`
+    All functions accept both VARCHAR and BLOB input types.
+
+    ### Extract Parameter
+
+    The `extract` parameter specifies what to extract from matched elements:
+
+    | Value | Description |
+    |-------|-------------|
+    | (omitted) | Full HTML of element |
+    | `@text` or `text` | Inner text content |
+    | `@href`, `href` | href attribute |
+    | `@src`, `src` | src attribute |
+    | `data-test-id` | Any attribute name |
+    | `['@href', '@text']` | Multiple attributes as JSON object |
+
+    ### `html_query(html, selector, extract)`
 
     Extract first HTML element matching CSS selector.
 
-    **Parameters:**
-    - `html` (VARCHAR): HTML content to parse
-    - `selector` (VARCHAR, optional): CSS selector (default: `:root`)
-    - `text_only` (BOOLEAN, optional): Extract text only (default: false)
-
-    **Returns:** VARCHAR - First matched element, or NULL if no match
-
     **Examples:**
     ```sql
-    SELECT html_query(html, 'title', true) FROM pages;
-    SELECT html_query(html, 'p:last-child', true) FROM pages;
+    SELECT html_query(html, 'title', '@text') FROM pages;
+    SELECT html_query(html, 'a.nav-link', '@href') FROM pages;
+    SELECT html_query(html, 'div.content') FROM pages;  -- returns HTML
     ```
 
-    ### `html_query_all(html, selector, text_only)`
+    ### `html_query_all(html, selector, extract)`
 
-    Extract all HTML elements matching CSS selector as JSON array.
+    Extract all HTML elements matching CSS selector as VARCHAR[].
 
     **Examples:**
     ```sql
-    SELECT html_query_all(html, 'p', true) FROM pages;
-    -- Returns: ["First paragraph", "Second paragraph"]
+    SELECT html_query_all(html, 'a', '@href') FROM pages;
+    -- Returns: [/home, /about, /contact]
 
-    SELECT html_query_all(html, 'a', true)->>0 FROM pages;
-    -- Access first element
+    SELECT list_extract(html_query_all(html, 'a', '@href'), 2) FROM pages;
+    -- Access second element
+
+    SELECT html_query_all(html, 'a', ['@href', '@text']) FROM pages;
+    -- Returns: [{"href":"/home","text":"Home"}, ...]
     ```
 
     ### `html_extract_json(html, selector, var_pattern)`


### PR DESCRIPTION
## Summary
- Add BLOB input support for all functions
- New extract parameter API (replaces text_only boolean)
- html_query_all now returns VARCHAR[] instead of JSON
- Multi-attribute extraction support

## Changes
- version: 0.1.0 → 0.1.1
- ref: updated to latest commit