### PR TITLE
Update sshfs to duckdb 1.4.3

### DIFF
--- a/extensions/sshfs/description.yml
+++ b/extensions/sshfs/description.yml
@@ -12,7 +12,7 @@ extension:
   vcpkg_commit: 'dd3097e305afa53f7b4312371f62058d2e665320'
 repo:
   github: midwork-finds-jobs/duckdb-sshfs
-  ref: d1884ceb1e3912d8d636998156a5016c3abe87be
+  ref: 1679e46e57960ec62523fe7853942d2f97e2c952
 
 docs:
   hello_world: |


### PR DESCRIPTION
Updates sshfs extension ref to support DuckDB 1.4.3.

Changes in referenced commit:
- Updated duckdb submodule from v1.4.2 to v1.4.3
- Updated extension-ci-tools submodule to v1.4.3