### PR TITLE
Update sitemap extension to v0.1.4

### DIFF
--- a/extensions/sitemap/description.yml
+++ b/extensions/sitemap/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: sitemap
   description: Parse XML sitemaps from websites with automatic discovery via robots.txt
-  version: 0.1.2
+  version: 0.1.4
   language: C++
   build: cmake
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb-sitemap
-  ref: v0.1.2
+  ref: v0.1.4
 
 docs:
   hello_world: |
@@ -29,8 +29,14 @@ docs:
     SELECT * FROM sitemap_urls('example.com')
     WHERE url LIKE '%/blog/%';
 
+    -- Bruteforce find sitemap (tries 587+ patterns)
+    SELECT bruteforce_find_sitemap('example.com') as sitemap_url;
+
     -- Ignore errors for invalid domains
     SELECT * FROM sitemap_urls(['valid.com', 'invalid.com'], ignore_errors := true);
+
+    -- Set custom user agent
+    SET sitemap_user_agent = 'MyBot/1.0';
 
     -- Count URLs by type
     SELECT
@@ -45,11 +51,13 @@ docs:
 
   extended_description: |
     The sitemap extension provides a table function for parsing XML sitemaps from websites.
-    It automatically discovers sitemaps via robots.txt and supports recursive sitemap index traversal.
+    It automatically discovers sitemaps via multiple fallback methods and supports recursive sitemap index traversal.
 
     Features:
     - Multi-fallback sitemap discovery (robots.txt, /sitemap.xml, /sitemap_index.xml, HTML meta tags)
     - Session caching for discovered sitemap locations
+    - Bruteforce finder (bruteforce_find_sitemap) - tries 587+ common sitemap URL patterns
+    - Custom user agent via SET sitemap_user_agent
     - Direct sitemap URL support (skips discovery)
     - Sitemap index support (nested sitemaps)
     - Array support for processing multiple domains
@@ -82,6 +90,20 @@ docs:
         max_depth := 5,
         max_retries := 10
     ) WHERE url LIKE '%/product/%';
+    ```
+
+    Bruteforce sitemap discovery (scalar function):
+    ```sql
+    -- Find sitemap by trying 587+ common patterns
+    SELECT bruteforce_find_sitemap('https://example.com') as sitemap_url;
+    -- Returns first working sitemap URL or NULL
+
+    -- Patterns tested include:
+    -- /sitemap.xml, /sitemap_index.xml
+    -- /sitemap/sitemap.xml, /sitemaps/sitemap-index.xml
+    -- /en/sitemap.xml, /de/sitemap.xml
+    -- /pub/media/sitemap.xml
+    -- And 580+ more variations
     ```
 
     Compose with http_request to fetch page content:


### PR DESCRIPTION
## Update sitemap extension to v0.1.4

### New in v0.1.4

**Configurable User Agent**
```sql
-- Set custom user agent (default: 'DuckDB-Sitemap/1.0')
SET sitemap_user_agent = 'MyBot/1.0 (https://example.com/bot)';

-- All subsequent requests use this header
SELECT * FROM sitemap_urls('example.com');
SELECT bruteforce_find_sitemap('example.com');
```

### Also includes from v0.1.3

**bruteforce_find_sitemap() Scalar Function**
- Tries 587+ common sitemap URL patterns
- Returns first working sitemap URL or NULL

### Also includes from v0.1.2

**Multi-Fallback Discovery**
1. Session cache
2. robots.txt
3. /sitemap.xml
4. /sitemap_index.xml
5. HTML meta tags

### Changes
- Version: 0.1.3 → 0.1.4
- Ref: v0.1.3 → v0.1.4
- Added sitemap_user_agent setting
- Updated documentation

Release: https://github.com/midwork-finds-jobs/duckdb-sitemap/releases/tag/v0.1.4