### PR TITLE
Add duckgl extension

### DIFF
--- a/extensions/duckgl/description.yml
+++ b/extensions/duckgl/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: nkwork9999/duckgl # あなたのリポジトリ名に合わせて
-  ref: 3f77100eeb1aaec0119fbcc27a523ee6a09911c7
+  ref: 0de60a34e7bc04141fbc6b2efd6dcad6a80ac1e8
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary
Add duckgl - a DuckDB extension for geospatial data visualization using deck.gl and MapLibre.

## Features
- Web-based interactive map visualization
- GeoJSON layer rendering from spatial tables
- SQL query execution from browser UI
- Automatic geometry detection

## Usage
```sql

-- Start visualization server
SELECT duckgl_start('localhost', 8080);

-- Stop server
SELECT duckgl_stop();
```

## Repository
https://github.com/nkwork9999/duckgl