### PR TITLE
Add html_readability extension

### DIFF
--- a/extensions/html_readability/description.yml
+++ b/extensions/html_readability/description.yml
@@ -5,14 +5,14 @@ extension:
   language: Rust
   build: cargo
   license: MIT
-  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw;linux_amd64_musl"
+  excluded_platforms: "windows_amd64_rtools;windows_amd64_mingw;linux_amd64_musl"
   requires_toolchains: "rust"
   maintainers:
     - onnimonni
 
 repo:
   github: midwork-finds-jobs/duckdb-html-readability
-  ref: bc5ddffaf9dddb36a05906ae9730afcabfe490c0
+  ref: 53ebdc43c1014db969d9bb50359e0eb9d2cf5e6d
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary
Add `html_readability` extension that extracts readable content from HTML using Mozilla's Readability algorithm.

Mozilla's Readability is the gold standard for extracting readable text from HTML documents. It powers the **Reader Mode** in Firefox and Safari, providing clutter-free viewing of web articles by stripping away navigation, ads, and other non-essential elements.

## Extension Details
- **Function**: `parse_html(html VARCHAR)` 
- **Returns**: `STRUCT(title VARCHAR, content VARCHAR, text VARCHAR)`
- **Implementation**: Rust, using the [readability](https://crates.io/crates/readability) crate (a Rust port of Mozilla's Readability.js)

## Example
```sql
SELECT parse_html('<html><head><title>Hello</title></head><body><article><p>World</p></article></body></html>');
-- Returns: {'title': Hello, 'content': <p>World</p>, 'text': World}
```

## Repository
https://github.com/midwork-finds-jobs/duckdb-html-readability