### PR TITLE
Update sitemap extension to v0.1.2

### DIFF
--- a/extensions/sitemap/description.yml
+++ b/extensions/sitemap/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: sitemap
   description: Parse XML sitemaps from websites with automatic discovery via robots.txt
-  version: 0.1.1
+  version: 0.1.2
   language: C++
   build: cmake
   license: MIT
@@ -12,12 +12,15 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb-sitemap
-  ref: v0.1.1
+  ref: v0.1.2
 
 docs:
   hello_world: |
     -- Get all URLs from a sitemap (auto-prepends https://)
     SELECT * FROM sitemap_urls('example.com');
+
+    -- Direct sitemap URL (skips discovery)
+    SELECT * FROM sitemap_urls('https://example.com/sitemap.xml');
 
     -- Get URLs from multiple sites
     SELECT * FROM sitemap_urls(['example.com', 'google.com']);
@@ -45,7 +48,9 @@ docs:
     It automatically discovers sitemaps via robots.txt and supports recursive sitemap index traversal.
 
     Features:
-    - Automatic sitemap discovery from /robots.txt
+    - Multi-fallback sitemap discovery (robots.txt, /sitemap.xml, /sitemap_index.xml, HTML meta tags)
+    - Session caching for discovered sitemap locations
+    - Direct sitemap URL support (skips discovery)
     - Sitemap index support (nested sitemaps)
     - Array support for processing multiple domains
     - Retry logic with exponential backoff


### PR DESCRIPTION
## Update sitemap extension to v0.1.2

This PR updates the sitemap extension with enhanced sitemap discovery capabilities.

### New Features

**Multi-Fallback Sitemap Discovery**
Discovery now tries multiple methods in order:
1. Session cache (instant repeat queries)
2. robots.txt Sitemap directives
3. /sitemap.xml
4. /sitemap_index.xml
5. HTML `<link rel="sitemap">` tags

**Session Caching**
- Caches discovered sitemap locations per domain
- Subsequent queries skip discovery for much faster performance
- Cache persists for the DuckDB session

**Direct Sitemap URLs**
- Automatically detects when URL points to a sitemap file
- Skips discovery for direct paths like `sitemap_urls('https://example.com/sitemap.xml')`
- Works with .xml and .xml.gz files

### Changes
- Version: 0.1.1 → 0.1.2
- Ref: v0.1.1 → v0.1.2
- Updated documentation with discovery features
- Added direct sitemap URL examples

### Testing
- ✓ www.s-kaupat.fi: Successfully discovered via HTML parsing (79,320 URLs)
- ✓ Direct URLs: Skip discovery as expected
- ✓ Session caching: Second calls use cache (instant)
- ✓ All unit tests pass

### Commits
- 9cc8029: Multi-fallback discovery + caching
- 95885c8: Direct sitemap URL detection

Release: https://github.com/midwork-finds-jobs/duckdb-sitemap/releases/tag/v0.1.2