### PR TITLE
Add chess extension

### DIFF
--- a/extensions/chess/description.yml
+++ b/extensions/chess/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: chess
   description: A DuckDB extension for parsing and analyzing chess games in PGN format.
-  version: 0.1.1
+  version: 0.1.2
   language: Rust
   build: cmake
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: dotneB/duckdb-chess
-  ref: v0.1.1
+  ref: v0.1.2
 
 docs:
   hello_world: |


### PR DESCRIPTION
This PR adds the chess extension to the community registry.

It's an extension for parsing and analyzing chess games in PGN format.

Some notes on the toolchain:  
Extension development started using the [rust community template](https://github.com/duckdb/extension-template-rs) but later moved to using [redraiment/duckdb-ext-rs-template](https://github.com/redraiment/duckdb-ext-rs-template) for a pure rust edition workflow.

It uses a pinned version of [redraiment/cargo-duckdb-ext-tools](https://github.com/redraiment/cargo-duckdb-ext-tools) with a fix for [windows build](https://github.com/redraiment/cargo-duckdb-ext-tools/pull/2)

The last bit of python used in the project were the integration tests with [duckdb-sqllogictest-python](https://github.com/duckdb/duckdb-sqllogictest-python), there were no rust equivalent. I created a runner in Rust [duckdb-sqllogictest-rs](https://github.com/dotneB/duckdb-sqllogictest-rs). At the moment, it doesn't support all that is supported in duckdb-sqllogictest-python, only what was needed in my test suites to ensure the same duckdb_chess tests could run in both SLT versions.

I kept the CI and Makefile commands (makes the Makefile a bit ugly) from the community template, to be able to ensure that building with the community CI tools, without require any of cargo-duckdb-ext-tools, would succeed when submitting to the community registry. So in theory, it should be good.
