### PR TITLE
Update http_request to v0.2.4

### DIFF
--- a/extensions/http_request/description.yml
+++ b/extensions/http_request/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: http_request
   description: HTTP client extension for DuckDB with GET/POST/PUT/PATCH/DELETE and byte-range requests
-  version: 0.2.3
+  version: 0.2.4
   language: C++
   build: cmake
   license: MIT
@@ -11,18 +11,23 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb_http_request
-  ref: 62a31a37b992ee24c0232126184a49184d486b49
+  ref: 7913303cc783249b2c6a16bdde143d696344c195
 
 docs:
   hello_world: |
     -- Simple GET request
     SELECT http_get('https://example.com/');
 
+    -- Access response fields
+    SELECT
+        r.status,
+        r.content_type,
+        r.content_length,
+        r.cookies[1].name as first_cookie
+    FROM (SELECT http_get('https://example.com/') as r);
+
     -- GET with custom headers
     SELECT http_get('https://httpbin.org/get', headers := {'Accept': 'application/json'}).body;
-
-    -- POST with custom body
-    SELECT http_post('https://httpbin.org/get', params := {'limit': 10});
 
     -- Byte-range request for partial content
     SELECT http_get(
@@ -40,6 +45,8 @@ docs:
     - Byte-range requests with helper function
     - Auto-decompression of gzip/zstd responses
     - Form-encoded POST with http_post_form()
+    - Parsed Set-Cookie headers into structured cookies array
+    - Convenience fields: content_type, content_length
     - Respects duckdb http and proxy settings
 
     Uses DuckDB's built-in httplib for HTTP connections.


### PR DESCRIPTION
## Summary
- Fix duplicate Set-Cookie headers causing "map keys must be unique" error
- Parse Set-Cookie headers into structured `cookies[]` array
- Add convenience fields: `content_type`, `content_length`

## Changes
The response structure is now:
```sql
STRUCT{
  status: INTEGER,
  content_type: VARCHAR,
  content_length: BIGINT,
  headers: MAP(VARCHAR, VARCHAR),
  cookies: STRUCT{name, value, expires, max_age, path, domain, secure, httponly, samesite}[],
  body: BLOB
}
```

## Test plan
- [x] Local build passes
- [x] Tests pass