### PR TITLE
:beer:  `brew` > Fix example in `brew_dependencies` description

### DIFF
--- a/extensions/brew/docs/function_descriptions.csv
+++ b/extensions/brew/docs/function_descriptions.csv
@@ -2,4 +2,4 @@ function,description,comment,example
 "brew_casks","Returns the installed casks","","from brew_casks()"
 "brew_packages","Returns the installed packages, casks and formulas","","from brew_packages()"
 "brew_formulas","Returns the installed formulas","","from brew_formulas()"
-"brew_dependencies","Return a table with two columns : the package and the pakage that relies on it. One row per dependency","Useful to produce a graph of dependencies and security reports","brew_dependencies"
+"brew_dependencies","Return a table with two columns : the package and the pakage that relies on it. One row per dependency","Useful to produce a graph of dependencies and security reports","from brew_dependencies"


### PR DESCRIPTION
# :grey_question: About

The example lacks from `from` keyword : 
<img width="1096" height="418" alt="image" src="https://github.com/user-attachments/assets/e2c37b4a-7d73-42c9-b58c-272598a094aa" />

**:point_right: This PR fixes this**