### PR TITLE
Update html_query to 0.6.0 - add Next.js RSC support

### DIFF
--- a/extensions/html_query/description.yml
+++ b/extensions/html_query/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: html_query
-  description: Query HTML using CSS selectors, extract JSON from LD+JSON and JavaScript variables
-  version: 0.1.1
+  description: Query HTML using CSS selectors, extract JSON from LD+JSON, JavaScript variables, and Next.js RSC
+  version: 0.6.0
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb_html_query
-  ref: c7c101b27a0123ccb87526e9aa2e7c6b512e3b0a
+  ref: a78df2bfb6ad547ceae25cac70277bbaf0ecba62
 
 docs:
   hello_world: |
@@ -101,7 +101,7 @@ docs:
 
     ### `html_extract_json(html, selector, var_pattern)`
 
-    Extract JSON from HTML scripts. Supports LD+JSON and JavaScript variables.
+    Extract JSON from HTML scripts. Supports LD+JSON, JavaScript variables, and Next.js RSC.
     Always returns a JSON array.
 
     **Examples:**
@@ -111,6 +111,9 @@ docs:
 
     -- Extract JS variable (decodes hex escapes like \x22)
     SELECT html_extract_json(html, 'script', 'var config')->0 FROM pages;
+
+    -- Extract JSON from Next.js RSC payloads by key name
+    SELECT html_extract_json(html, 'script', '@nextjs_rsc:productDisplay')->0 FROM pages;
     ```
 
     ## CSS Selectors


### PR DESCRIPTION
## Summary
- Extract JSON from React Server Components payloads