### PR TITLE
add: sitting_duck

### DIFF
--- a/extensions/sitting_duck/description.yml
+++ b/extensions/sitting_duck/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: teaguesterling/sitting_duck
-  ref: adaaf49968abae7d318852d597abec080baf412d
+  ref: 22831984342b22ba6505261cefee0e1027ce9c9f
 
 docs:
   hello_world: |


### PR DESCRIPTION
Sitting duck allows duckdb to wrap tree-sitter AST parsing framework to query syntax trees (and add normalization) for 20+ languages including a special handler for DuckDB's internal parser. 