### PR TITLE
Add anndata extension for single-cell genomics data

### DIFF
--- a/extensions/anndata/description.yml
+++ b/extensions/anndata/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: anndata
   description: Read AnnData (.h5ad) files for single-cell genomics data analysis
-  version: 0.8.3
+  version: 0.9.0
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: honicky/anndata-duckdb-extension
-  ref: 7e25e0bf643bfdfffd07d973328060962eeb20ea
+  ref: b3206219e67fa3621c0db29793b333aeb2f72e80
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary

Adds the `anndata` extension which provides read-only access to AnnData (.h5ad) files, the standard format for single-cell genomics data analysis.

## Features

- ATTACH syntax for mounting .h5ad files as virtual databases
- Query cell metadata (`obs`), gene metadata (`var`), and expression matrix (`X`)
- Access dimensional reductions (PCA, UMAP), layers, and pairwise matrices
- Table functions for direct file access

## Example Usage

```sql
ATTACH 'data.h5ad' AS scdata (TYPE ANNDATA);
SELECT * FROM scdata.obs LIMIT 10;
SELECT * FROM scdata.X LIMIT 10;
DETACH scdata;
```

## Repository

https://github.com/honicky/anndata-duckdb-extension