### PR TITLE
Update PDAL extension to v0.3.0

### DIFF
--- a/extensions/pdal/description.yml
+++ b/extensions/pdal/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: pdal
   description: Extension that adds support for manipulating point cloud data using SQL.
-  version: 0.2.0
+  version: 0.3.0
   language: C++
   build: cmake
   excluded_platforms: "windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads"
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: ahuarte47/duckdb-pdal
-  ref: d75507f8fb74331d24ce27809f20b37e1502a687
+  ref: 9fcc01eec12fbd32dadfd147d7c361d2c1644f91
 
 docs:
   hello_world: |
@@ -115,4 +115,42 @@ docs:
             }
         ]
     }
+    ```
+
+    The pipeline can be provided either as a JSON file or as an inline JSON string. If the second parameter value
+    starts with "[" and ends with "]", it represents an inline JSON, otherwise it is a file path:
+
+    ```sql
+    SELECT
+        COUNT(*)
+    FROM
+        PDAL_pipeline('./test/data/autzen_trim.las',
+            '[
+                {
+                    "type": "filters.tail",
+                    "count": 10
+                }
+            ]'
+        )
+    ;
+    ┌──────────────┐
+    │ count_star() │
+    │    int64     │
+    ├──────────────┤
+    │     10       │
+    └──────────────┘
+    ```
+
+    The `PDAL_PipelineTable` function runs a PDAL pipeline on an input table. It is supposed that the input table
+    contains columns compatible with PDAL point clouds.
+
+    The pipeline can be provided either as a JSON file or as an inline JSON string as well. If the second parameter value
+    starts with "[" and ends with "]", it represents an inline JSON, otherwise it is a file path:
+
+    ```sql
+    SELECT
+    	*
+    FROM
+        PDAL_PipelineTable((SELECT X,Y,Z FROM ...), '[ {"type": "filters.tail", "count": 10} ]')
+    ;
     ```

--- a/extensions/pdal/docs/function_descriptions.csv
+++ b/extensions/pdal/docs/function_descriptions.csv
@@ -3,4 +3,5 @@ PDAL_Drivers,"Returns the list of supported stage types of a PDAL Pipeline.","",
 PDAL_Read,"Read and import a variety of point cloud data file formats using the PDAL library.","","SELECT * FROM PDAL_Read('./test/data/autzen_trim.laz');"
 PDAL_Info,"Read the metadata from point cloud file[s].","","SELECT * FROM PDAL_Info('./test/data/autzen_trim.la*');"
 PDAL_Pipeline,"Read and import a point cloud data file, applying also a custom processing pipeline to the data.","","SELECT * FROM PDAL_Pipeline('path/to/your/filename.las', 'path/to/your/pipeline.json');"
+PDAL_PipelineTable,"Apply a custom processing pipeline to the input table.","","SELECT * FROM PDAL_PipelineTable((SELECT X,Y,Z FROM ...), '[ {"type": "filters.tail", "count": 100} ]');"
 COPY_TO_PDAL,"Write collection of data points to a point cloud data file.","","COPY ( ... ) TO './test/data/autzen_new.laz' WITH (FORMAT PDAL, DRIVER 'LAS', CREATION_OPTIONS ('COMPRESSION=true', ...));"

--- a/extensions/pdal/docs/functions.md
+++ b/extensions/pdal/docs/functions.md
@@ -9,6 +9,7 @@
 | [`PDAL_Drivers`](#pdal_drivers) | Returns the list of supported stage types of a PDAL Pipeline. |
 | [`PDAL_Info`](#pdal_info) | Read the metadata from a point cloud file. |
 | [`PDAL_Pipeline`](#pdal_pipeline) | Read and import a point cloud data file, applying also a custom processing pipeline file to the data. |
+| [`PDAL_PipelineTable`](#pdal_pipelinetable) | Apply a custom processing pipeline to the input table. |
 | [`PDAL_Read`](#pdal_read) | Read and import a variety of point cloud data file formats using the PDAL library. |
 
 ----
@@ -95,7 +96,7 @@ SELECT * FROM PDAL_Info('./test/data/autzen_trim.laz');
 #### Signature
 
 ```sql
-PDAL_Pipeline (file_name VARCHAR, pipeline VARCHAR, options MAP(VARCHAR, VARCHAR))
+PDAL_Pipeline (file_name VARCHAR, pipeline_or_file_name VARCHAR, options MAP(VARCHAR, VARCHAR))
 ```
 
 #### Description
@@ -104,15 +105,45 @@ PDAL_Pipeline (file_name VARCHAR, pipeline VARCHAR, options MAP(VARCHAR, VARCHAR
 Read and import a variety of point cloud data file formats using the PDAL library,
 applying also a custom processing pipeline to the data.
 
-The pipeline can be provided either as a JSON file or as an inline JSON string. If the second parameter value
-starts with "[" and ends with "]", it represents an inline JSON, otherwise it is a file path.
+The pipeline can be provided either as a JSON file or as an inline JSON string. If the second parameter
+value starts with "[" and ends with "]", it represents an inline JSON, otherwise it is a file path.
+
 
 #### Example
 
 ```sql
 
 SELECT * FROM PDAL_Pipeline('path/to/your/filename.las', 'path/to/your/pipeline.json');
-SELECT * FROM PDAL_Pipeline('path/to/your/filename.las', '[ {"type": "filters.tail", "count": 100} ]');
+SELECT * FROM PDAL_Pipeline('path/to/your/filename.las', '[ {"type": "filters.tail", "count": 10} ]');
+
+```
+
+----
+
+### PDAL_PipelineTable
+
+#### Signature
+
+```sql
+PDAL_PipelineTable (table TABLE, pipeline_or_file_name VARCHAR)
+```
+
+#### Description
+
+
+Apply a custom processing pipeline to the input table. It is supposed that the input table contains columns
+compatible with PDAL point clouds.
+
+The pipeline can be provided either as a JSON file or as an inline JSON string. If the second parameter
+value starts with "[" and ends with "]", it represents an inline JSON, otherwise it is a file path.
+
+
+#### Example
+
+```sql
+
+SELECT * FROM PDAL_PipelineTable((SELECT X,Y,Z FROM PDAL_Read('path/to/your/filename.las')), 'path/to/your/pipeline.json');
+SELECT * FROM PDAL_PipelineTable((SELECT X,Y,Z FROM PDAL_Read('path/to/your/filename.las')), '[ {"type": "filters.tail", "count": 100} ]');
 
 ```
 


### PR DESCRIPTION
The extension adds:
+ The `PDAL_PipelineTable` function to run a PDAL pipeline on an input table.
  
   ```sql
   SELECT * FROM PDAL_PipelineTable((SELECT X,Y,Z FROM ...), '[ {"type": "filters.tail", "count": 100} ]');
   ``` 

+ Enable support of PDAL to load remote files.


