### PR TITLE
markdown: bump to v1.3.7

### DIFF
--- a/extensions/markdown/description.yml
+++ b/extensions/markdown/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: markdown
   description: Read, analyze, and write Markdown files with block-level document representation and inline element support
-  version: 1.3.6
+  version: 1.3.7
   language: C++
   build: cmake
   license: MIT
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: teaguesterling/duckdb_markdown
-  ref: '2706554c1f46f5860a8ed7b4fada5ab24d746eaf'
+  ref: 'd8885080631029751dd2415b677962fe8854476a'
 
 docs:
   hello_world: |
@@ -105,4 +105,4 @@ docs:
 
     Real-world benchmark: Processing 287 Markdown files (2,699 sections, 1,137 code blocks, 1,174 links) in 603ms.
 
-    Full test suite with 1102 passing assertions across 20 test files.
+    Full test suite with 1108 passing assertions across 20 test files.


### PR DESCRIPTION
Bump markdown to v1.3.6 to fix some bugs with rendering `duck_block`s.