### PR TITLE
Add mssql extension (Microsoft SQL Server connector via native TDS)

### DIFF
--- a/extensions/mssql/description.yml
+++ b/extensions/mssql/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: mssql
   description: "Connect DuckDB to Microsoft SQL Server via native TDS (including TLS)."
-  version: "0.1.5"
+  version: "0.1.6"
   language: "C++"
   build: "cmake"
   licence: "MIT"
@@ -18,7 +18,7 @@ extension:
 
 repo:
   github: "hugr-lab/mssql-extension"
-  ref: "v0.1.5"
+  ref: "v0.1.6"
 
 docs:
   hello_world: |


### PR DESCRIPTION
This PR adds a new community extension: mssql — a DuckDB connector for Microsoft SQL Server implemented via a native TDS protocol stack.

Why

Many data stacks still rely on SQL Server, and having a native DuckDB extension makes it possible to query MSSQL data directly from DuckDB with pushdown and proper catalog integration.

What’s included
	•	New extension metadata file:
	•	extensions/mssql/description.yml

Key features
	•	Native TDS protocol implementation (no ODBC required)
	•	TLS / encryption support (mbedTLS)
	•	Connection pooling
	•	Catalog integration:
	•	schemas
	•	tables
	•	views
	•	Query pushdown:
	•	column projection
	•	filter pushdown
	•	DDL support: catalog-driven CREATE / DROP / ALTER
	•	DML support:
	•	INSERT, including INSERT ... RETURNING
	•	CTAS support is in progress

Repository

Source code: https://github.com/hugr-lab/mssql-extension

```sql
INSTALL mssql FROM community;
LOAD mssql;

ATTACH 'mssql://user:password@host:1433?database=demo&encrypt=true' AS ms;
FROM ms.dbo.table LIMIT 10;
```

Notes
	•	The extension is open-source (MIT).
	•	Tested primarily on:
	•	Linux amd64
	•	macOS arm64
	•	Windows amd64 (CI coverage in progress / improving)

If you’d like any adjustments to the metadata file (supported platforms, build config, etc.), I’m happy to iterate.