### PR TITLE
anndata: update to v0.13.3 (fix MinGW build)

### DIFF
--- a/extensions/anndata/description.yml
+++ b/extensions/anndata/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: anndata
   description: Read AnnData (.h5ad) files for single-cell genomics data analysis, with support for local and remote (HTTP/HTTPS/S3) files
-  version: 0.13.2
+  version: 0.13.3
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: honicky/anndata-duckdb-extension
-  ref: 649387efd97a408e9be86ae9325eac7ad8828e82
+  ref: e15dd151b1ec85661f93cee146bd27bad8c00caa
 
 docs:
   hello_world: |
@@ -41,6 +41,12 @@ docs:
 
     -- Remote file via HTTPS
     ATTACH 'https://example.com/data.h5ad' AS name (TYPE ANNDATA);
+
+    -- S3 file (requires httpfs extension and credentials)
+    INSTALL httpfs;
+    LOAD httpfs;
+    CREATE SECRET s3_secret (TYPE S3, KEY_ID 'xxx', SECRET 'xxx', REGION 'us-east-1');
+    ATTACH 's3://bucket/data.h5ad' AS name (TYPE ANNDATA);
 
     -- With custom gene name/ID columns
     ATTACH 'file.h5ad' AS name (TYPE ANNDATA, VAR_NAME_COLUMN 'gene_symbols', VAR_ID_COLUMN 'ensembl_id');


### PR DESCRIPTION
## Changes
- Update from v0.13.2 to v0.13.3
- Add S3 access example to documentation

## What's new in v0.13.3
- Fixed MinGW build failure by excluding curl/openssl dependencies
- Remote file access (HTTP/S3) not available on MinGW builds, but local files work
- Note: v0.13.2 failed to build on MinGW due to OpenSSL vcpkg port issues