### PR TITLE
Add rate limit filesystem extension

### DIFF
--- a/extensions/rate_limit_fs/description.yml
+++ b/extensions/rate_limit_fs/description.yml
@@ -1,0 +1,25 @@
+extension:
+  name: rate_limit_fs
+  description: Perform rate and burst limit on filesystem operations
+  version: 0.0.1
+  language: C++
+  build: cmake
+  license: MIT
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;windows_amd64_mingw"
+  maintainers:
+    - dentiny
+
+repo:
+  github: dentiny/duckdb-rate-limit-filesystem
+  ref: 7d8f9018b55e3eea00ba508b51f192a666e420b3
+
+docs:
+  hello_world: |
+    SELECT rate_limit_fs_wrap('RateLimitFsFakeFileSystem');
+    SELECT rate_limit_fs_quota('RateLimitFileSystem - RateLimitFsFakeFileSystem', 'read', 1000000, 'blocking');
+  extended_description: |
+    This extension implements rate and burst limit for duckdb filesystems.
+    It supports a few key features:
+    - Support filesystem and operation based limit.
+    - Support burst limit and GCRA-based rate limit.
+    - Supports wrap custom filesystems, so users don't need to change their query.


### PR DESCRIPTION
This PR adds a new community extension: rate limit filesystem, which performs rate and burst limit based on configured filesystem and operations.