### PR TITLE
:beer: `brew` > Add function descriptions to the documentation

### DIFF
--- a/extensions/brew/docs/function_descriptions.csv
+++ b/extensions/brew/docs/function_descriptions.csv
@@ -1,0 +1,5 @@
+function,description,comment,example
+"brew_casks","Returns the installed casks","","from brew_casks()"
+"brew_packages","Returns the installed packages, casks and formulas","","from brew_packages()"
+"brew_formulas","Returns the installed formulas","","from brew_formulas()"
+"brew_dependencies","Return a table with two columns : the package and the pakage that relies on it. One row per dependency","Useful to produce a graph of dependencies and security reports","brew_dependencies"


### PR DESCRIPTION
# :grey_question: About

Unlike [`gaggle`](https://duckdb.org/community_extensions/extensions/gaggle) : 

<img width="1046" height="674" alt="image" src="https://github.com/user-attachments/assets/5fa7b9a1-b81c-4751-9659-d47997b80a01" />

the [`brew`](https://duckdb.org/community_extensions/extensions/brew) does not have such a documentation : 

<img width="682" height="281" alt="image" src="https://github.com/user-attachments/assets/90d1f181-16fd-4a38-8ac2-e360b7556961" />


**:point_right: The goal of this PR is to (hopefully) fix that**

