### PR TITLE
Update http_request to v0.6.0

### DIFF
--- a/extensions/http_request/description.yml
+++ b/extensions/http_request/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: http_request
   description: HTTP client extension for DuckDB with GET/POST/PUT/PATCH/DELETE and byte-range requests
-  version: 0.5.0
+  version: 0.6.0
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb_http_request
-  ref: b4ea40f3e8f1287db8f7a729c10fddb4dda30946
+  ref: fe4e6fc3e2eaecd409a396477927d1f181562e9f
 
 docs:
   hello_world: |
@@ -52,5 +52,7 @@ docs:
     - Respects duckdb http and proxy settings
     - Configurable concurrency via http_max_concurrency setting (default: 32)
     - Global User-Agent override via http_user_agent setting
+    - Request caching to prevent duplicate requests (http_request_cache setting)
+    - Headers support both STRUCT and MAP syntax
 
     Uses DuckDB's built-in httplib for HTTP connections.


### PR DESCRIPTION
## Changes

- Add request caching to prevent duplicate HTTP requests within same query
- Fix crash when using MAP syntax for headers (`headers := MAP {'key': 'value'}`)
- Headers now support both STRUCT and MAP syntax

## New settings

- `http_request_cache` (default: true) - Cache HTTP responses within query execution to prevent duplicate requests

## Bug fixes

- Fixes crash when using `headers := MAP {...}` syntax (was only supporting STRUCT)