### PR TITLE
Bump up cache httpfs to v0.11.0

### DIFF
--- a/extensions/cache_httpfs/description.yml
+++ b/extensions/cache_httpfs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: cache_httpfs
   description: Read cached filesystem for httpfs
-  version: 0.10.1
+  version: 0.11.0
   language: C++
   build: cmake
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: dentiny/duck-read-cache-fs
-  ref: 933bb58c017c41cee3af9a87dbe9d5b666f42bb3
+  ref: 5f1259cdfa7cf4c3fb398a859df85916b237289f
 
 docs:
   hello_world: |


### PR DESCRIPTION
Two main changes:
- [fix] Allow one single process to run multiple duckdb instances with cache httpfs extension
- [improvement] Leverage duckdb setting callback to update instance state config active, instead of check all configs passively at every IO operation