### PR TITLE
Update sazgar: Switch to rustls TLS (fixes ARM64 build)

### DIFF
--- a/extensions/sazgar/description.yml
+++ b/extensions/sazgar/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: Angelerator/Sazgar
-  ref: 4ecfac69559eb366727e92a49805ad6f41ec2c21
+  ref: 038b399e537be49e98a83b32984d0b5e29004e25
 
 docs:
   hello_world: |
@@ -286,7 +286,7 @@ docs:
     - ✅ **Supported backends** - PostgreSQL, Tavana, MySQL*, ClickHouse*, Snowflake*, BigQuery*
     - ✅ **Conditional routing** - Route based on system resources
     - ✅ **JOIN support** - Combine remote data with local DuckDB tables
-    - ✅ **Optional TLS** - Build with `--features tls` for secure connections
+    - ✅ **Built-in TLS** - Secure connections enabled by default (rustls, no OpenSSL needed)
     
     > *Non-PostgreSQL backends require PostgreSQL-compatible interface (e.g., protocol adapter)
 


### PR DESCRIPTION
## Changes

- Updated sazgar to latest commit (038b399) which switches from `native-tls` to `rustls`
- TLS is now enabled by default on all platforms without needing OpenSSL
- Fixes ARM64 CI build failures (no longer needs Perl Time::Piece for OpenSSL vendored builds)

## What's New in Sazgar

- **Pure Rust TLS**: Uses `rustls` instead of `native-tls`/OpenSSL
- **No external dependencies**: Works on ARM64 Linux without special CI setup
- **TLS modes**:
  - `sslmode=require` - TLS enabled, accepts any certificate (dev/testing)
  - `sslmode=verify` - TLS with certificate verification

## Related

- Issue: https://github.com/duckdb/extension-ci-tools/issues/304 (optional fix for other Rust extensions using OpenSSL)