### PR TITLE
bump psyduck to v1.0.2

### DIFF
--- a/extensions/psyduck/description.yml
+++ b/extensions/psyduck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: psyduck
   description: Pokemon data native in DuckDB
-  version: 1.0.1
+  version: 1.0.2
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: Ian-Fogelman/psyduck
-  ref: 4aabf9c7e50b577611ad19e6b367df17330c3c0f
+  ref: c4f8faa4d25e4ca8b3cb0bac8cb958b030f1b2b5
   
 docs:
   hello_world: |
@@ -29,3 +29,6 @@ docs:
 
     -- Select pokemon moves
     SELECT * FROM list_pokemon_moves();
+    
+    -- Select gen1 items
+    SELECT * FROM list_pokemon_items();


### PR DESCRIPTION
- Bumping psyduck ext to `v1.0.2` and updating documentation page.