### PR TITLE
Update webdavfs to duckdb 1.4.3

### DIFF
--- a/extensions/webdavfs/description.yml
+++ b/extensions/webdavfs/description.yml
@@ -12,7 +12,7 @@ extension:
   vcpkg_commit: 'dd3097e305afa53f7b4312371f62058d2e665320'
 repo:
   github: midwork-finds-jobs/duckdb-webdavfs
-  ref: 00894c37e652a256a26299b7023fc000d47a85c5
+  ref: 981500f7f10bee044d1e9eb92a62d1494cf987fa
 
 docs:
   hello_world: |


### PR DESCRIPTION
Updates webdavfs extension ref to support DuckDB 1.4.3.

Changes in referenced commit:
- Updated duckdb submodule from v1.4.2 to v1.4.3
- Updated extension-ci-tools submodule to v1.4.3