### PR TITLE
:beer:  An extension to list locally installed software with  `brew` / `Homebrew`

### DIFF
--- a/extensions/brew/description.yml
+++ b/extensions/brew/description.yml
@@ -7,15 +7,7 @@ extension:
   license: MIT
   maintainers:
     - adriens
-  excluded_platforms:
-    - "windows_arm64"
-    - "windows_amd64"
-    - "windows_amd64_mingw"
-    - "windows_amd64_rtools"
-    - "windows_amd64_mingw"
-    - "wasm_threads"
-    - "wasm_eh"
-    - "wasm_mvp"
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64;windows_amd64_mingw;windows_arm64;windows_amd64_rtools"
     
 
 repo:


### PR DESCRIPTION
# :grey_question: About

Inpired by [`osquery`](https://github.com/osquery/osquery) and for personal reporting purposes, I needed to be able to efficiently list all the software I installed with [`brew`](https://brew.sh/).

The main idea is to : 

1. Be able to to list `casks`, `packages` and formulas as tables and structured/typed contents
2. Do reporting from `quarto` to create nice looking reports

Therefore I tried to build the `brew` extension, and I'm preety happy as it's good enough to do the job.

```sql
from brew_casks();
``` 

<img width="949" height="175" alt="image" src="https://github.com/user-attachments/assets/4c0e08fc-2afc-40a6-86f3-320032d65ce1" />


```sql
from brew_packages();
```
<img width="938" height="910" alt="image" src="https://github.com/user-attachments/assets/929b2468-8ec4-4662-9e4b-af60a7553a8e" />

<img width="719" height="177" alt="image" src="https://github.com/user-attachments/assets/831dfd42-c5c3-4a94-ac25-5e2f2ce3d385" />


```sql
from brew_formulas();
```

<img width="937" height="869" alt="image" src="https://github.com/user-attachments/assets/c87fae16-ee93-4d68-a254-12e9bb3ad4fc" />


Please let me know if it's OK or what should be done.

# :telescope: Perspectives

A bit like for [`osquery`](https://github.com/osquery/osquery), and depending on this PR sucess, I have in the pipe to implement the same philosphy for : 

- `snap` packages
- standard `dpkg` applications

... always in the same goal : make software reporting easy to handle by datascientists.