### PR TITLE
http_request: v0.4.0 - add multipart/form-data uploads

### DIFF
--- a/extensions/http_request/description.yml
+++ b/extensions/http_request/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb_http_request
-  ref: 405745b0706ceb42104504fe532a97a33eb7fead
+  ref: fa3a7438c658a423f607a525673156034bf46244
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary
- Add `http_post_multipart()` for multipart/form-data file uploads
- Enables file uploads to APIs like OpenAI

## Usage
```sql
SELECT http_post_multipart(
    'https://api.openai.com/v1/files',
    files := [{'name': 'file', 'content': data, 'filename': 'train.jsonl'}],
    fields := {'purpose': 'fine-tune'},
    headers := {'Authorization': 'Bearer sk-...'}
);
```