### PR TITLE
Update otlp extension to v0.3.0

### DIFF
--- a/extensions/otlp/description.yml
+++ b/extensions/otlp/description.yml
@@ -6,6 +6,7 @@ extension:
   build: cmake
   license: MIT
   excluded_platforms: "wasm_mvp;wasm_threads;linux_amd64_musl"
+  requires_toolchains: rust
   maintainers:
     - smithclay
 


### PR DESCRIPTION
- Bumps to OTLP extension v0.3.0
- Builds against duckdb v1.4.3
- Adds support for reading protobuf files in wasm
- Uses new standardized schema used in other OTLP projects
- Fairly major refactor: core extension code now uses https://github.com/smithclay/otlp2records **
- Drops support for some wasm platforms and linux musl (not supported by our new shared rust crate)

** This isn't a pure rust extension (yet) to preserve support for wasm_eh builds