### PR TITLE
Add sitemap extension

### DIFF
--- a/extensions/sitemap/description.yml
+++ b/extensions/sitemap/description.yml
@@ -5,6 +5,7 @@ extension:
   language: C++
   build: cmake
   license: MIT
+  excluded_platforms: "windows_amd64_mingw"
   requires_toolchains: "libxml2;zlib"
   maintainers:
     - onnimonni


### PR DESCRIPTION
# Add sitemap extension

DuckDB extension for parsing XML sitemaps from websites with automatic discovery via robots.txt.

## Features
- 🔍 Automatic sitemap discovery from `/robots.txt`
- 🗂️ Sitemap index support - recursively fetches nested sitemaps
- 🔄 Retry logic with exponential backoff and `Retry-After` header support
- 📦 Gzip support for `.xml.gz` sitemaps
- 🌐 Multiple namespace support (standard + Google schemas)
- ⚡ SQL filtering with WHERE clauses

## Example Usage

```sql
-- Get all URLs from a sitemap
SELECT * FROM sitemap_urls('https://example.com');

-- Filter specific URLs
SELECT * FROM sitemap_urls('https://example.com')
WHERE url LIKE '%/blog/%';

-- Compose with http_get to fetch page content
SELECT s.url, h.body
FROM sitemap_urls('https://example.com') s
JOIN LATERAL (SELECT * FROM http_get(s.url)) h ON true
WHERE s.url LIKE '%/product/%'
LIMIT 10;
```

## Repository
https://github.com/midwork-finds-jobs/duckdb-sitemap

## Dependencies
- libxml2 (XML parsing)
- zlib (gzip decompression)
- http_request extension (from community)

## Testing
Tested with real-world sitemaps including:
- Google (44,100 URLs extracted)