### PR TITLE
Bump erpl-web to DuckDB v1.4.4

### DIFF
--- a/extensions/erpl_web/description.yml
+++ b/extensions/erpl_web/description.yml
@@ -10,4 +10,4 @@ extension:
     - jrosskopf
 repo:
   github: DataZooDE/erpl-web
-  ref: 8d0b2eb30f9ffc097e2dae8cda558cb43b9ef180
+  ref: 4e2fbe02164371d26ac255e4f40878694b1eaf56


### PR DESCRIPTION
Updated the GitHub reference for the repository.