### PR TITLE
markdown: bump to v1.4.0

### DIFF
--- a/extensions/markdown/description.yml
+++ b/extensions/markdown/description.yml
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: teaguesterling/duckdb_markdown
-  ref: 'ff99ce0948e01bfe4f89019732646e0061beaa9f'
+  ref: '3903fd0c027e9661f299ffdfba75dbb1047a9db2'
 
 docs:
   hello_world: |


### PR DESCRIPTION
**Full WebAssembly (WASM) support** - All markdown functions now work in browser environments via DuckDB-WASM.

1. **Static Library Linking**: cmark-gfm is now statically linked into the WASM side module via DuckDB's `LINKED_LIBS` mechanism, ensuring all symbols are embedded rather than left as unresolved imports.
2. **Function Pointer Compatibility**: Added wrapper functions to fix cmark-gfm's function pointer casts that violate WASM's strict `call_indirect` type checking.
See: [docs/WASM.md](https://github.com/teaguesterling/duckdb_markdown/blob/main/docs/WASM.md)
