### PR TITLE
Update http_request to v0.7.0

### DIFF
--- a/extensions/http_request/description.yml
+++ b/extensions/http_request/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: http_request
   description: HTTP client extension for DuckDB with GET/POST/PUT/PATCH/DELETE and byte-range requests
-  version: 0.6.0
+  version: 0.7.0
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb_http_request
-  ref: fe4e6fc3e2eaecd409a396477927d1f181562e9f
+  ref: b07cfb2335db8e3ef8135d7bb3c78085726bde1f
 
 docs:
   hello_world: |
@@ -54,5 +54,6 @@ docs:
     - Global User-Agent override via http_user_agent setting
     - Request caching to prevent duplicate requests (http_request_cache setting)
     - Headers support both STRUCT and MAP syntax
+    - Redirect control via http_follow_redirects setting (default: true)
 
     Uses DuckDB's built-in httplib for HTTP connections.


### PR DESCRIPTION
## Summary
- Add `http_follow_redirects` setting to control redirect auto-following
- Default: true (follows redirects). Set to false to get 302 status with Location header
- Enables manual redirect chain tracking for SEO analysis

## Test plan
- Extension builds successfully on all platforms
- Tests pass (including new redirect setting tests)

Fixes https://github.com/midwork-finds-jobs/duckdb_http_request/issues/2