### PR TITLE
scalarfs: new extension

### DIFF
--- a/extensions/scalarfs/description.yml
+++ b/extensions/scalarfs/description.yml
@@ -1,0 +1,46 @@
+extension:
+  name: scalarfs
+  description: A collection of virtual filesystems for working with scalars
+  version: 1.0.0
+  language: C++
+  build: cmake
+  license: MIT
+  maintainers:
+    - teaguesterling
+
+repo:
+  github: teaguesterling/duckdb_scalarfs
+  ref: "820cac9141a5f7039163a04c8e69cb6ebcf22bf2"
+
+docs:
+  hello_world: |
+    LOAD scalarfs;
+
+    -- Read JSON from a variable
+    SET VARIABLE config = '{"debug": true, "port": 8080}';
+    SELECT * FROM read_json('variable:config');
+    
+    -- Read CSV from inline content
+    SELECT * FROM read_csv('data+varchar:name,score
+    Alice,95
+    Bob,87');
+    
+    -- Write query results to a variable
+    COPY (SELECT * FROM my_table WHERE active) TO 'variable:exported' (FORMAT json);
+    SELECT getvariable('exported');
+
+  extended_description: |
+    DuckDB's file functions (read_csv, read_json, COPY TO, etc.) expect file paths. scalarfs bridges the gap
+    when your content is already in memory, allowing the same functions to work with:
+    
+    Variables — Store data in DuckDB variables and read/write them as files
+    Inline literals — Embed content directly in your queries without temporary files
+    
+    | Protocol      | Purpose                                |   Mode     |
+    |---------------|----------------------------------------|------------|
+    | variable:     | DuckDB variable as file                | Read/Write |
+    | data:         | RFC 2397 data URI (base64/url-encoded) | Read       |
+    | data+varchar: | Raw VARCHAR content as file            | Read       |
+    | data+blob:    | Escaped BLOB content as file           | Read       |
+    
+    **Note**: This extension was written primarily using Claude and Claude Code as an exercise in AI-driven development.


### PR DESCRIPTION
Adding an extension that adds a few utility filesystems like `variable:` and `data:`.