### PR TITLE
Update llm extension to v0.2.0: lateral join support

### DIFF
--- a/extensions/llm/description.yml
+++ b/extensions/llm/description.yml
@@ -4,7 +4,7 @@ docs:
 
     ## Features
 
-    - `llm()` table function with full provider/parameter control
+    - `llm()` table function with lateral join and named parameter support
     - `prompt()` scalar function with auto-detection of API keys
     - `llm_and_cache()` for immediate responses with caching
     - `llm_batch_and_cache()` for 50% cheaper batch API processing
@@ -80,7 +80,7 @@ extension:
   name: llm
   requires_extensions:
     - http_request
-  version: 0.1.0
+  version: 0.2.0
 repo:
   github: midwork-finds-jobs/duckdb-llm
-  ref: 2e815c1f1c77843e2e526f76f62bd95abd76a49e
+  ref: d3415f76c722737df109236591f9273d81a7b904


### PR DESCRIPTION
## Summary
Update llm extension to v0.2.0 with lateral join and named parameter support.

## Changes
- `llm()` now supports lateral joins with named parameters:
  ```sql
  SELECT t.id, l.response 
  FROM my_table t, llm(t.content, provider := 'gemini', model := 'gemini-2.5-flash') l;
  ```
- Updated ref to d3415f76c722737df109236591f9273d81a7b904

## Test plan
- [x] All tests pass locally
- [x] Tested lateral joins with named parameters
- [x] Tested with Gemini and OpenAI providers