### PR TITLE
:beer: `brew` > Add the `brew_dependencies()` function

### DIFF
--- a/extensions/brew/description.yml
+++ b/extensions/brew/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: brew
   description: Get locally homebrew casks, packages and formulas and their dependencies as nicely types tables
-  version: 0.6.0
+  version: 0.6.1
   language: C++
   build: cmake
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: adriens/duckdb-brew
-  ref: 344c4dd3191dd0f5f4e883f9770a492023adfb7c
+  ref: 5d7fddcd6d09f0e82804f5d175254b718c6c09f5
 
 docs:
   hello_world: |


### PR DESCRIPTION
# :grey_question: About

I have just released the [`v0.6.1`](https://github.com/adriens/duckdb-brew/releases/tag/v0.6.1) which make relationship management between packages much easier.

:point_up: Prior to this release, people has to manually perform the `UNNEST` command
:point_right: Now, they just have to run : 

```sql
FROM brew_dependencies();
```

<img width="332" height="534" alt="image" src="https://github.com/user-attachments/assets/8d7b001a-6352-4615-b9ab-21fa16ff69cb" />
