### PR TITLE
bump sshfs/webdavfs to duckdb v1.4.4

### DIFF
--- a/extensions/sshfs/description.yml
+++ b/extensions/sshfs/description.yml
@@ -12,7 +12,7 @@ extension:
   vcpkg_commit: 'dd3097e305afa53f7b4312371f62058d2e665320'
 repo:
   github: midwork-finds-jobs/duckdb-sshfs
-  ref: 1679e46e57960ec62523fe7853942d2f97e2c952
+  ref: 913e81ac5d8eb2940e12d85a3247077a408a944d
 
 docs:
   hello_world: |

--- a/extensions/webdavfs/description.yml
+++ b/extensions/webdavfs/description.yml
@@ -12,7 +12,7 @@ extension:
   vcpkg_commit: 'dd3097e305afa53f7b4312371f62058d2e665320'
 repo:
   github: midwork-finds-jobs/duckdb-webdavfs
-  ref: 981500f7f10bee044d1e9eb92a62d1494cf987fa
+  ref: 9c422545c211133e1c70c5a937098b5c688990cf
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary
- Update sshfs extension ref to build with duckdb v1.4.4
- Update webdavfs extension ref to build with duckdb v1.4.4

Extension repos now include:
- Dependabot for github-actions updates
- Weekly version check workflow to detect new DuckDB releases

## Test plan
- [ ] CI builds extensions successfully