### PR TITLE
Update sitemap extension to v0.1.1

### DIFF
--- a/extensions/sitemap/description.yml
+++ b/extensions/sitemap/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: sitemap
   description: Parse XML sitemaps from websites with automatic discovery via robots.txt
-  version: 0.1.0
+  version: 0.1.1
   language: C++
   build: cmake
   license: MIT
@@ -12,16 +12,22 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb-sitemap
-  ref: 6cd72d65fa3ee544cc25bac574094a8c4faeeb4d
+  ref: v0.1.1
 
 docs:
   hello_world: |
     -- Get all URLs from a sitemap (auto-prepends https://)
     SELECT * FROM sitemap_urls('example.com');
 
+    -- Get URLs from multiple sites
+    SELECT * FROM sitemap_urls(['example.com', 'google.com']);
+
     -- Filter specific URLs
     SELECT * FROM sitemap_urls('example.com')
     WHERE url LIKE '%/blog/%';
+
+    -- Ignore errors for invalid domains
+    SELECT * FROM sitemap_urls(['valid.com', 'invalid.com'], ignore_errors := true);
 
     -- Count URLs by type
     SELECT
@@ -41,11 +47,13 @@ docs:
     Features:
     - Automatic sitemap discovery from /robots.txt
     - Sitemap index support (nested sitemaps)
+    - Array support for processing multiple domains
     - Retry logic with exponential backoff
     - Respects Retry-After header on 429 responses
     - Gzip decompression for .xml.gz files
     - Multiple namespace support (standard + Google schemas)
     - SQL filtering with WHERE clauses
+    - Optional error ignoring for batch processing
 
     The function returns a table with columns:
     - url: Page URL (VARCHAR)
@@ -59,6 +67,7 @@ docs:
     - max_retries (INTEGER): Max retry attempts (default: 5)
     - backoff_ms (INTEGER): Initial backoff in ms (default: 100)
     - max_backoff_ms (INTEGER): Max backoff cap in ms (default: 30000)
+    - ignore_errors (BOOLEAN): Don't throw on failed fetches (default: false)
 
     Example with options:
     ```sql


### PR DESCRIPTION
## Update sitemap extension to v0.1.1

This PR updates the sitemap extension with new features from v0.1.1.

### New Features

**Array Support**
- Process multiple domains in a single call
- Example: `SELECT * FROM sitemap_urls(['site1.com', 'site2.com'])`

**Error Handling**
- New `ignore_errors` parameter (default: false)
- Throws on failed fetches by default for safety
- Set `ignore_errors := true` for batch processing
- Example: `SELECT * FROM sitemap_urls(['valid.com', 'invalid.com'], ignore_errors := true)`

### Changes
- Version: 0.1.0 → 0.1.1
- Ref: 6cd72d6 → v0.1.1
- Updated documentation with new features
- Added unit tests for array support and error handling

### Testing
All existing tests pass, plus new tests for:
- Single string parameter (existing behavior)
- Array of URLs parameter
- Empty array validation
- Error throwing behavior
- ignore_errors parameter

Release: https://github.com/midwork-finds-jobs/duckdb-sitemap/releases/tag/v0.1.1