### PR TITLE
markdown: bump to v1.3.9

### DIFF
--- a/extensions/markdown/description.yml
+++ b/extensions/markdown/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: markdown
   description: Read, analyze, and write Markdown files with block-level document representation and inline element support
-  version: 1.3.7
+  version: 1.3.9
   language: C++
   build: cmake
   license: MIT
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: teaguesterling/duckdb_markdown
-  ref: 'd8885080631029751dd2415b677962fe8854476a'
+  ref: 'b2244eb2205e521e2ddd1c043ed5917c906be142'
 
 docs:
   hello_world: |


### PR DESCRIPTION
Fix WASM compatibility issue (teaguesterling/duckdb_markdown#13) and Windows frontmatter regex matching bug.

**v1.3.8**: WASM fix - cmark-gfm function pointer casts caused indirect call signature mismatch errors in WebAssembly.

**v1.3.9**: Windows fix - MSVC regex `^` anchor wasn't correctly matching only at the start of the string, causing false positive frontmatter detection.

🤖 Generated with [Claude Code](https://claude.ai/code)