### PR TITLE
Update http_request to v0.8.0

### DIFF
--- a/extensions/http_request/description.yml
+++ b/extensions/http_request/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb_http_request
-  ref: 069e6ff997673daeda30fd6180887c459fcdfc30
+  ref: e55035fe799fc7173fa8b3706e1d88c866a048d3
 
 docs:
   hello_world: |
@@ -55,7 +55,6 @@ docs:
     - Request caching to prevent duplicate requests (http_request_cache setting)
     - Headers support both STRUCT and MAP syntax
     - Redirect control via http_follow_redirects setting (default: true)
-    - Case-insensitive header access: headers normalized to Title-Case
-    - http_header() function for case-insensitive header lookup
+    - HTTP_HEADERS type with case-insensitive [] access (headers['Content-Type'] = headers['content-type'])
 
     Uses DuckDB's built-in httplib for HTTP connections.


### PR DESCRIPTION
## Changes
- Add `http_follow_redirects` setting to disable auto-follow redirects (default: true)
- Add `HTTP_HEADERS` type with case-insensitive `[]` access

## Details

### Redirect Control
```sql
SET http_follow_redirects = false;
SELECT status, headers['Location'] FROM http_get('https://example.com/redirect');
-- Returns 301/302 with Location header instead of following
```

### Case-Insensitive Header Access
HTTP headers are case-insensitive per RFC 7230. The new `HTTP_HEADERS` type provides native case-insensitive `[]` operator:

```sql
-- All return the same value
SELECT headers['Content-Type'] FROM http_get('https://example.com/');
SELECT headers['content-type'] FROM http_get('https://example.com/');
SELECT headers['CONTENT-TYPE'] FROM http_get('https://example.com/');
```