### PR TITLE
Add h5db extension

### DIFF
--- a/extensions/h5db/description.yml
+++ b/extensions/h5db/description.yml
@@ -1,17 +1,17 @@
 extension:
   name: h5db
   description: A DuckDB extension for reading HDF5 files.
-  version: 0.1.0
+  version: 0.1.1
   language: C++
   build: cmake
   license: MIT
-  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads"
-  requires_toolchains: "python3"
+  excluded_platforms: "windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads"
+  requires_toolchains: "vcpkg;python3"
   maintainers:
     - jokasimr
 repo:
   github: jokasimr/h5db
-  ref: v0.1.0
+  ref: v0.1.1
 
 docs:
   hello_world: |


### PR DESCRIPTION
This PR adds the h5db extension to the community registry.

It is an(other) extension for reading HDF5 files.
Made a new extension because my use case needed some features that are currently not in the existing `hdf5` community extension.

**Features**

* `h5_tree()` table function for listing groups and datasets in the file.
* `h5_read()` table function for reading datasets.
* `h5_attributes()` table function for accessing attributes.
* Multiple datasets: Read and combine multiple datasets in a single query.
* Multi-dimensional arrays: Support for 1D-4D datasets.
* Projection pushdown: Only reads datasets that are actually needed.
* Index column: Optionally adds an `index` column that supports pushing down constant "range" like filters (`>`, `<=`, `BETWEEN`, etc), to allow efficient selective reads from datasets.
* Can read datasets that are larger than memory.

Collaboration and contributions very welcome!

**Extension Details:**

* **Name:** h5db
* **Description:** A DuckDB extension for reading HDF5 files.
* **Repository:** https://github.com/jokasimr/h5db

