### PR TITLE
http_request: v0.5.0 - add http_user_agent setting

### DIFF
--- a/extensions/http_request/description.yml
+++ b/extensions/http_request/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: http_request
   description: HTTP client extension for DuckDB with GET/POST/PUT/PATCH/DELETE and byte-range requests
-  version: 0.4.0
+  version: 0.5.0
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb_http_request
-  ref: fa3a7438c658a423f607a525673156034bf46244
+  ref: b4ea40f3e8f1287db8f7a729c10fddb4dda30946
 
 docs:
   hello_world: |
@@ -51,5 +51,6 @@ docs:
     - Convenience fields: content_type, content_length
     - Respects duckdb http and proxy settings
     - Configurable concurrency via http_max_concurrency setting (default: 32)
+    - Global User-Agent override via http_user_agent setting
 
     Uses DuckDB's built-in httplib for HTTP connections.


### PR DESCRIPTION
## Summary
- Add `http_user_agent` setting for global User-Agent override

## Usage
```sql
SET http_user_agent = 'MyApp/1.0';
SELECT http_get('https://api.example.com/');
```

Per-request headers still override the global setting.