### PR TITLE
Upgrade cache httpfs to v0.12.4

### DIFF
--- a/extensions/cache_httpfs/description.yml
+++ b/extensions/cache_httpfs/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: dentiny/duck-read-cache-fs
-  ref: 19131b3ae62c47aea1aae3222f498527e8a6b58f
+  ref: 479507fdb79b23e81655547f054f578be16d8cf1
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumpup cache httpfs extension version, which contains a few fixes and improvements, see https://github.com/dentiny/duck-read-cache-fs/blob/main/CHANGELOG.md#0124