### PR TITLE
web_archive: switch to commit SHA ref for version branch compatibility

### DIFF
--- a/extensions/web_archive/description.yml
+++ b/extensions/web_archive/description.yml
@@ -5,6 +5,7 @@ extension:
   language: C++
   build: cmake
   license: MIT
+  excluded_platforms: windows_amd64_mingw
   maintainers:
     - onnimonni
 


### PR DESCRIPTION
## Summary

- Switch from tag ref (`v0.2.1`) to commit SHA ref pointing to v1.4 branch
- Use date-based version format (`2026020301`) instead of semver

## Why

The extension now uses a branch-based versioning strategy similar to the [tera extension](https://github.com/query-farm/tera):

| Branch | DuckDB Version | Purpose |
|--------|----------------|---------|
| main | main | Development |
| v1.4 | v1.4-andium | Stable 1.4.x |
| v1.5 | v1.5-variegata | Stable 1.5.x |

Using commit SHAs allows pointing to the appropriate version branch without creating new tags for each patch release.

## Test plan

- [ ] Extension builds successfully against DuckDB stable
- [ ] `wayback_machine()` and `common_crawl_index()` functions work