### PR TITLE
Upgrade cache httpfs 0.12.2

### DIFF
--- a/extensions/cache_httpfs/description.yml
+++ b/extensions/cache_httpfs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: cache_httpfs
   description: Read cached filesystem for httpfs
-  version: 0.12.1
+  version: 0.12.2
   language: C++
   build: cmake
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: dentiny/duck-read-cache-fs
-  ref: e66d74d25bcc3866c036a65c435d547c1fccf902
+  ref: ec98b83797a85c6f6ddaf0bdcd5c6397639e5316
 
 docs:
   hello_world: |


### PR DESCRIPTION
This PR upgrades cache httpfs to v0.12.2, changelog see https://github.com/dentiny/duck-read-cache-fs/pull/384