### PR TITLE
yaml: bump to v1.5.0

### DIFF
--- a/extensions/yaml/description.yml
+++ b/extensions/yaml/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: yaml
   description: Read YAML files into DuckDB with native YAML type support, comprehensive extraction functions, and seamless JSON interoperability
-  version: 1.4.0
+  version: 1.5.0
   language: C++
   build: cmake
   license: MIT
@@ -13,32 +13,40 @@ extension:
   
 repo:
   github: teaguesterling/duckdb_yaml
-  ref: 238f700422ff5cd2954588d294f409f7227e65a2
+  ref: 2c5f852ceda6a96bd7a95b724c121fd86bce30a5
 
 docs:
   hello_world: |
     -- Load the extension
     LOAD yaml;
-    
+
     -- Query YAML files directly
     SELECT * FROM 'config.yaml';
     SELECT * FROM 'data/*.yml' WHERE active = true;
-    
+
     -- Create tables with YAML columns
     CREATE TABLE configs(id INTEGER, config YAML);
     INSERT INTO configs VALUES (1, E'server: production\nport: 8080\nfeatures: [logging, metrics]');
-    
+
     -- Extract data using YAML functions
-    SELECT 
-        yaml_extract_string(config, '$.server') AS environment,
+    SELECT
+        config ->> '$.server' AS environment,  -- Arrow operator
         yaml_extract(config, '$.port') AS port,
-        yaml_extract(config, '$.features[0]') AS first_feature
+        yaml_value(config, '$.port') AS port_scalar
     FROM configs;
-    
+
+    -- Analyze YAML structure
+    SELECT yaml_structure(config) FROM configs;
+    -- Returns: {"server":"VARCHAR","port":"UBIGINT","features":["VARCHAR"]}
+
+    -- Check containment and merge documents
+    SELECT yaml_contains(config, 'server: production') AS is_prod FROM configs;
+    SELECT yaml_merge_patch(config, 'debug: true') AS with_debug FROM configs;
+
     -- Convert between YAML and JSON
     SELECT yaml_to_json(config) AS json_config FROM configs;
-    SELECT value_to_yaml({name: 'John', age: 30}) AS yaml_person;
-    
+    SELECT to_yaml({name: 'John', age: 30}) AS yaml_person;
+
     -- Write query results to YAML
     COPY (SELECT * FROM users) TO 'output.yaml' (FORMAT yaml, STYLE block);
 
@@ -50,7 +58,8 @@ docs:
     - **Native YAML Type**: Full YAML type support with automatic casting between YAML, JSON, and VARCHAR
     - **File Reading**: Read YAML files with `read_yaml()` and `read_yaml_objects()` functions supporting multi-document files, top-level sequences, and robust error handling
     - **Direct File Querying**: Query YAML files directly using `FROM 'file.yaml'` syntax
-    - **Extraction Functions**: Query YAML data with `yaml_extract()`, `yaml_type()`, `yaml_exists()`, and path-based extraction
+    - **Extraction Functions**: Query YAML data with `yaml_extract()`, `yaml_type()`, `yaml_exists()`, `yaml_value()`, `->>` operator, and path-based extraction
+    - **Document Operations**: Check containment with `yaml_contains()`, merge documents with `yaml_merge_patch()`, and analyze structure with `yaml_structure()`
     - **Type Detection**: Comprehensive automatic type detection for temporal types (DATE, TIME, TIMESTAMP), optimal numeric types, and boolean values
     - **Column Type Specification**: Explicitly define column types when reading YAML files for schema consistency
     - **YAML Output**: Write query results to YAML files using `COPY TO` with configurable formatting styles


### PR DESCRIPTION
Updates the yaml extension to v1.5.0.

## New Features

- **`->>` operator**: Arrow operator for string extraction
- **`yaml_structure`**: Returns JSON schema of YAML documents
- **`yaml_contains`**: Check if YAML contains another document
- **`yaml_merge_patch`**: RFC 7386 merge patch support
- **`yaml_value`**: Extract scalar values only (NULL for arrays/objects)
- **Function aliases**: `yaml_extract_path`, `yaml_extract_path_text`, `to_yaml`

Release: https://github.com/teaguesterling/duckdb_yaml/releases/tag/v1.5.0