### PR TITLE
crawler: bump to v0.2.1 for DuckDB 1.4.4 compatibility

### DIFF
--- a/extensions/crawler/description.yml
+++ b/extensions/crawler/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: crawler
   description: SQL-native web crawler with HTML extraction and MERGE support
-  version: 0.2.0
+  version: 0.2.1
   language: C++
   build: cmake
   license: MIT


### PR DESCRIPTION
Bump crawler extension version to trigger rebuild for DuckDB 1.4.4.

The extension currently returns 404 on v1.4.4:
```
HTTP Error: Failed to download extension "crawler" at URL 
"http://community-extensions.duckdb.org/v1.4.4/osx_arm64/crawler.duckdb_extension.gz" (HTTP 404)
```