### PR TITLE
Update file_dialog for DuckDB v1.4.3

### DIFF
--- a/extensions/file_dialog/description.yml
+++ b/extensions/file_dialog/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: yutannihilation/duckdb-ext-file-dialog
-  ref: 528c5ab4340c61094bd3ebd2af62d7f73501b7cb
+  ref: 981ba64e4bdfe43e5ff7d98573e3f6c4602bd2cd
 
 docs:
   hello_world: |


### PR DESCRIPTION
I'm not sure if extension-ci-tools is ready for DuckDB v1.4.3 (is https://github.com/duckdb/extension-ci-tools/pull/292 blocked for some reason?), but this pull request updates the dependency of file_dialog in the hope it will be listed in https://duckdb.org/community_extensions/list_of_extensions again...