### PR TITLE
crawler: bump to v0.2.0 - add read_html() table function

### DIFF
--- a/extensions/crawler/description.yml
+++ b/extensions/crawler/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: crawler
   description: SQL-native web crawler with HTML extraction and MERGE support
-  version: 0.1.0
+  version: 0.2.0
   language: C++
   build: cmake
   license: MIT
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb-crawler
-  ref: 8db43f686788f97b0f7cbba8db3d7d38e194bd05
+  ref: 885a57c5da861b140fb451571c9d6e89d8413521
 
 docs:
   hello_world: |
@@ -26,10 +26,17 @@ docs:
     - `crawl()` table function with automatic rate limiting and robots.txt compliance
     - `crawl_url()` for LATERAL joins
     - `sitemap()` for XML sitemap parsing
+    - `read_html()` for Google Sheets-style IMPORTHTML (tables, lists, JS variables)
     - `jq()` and `htmlpath()` functions for CSS selector-based extraction
     - `html.readability` for article extraction
     - `html.schema` for JSON-LD/microdata parsing
     - `CRAWLING MERGE INTO` syntax for upsert operations
+
+    Example with read_html (like Google Sheets =IMPORTHTML):
+    ```sql
+    SELECT * FROM read_html('https://en.wikipedia.org/wiki/...', 'table.wikitable', 1);
+    SELECT * FROM read_html('https://example.com/page', 'js=jobs');
+    ```
 
     Example with extraction:
     ```sql


### PR DESCRIPTION
## Summary
- Bump crawler extension to v0.2.0
- Add `read_html()` table function (Google Sheets-style IMPORTHTML)

## New Features
- **HTML tables**: `read_html(url, 'table.class', index)`
- **HTML lists**: `read_html(url, 'ul', index)` 
- **JS variables**: `read_html(url, 'js=varname')`
- Auto type inference (BIGINT, DOUBLE, VARCHAR)
- Wikipedia citation removal for *.wikipedia.org
- 1-based index like Google Sheets

## Example
```sql
SELECT * FROM read_html('https://en.wikipedia.org/wiki/List_of_programming_languages', 'div.div-col ul', 1);
SELECT * FROM read_html('https://example.com/careers', 'js=jobs');
```