### PR TITLE
Updates for the rusty_sheet extension v0.4.2

### DIFF
--- a/extensions/rusty_sheet/description.yml
+++ b/extensions/rusty_sheet/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: rusty_sheet
   description: An Excel/WPS/OpenDocument Spreadsheets file reader for DuckDB
-  version: 0.4.1
+  version: 0.4.2
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: redraiment/rusty-sheet
-  ref: v0.4.1
+  ref: v0.4.2
 
 docs:
   hello_world: |


### PR DESCRIPTION
* Build plugin using the STABLE DuckDB C API, ensuring forward compatibility without repackaging on future DuckDB upgrades
* Update DuckDB support to version 1.4.3
* Fix incorrect field type detection when processing nulls in non‑string columns