### PR TITLE
Add mongodb extension

### DIFF
--- a/extensions/mongo/description.yml
+++ b/extensions/mongo/description.yml
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: stephaniewang526/duckdb-mongo
-  ref: fcb318be9df751798e90dc671686ed4540ca726d
+  ref: faaa7c6912bc8ba297493a137b987c272e63055c
 
 docs:
   hello_world: |


### PR DESCRIPTION
Add the mongo extension to the DuckDB community extensions repository.

### Overview
The mongo extension enables direct SQL queries over MongoDB collections without requiring data export or ETL processes. It provides seamless integration between DuckDB and MongoDB, allowing users to run analytical SQL queries directly against MongoDB data.

### Features
- **Direct MongoDB connectivity**: Support for both standalone MongoDB instances and MongoDB Atlas clusters
- **Table function**: `mongo_scan()` function for querying MongoDB collections
- **Storage extension**: `ATTACH` support to mount MongoDB as a database
- **Automatic schema inference**: Automatically infers schema from MongoDB documents
- **Filter pushdown**: Efficient querying with filter pushdown to MongoDB
- **Complex queries**: Support for joins, aggregations, and analytical operations

### Usage
```
-- Load the extension
LOAD 'mongo';

-- Query using table function
SELECT * FROM mongo_scan('mongodb://localhost:27017', 'mydb', 'mycollection');

-- Use MongoDB Atlas connection string
SELECT * FROM mongo_scan('mongodb+srv://user:pass@cluster.mongodb.net/dbname', 'mydb', 'mycollection');

-- Attach MongoDB as a database
ATTACH 'mongodb://localhost:27017' AS mongo_db (TYPE mongo);
USE mongo_db;
SELECT * FROM mycollection;
```

### Repository
https://github.com/stephaniewang526/duckdb-mongo