### PR TITLE
markdown: bump to v1.3.10

### DIFF
--- a/extensions/markdown/description.yml
+++ b/extensions/markdown/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: markdown
   description: Read, analyze, and write Markdown files with block-level document representation and inline element support
-  version: 1.3.9
+  version: 1.3.10
   language: C++
   build: cmake
   license: MIT
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: teaguesterling/duckdb_markdown
-  ref: 'b2244eb2205e521e2ddd1c043ed5917c906be142'
+  ref: 'bc6ddb1e14ca3feb5c4b51ba561ca7542a950d98'
 
 docs:
   hello_world: |


### PR DESCRIPTION
Another attempt at fixing the function pointer casts in cmark-gfm for WASM compatibility (ref: https://github.com/teaguesterling/duckdb_markdown/issues/13)