### PR TITLE
Extend to v1.5-variegata branch

### DIFF
--- a/extensions/mlpack/description.yml
+++ b/extensions/mlpack/description.yml
@@ -13,6 +13,7 @@ extension:
 repo:
   github: eddelbuettel/duckdb-mlpack
   ref: 1c1f71363b06afcf376e538a7b5e78ebfc7f8c0a
+  ref_next: 013bee3310127e1523763b4a4419a18027f205d6
 
 docs:
   hello_world: |


### PR DESCRIPTION
Adding a `ref_next` to a v1.5-variegata branch in the duckdb-mlpack repo.  It built without changes, the binary came up as 1.4.4-dev4686.

