### PR TITLE
Fix doc_test: allow unsigned extensions during doc generation

### DIFF
--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -44,9 +44,9 @@ jobs:
     - name: Install downloaded extension
       if: ${{ inputs.extension_name != '' }}
       env:
-        NAME: ${{ inputs.extension_name }} 
+        NAME: ${{ inputs.extension_name }}
       run: |
-        ./duckdb -c "SET extension_directory = 'build/extension_dir'; FORCE INSTALL 'build/downloaded/$NAME.duckdb_extension';"
+        ./duckdb -unsigned -c "SET extension_directory = 'build/extension_dir'; FORCE INSTALL 'build/downloaded/$NAME.duckdb_extension';"
 
     - name: Generate docs
       run: |


### PR DESCRIPTION
## Problem

The `doc_test` job fails for extension PRs because it tries to `FORCE INSTALL` extension artifacts that aren't signed yet. 

Example failure: https://github.com/duckdb/community-extensions/actions/runs/21458582834/job/61806822113

```
IO Error: Attempting to install an extension file that doesn't have a valid signature
```

The artifacts are only signed during the deploy phase, but `doc_test` runs on the unsigned build artifacts.

## Solution

Add the `-unsigned` flag to the duckdb CLI when installing extensions for documentation generation. This allows the doc generation to work with the pre-signing artifacts.

## Changes

```diff
- ./duckdb -c "SET extension_directory = 'build/extension_dir'; FORCE INSTALL 'build/downloaded/$NAME.duckdb_extension';"
+ ./duckdb -unsigned -c "SET extension_directory = 'build/extension_dir'; FORCE INSTALL 'build/downloaded/$NAME.duckdb_extension';"
```