### PR TITLE
duck_block_utils: bump to v1.2.0

### DIFF
--- a/extensions/duck_block_utils/description.yml
+++ b/extensions/duck_block_utils/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duck_block_utils
   description: Build, transform, validate, and extract content from structured documents using the duck_block type
-  version: 1.0.0
+  version: 1.2.0
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: teaguesterling/duckdb_duck_block_utils
-  ref: 561bb55d44f497ade785e9c16de3765786e060e2
+  ref: 88048e0fe27d93acd210623f41999e660c31a3f0
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bump duck_block_utils from v1.0.0 to v1.2.0.

Changes since v1.0.0:
- `pandoc_ast()` table function with meta/api_version params
- Nested list, div, blockquote, table, image Pandoc conversions
- Skip metadata blocks in Pandoc output
- 474 test assertions