### PR TITLE
Release cache httpfs v0.12.0

### DIFF
--- a/extensions/cache_httpfs/description.yml
+++ b/extensions/cache_httpfs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: cache_httpfs
   description: Read cached filesystem for httpfs
-  version: 0.11.2
+  version: 0.12.0
   language: C++
   build: cmake
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: dentiny/duck-read-cache-fs
-  ref: a0a4e3f3458a845fcd26fb59248a53d8699a5c96
+  ref: 7c84cdf48658de55a928530e818553f192d2a3d3
 
 docs:
   hello_world: |


### PR DESCRIPTION
This release fixes two bugs:
- Make sure current cache read doesn't affect correctness when compression involved
- Fix a big bug that IO exception is not checked after worker threads complete