### PR TITLE
Upgrade observefs to v0.4.5

### DIFF
--- a/extensions/observefs/description.yml
+++ b/extensions/observefs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: observefs
   description: Provides IO observability to filesystem
-  version: 0.4.4
+  version: 0.4.5
   language: C++
   build: cmake
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: dentiny/duckdb-filesystem-observability
-  ref: f0ee3540d47256178449d84ec503404acfc3f8ba
+  ref: 00eeeca0b208fcbc0c4d990c95f29c76ebc80439
 
 docs:
   hello_world: |
@@ -21,6 +21,7 @@ docs:
     This extension provides observability to duckdb filesystems.
     It supports a few key features:
     - 100% compatible with duckdb httpfs
+    - Record latency for most of the IO operations (open, read, write, etc)
     - Provides both process-wise and bucket-wise latency stats (including histogram and quantile estimation) to all read operations
     - Provides cache access insight to duckdb external file cache
     - Allows registering ANY duckdb compatible filesystems (i.e., azure filesystem)


### PR DESCRIPTION
Upgrade observefs to v0.4.5, which records most of the IO operations latency.