### PR TITLE
Update cache httpfs to v0.11.2

### DIFF
--- a/extensions/cache_httpfs/description.yml
+++ b/extensions/cache_httpfs/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: dentiny/duck-read-cache-fs
-  ref: f71b945aba276e5ed4b3f8af3a8848bf5bb1883e
+  ref: a0a4e3f3458a845fcd26fb59248a53d8699a5c96
 
 docs:
   hello_world: |


### PR DESCRIPTION
bump up version, which contains a hot patch to disable cached compressed read, need long-term solution.