### PR TITLE
Update `lsh` extension to `v0.2.2`

### DIFF
--- a/extensions/lsh/description.yml
+++ b/extensions/lsh/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: lsh
   description: Extension for locality-sensitive hashing (LSH)
-  version: 0.2.1
+  version: 0.2.2
   language: Rust
   build: cargo
   license: MIT
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: princeton-ddss/lsh
-  ref: 1df52d0ada664e9282d6c7c5d572f743163e2874
+  ref: d9fcfc34fc6909f35d93d481b5885b8e4989402b
 
 docs:
   hello_world: |


### PR DESCRIPTION
The extension has been adapted to a new DuckDB release (`v1.4.4`).

Thanks for your help!