### PR TITLE
Update `lsh` extension to `v0.2.1`

### DIFF
--- a/extensions/lsh/description.yml
+++ b/extensions/lsh/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: lsh
   description: Extension for locality-sensitive hashing (LSH)
-  version: 0.2.0
+  version: 0.2.1
   language: Rust
   build: cargo
   license: MIT
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: princeton-ddss/lsh
-  ref: f71843eeea4817ad4555cc989634fa19b845a410
+  ref: 1df52d0ada664e9282d6c7c5d572f743163e2874
 
 docs:
   hello_world: |


### PR DESCRIPTION
The extension has been adapted to a new DuckDB release (`v1.4.3`).

Thanks for your help!