### PR TITLE
Bump web_archive to v0.2.1

### DIFF
--- a/extensions/web_archive/description.yml
+++ b/extensions/web_archive/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: web_archive
   description: Query Common Crawl and Wayback Machine web archive CDX APIs directly from SQL
-  version: 0.2.0
+  version: 0.2.1
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb-web-archive
-  ref: v0.2.0
+  ref: v0.2.1
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary
- Bump web_archive extension to v0.2.1
- Fixes regex escaping for parentheses in urlkey filters

## Changes
- v0.2.1 fixes an issue where parentheses in urlkey NOT LIKE filters were being double-escaped by httpfs