### PR TITLE
crawler: update ref with read_html tests

### DIFF
--- a/extensions/crawler/description.yml
+++ b/extensions/crawler/description.yml
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb-crawler
-  ref: 885a57c5da861b140fb451571c9d6e89d8413521
+  ref: dd318c51c679a5de891b4470b5fb8d6b05faf4f2
 
 docs:
   hello_world: |


### PR DESCRIPTION
Updates crawler extension ref to include read_html() test coverage for Wikipedia table extraction.

Changes in this update:
- Added comprehensive tests for `read_html()` function
- Tests verify type inference (BIGINT, DOUBLE, VARCHAR)
- Tests verify Wikipedia table extraction works correctly