### PR TITLE
Add web_search extension

### DIFF
--- a/extensions/web_search/description.yml
+++ b/extensions/web_search/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: web_search
   description: Query Google Custom Search API directly from SQL with filter pushdowns
-  version: 0.3.0
+  version: 0.4.0
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb-web-search
-  ref: ebfc4ec83800dc1a87f5b0a4c5f9b56e4c398007
+  ref: 7993d775af7f1ab07bb4be1a0a1a68cf65ab8e9b
 
 docs:
   hello_world: |
@@ -44,6 +44,7 @@ docs:
     ### Filter Pushdowns (WHERE clause)
     - `site = 'example.com'` / `site IN (...)` / `site != '...'`
     - `language = 'en'` / `country = 'US'` / `file_type = 'pdf'`
+    - `exact_match = 'phrase'` / `term IN (...)` / `term != '...'`
     - `ORDER BY date DESC/ASC`
     - `LIMIT` optimization
 


### PR DESCRIPTION
## Summary
DuckDB extension for querying Google Custom Search API directly from SQL.

## Features
- `google_search(query)` - Web search table function
- `google_image_search(query)` - Image search table function
- Filter pushdowns: `site`, `language`, `country`, `file_type`, `term`, `exact_match`
- `ORDER BY date` pushdown
- `LIMIT` pushdown optimization
- `pagemap` as JSON type (arrow operator access)
- Graceful 429 rate limit handling
- `COPY TO` with `FORMAT google_pse_annotation` for PSE annotation XML export

## Installation
```sql
INSTALL web_search FROM community;
LOAD web_search;
```

## Quick Example
```sql
CREATE SECRET google_search (
    TYPE google_search,
    key 'YOUR_API_KEY',
    cx 'YOUR_SEARCH_ENGINE_ID'
);

SELECT title, link, snippet
FROM google_search('duckdb database')
WHERE site = 'github.com'
LIMIT 10;

-- Exact phrase and term filtering
SELECT title, link
FROM google_search('engineering jobs')
WHERE exact_match = 'systems engineering'
  AND term IN ('remote', 'hybrid')
LIMIT 10;
```

## Repository
https://github.com/midwork-finds-jobs/duckdb-web-search