### PR TITLE
Fix pre-release deploy

### DIFF
--- a/.github/workflows/_extension_deploy.yml
+++ b/.github/workflows/_extension_deploy.yml
@@ -18,6 +18,11 @@ on:
       duckdb_version:
         required: true
         type: string
+      # Override the duckdb tag for deployment (e.g., for releases)
+      duckdb_tag:
+        required: false
+        type: string
+        default: ""
       # Extension CI tools version to use
       ci_tools_version:
         required: true
@@ -131,8 +136,12 @@ jobs:
           git config --global --add safe.directory '*'
           cd duckdb
           git fetch --tags
-          export DUCKDB_VERSION=`git tag --points-at HEAD`
-          export DUCKDB_VERSION=${DUCKDB_VERSION:=`git log -1 --format=%h`}
+          if [ -n "${{ inputs.duckdb_tag }}" ]; then
+            export DUCKDB_VERSION="${{ inputs.duckdb_tag }}"
+          else
+            export DUCKDB_VERSION=`git tag --points-at HEAD`
+            export DUCKDB_VERSION=${DUCKDB_VERSION:=`git log -1 --format=%h`}
+          fi
           cd ..
           git fetch --tags
           export EXT_VERSION=`git tag --points-at HEAD`

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,6 +145,7 @@ jobs:
     with:
       deploy_latest: true
       duckdb_version: ${{ inputs.duckdb_version || 'v1.4.3' }}
+      duckdb_tag: ${{ inputs.duckdb_tag || '' }}
       ci_tools_version: 'v1.4-andium'
       exclude_archs: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_EXCLUDE_PLATFORMS }}
       opt_in_archs: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_OPT_IN_PLATFORMS}}


### PR DESCRIPTION
This should resolve the issue where community extensions builds targeting a non-existent release (as is done in duckdb's release process) are uploaded to the versioned path instead of the tag-based path