### PR TITLE
Update midwork-finds-jobs extensions to v1.4 branch refs

### DIFF
--- a/extensions/cloudfront/description.yml
+++ b/extensions/cloudfront/description.yml
@@ -9,7 +9,7 @@ extension:
   name: cloudfront
   vcpkg_url: https://github.com/microsoft/vcpkg.git
   vcpkg_commit: ce613c41372b23b1f51333815feb3edd87ef8a8b
-  version: 0.1.0
+  version: '2026020501'
 repo:
   github: midwork-finds-jobs/duckdb-cloudfront
-  ref: e6b2ff5e933c296ffbe1cb7403cac688f8e41e97
+  ref: 176b7ee77e2c12c8a7068fde233f04f93a729c39

--- a/extensions/crawler/description.yml
+++ b/extensions/crawler/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: crawler
   description: SQL-native web crawler with HTML extraction and MERGE support
-  version: 0.2.1
+  version: '2026020501'
   language: C++
   build: cmake
   license: MIT
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb-crawler
-  ref: dd318c51c679a5de891b4470b5fb8d6b05faf4f2
+  ref: f0aad857435a2ce138c567e8af11f9d4f8ae0c25
 
 docs:
   hello_world: |

--- a/extensions/html_query/description.yml
+++ b/extensions/html_query/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: html_query
   description: Query HTML using CSS selectors, extract JSON from LD+JSON, JavaScript variables, and Next.js RSC
-  version: 0.6.0
+  version: '2026020501'
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb_html_query
-  ref: a78df2bfb6ad547ceae25cac70277bbaf0ecba62
+  ref: ad8083fbd6b67128e4103a3ed1e66afc828e6815
 
 docs:
   hello_world: |

--- a/extensions/html_readability/description.yml
+++ b/extensions/html_readability/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: html_readability
   description: Extract readable content from HTML using Mozilla's Readability algorithm
-  version: 0.1.0
+  version: '2026020501'
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb-html-readability
-  ref: 53ebdc43c1014db969d9bb50359e0eb9d2cf5e6d
+  ref: 80d0e21b734dd5152e1af14236c75ffd0e930474
 
 docs:
   hello_world: |

--- a/extensions/http_request/description.yml
+++ b/extensions/http_request/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: http_request
   description: HTTP client extension for DuckDB with GET/POST/PUT/PATCH/DELETE and byte-range requests
-  version: '2026020301'
+  version: '2026020501'
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb_http_request
-  ref: c3e9b06d912aa5a03d2eaefb686a081b4091d02a
+  ref: d4ad6fb9728b637996de4e23e0afcaf89b5140b4
 
 docs:
   hello_world: |

--- a/extensions/llm/description.yml
+++ b/extensions/llm/description.yml
@@ -80,7 +80,7 @@ extension:
   name: llm
   requires_extensions:
     - http_request
-  version: 0.2.0
+  version: '2026020501'
 repo:
   github: midwork-finds-jobs/duckdb-llm
-  ref: d3415f76c722737df109236591f9273d81a7b904
+  ref: 2de6c4d2a7d1bc6cefe8adfac8ecb16c1e7b2f3e

--- a/extensions/sitemap/description.yml
+++ b/extensions/sitemap/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: sitemap
   description: Parse XML sitemaps from websites with automatic discovery via robots.txt
-  version: 0.1.4
+  version: '2026020501'
   language: C++
   build: cmake
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb-sitemap
-  ref: v0.1.4
+  ref: 4c873c85c3f7c8dcab6154de51aa218f61677634
 
 docs:
   hello_world: |

--- a/extensions/sshfs/description.yml
+++ b/extensions/sshfs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: sshfs
   description: Allows reading and writing files over SSH
-  version: 1.0.1
+  version: '2026020501'
   language: C++
   build: cmake
   license: MIT
@@ -12,7 +12,7 @@ extension:
   vcpkg_commit: 'dd3097e305afa53f7b4312371f62058d2e665320'
 repo:
   github: midwork-finds-jobs/duckdb-sshfs
-  ref: 913e81ac5d8eb2940e12d85a3247077a408a944d
+  ref: 644366f21a80397d38979e6200fd26a544b98e7e
 
 docs:
   hello_world: |

--- a/extensions/valhalla_routing/description.yml
+++ b/extensions/valhalla_routing/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: valhalla_routing
   description: DuckDB extension for routing and travel time calculations using Valhalla routing engine
-  version: 0.2.0
+  version: '2026020501'
   language: C++
   build: cmake
   license: MIT
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb-valhalla-routing
-  ref: ef2527b911a553657483a045dde7aa687182b4e2
+  ref: d379f55ff8d80080b5b8e927c53d3062e6a57fab
 
 docs:
   hello_world: |

--- a/extensions/warc/description.yml
+++ b/extensions/warc/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: warc
   description: Parse WARC (Web ARChive) records for Common Crawl data processing
-  version: 0.1.0
+  version: '2026020501'
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb_warc
-  ref: 7184683eec41abd8dbe34b8457c780cd80648cae
+  ref: e724cf786900d4b32736136799997286bf4458e0
 
 docs:
   hello_world: |

--- a/extensions/web_search/description.yml
+++ b/extensions/web_search/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: web_search
   description: Query Google Custom Search API directly from SQL with filter pushdowns
-  version: 0.4.0
+  version: '2026020501'
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb-web-search
-  ref: 7993d775af7f1ab07bb4be1a0a1a68cf65ab8e9b
+  ref: cbfe75a10fbe513d5e3ae30151be427f22cfb4e5
 
 docs:
   hello_world: |

--- a/extensions/webdavfs/description.yml
+++ b/extensions/webdavfs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: webdavfs
   description: Allows reading and writing files over WebDAV protocol
-  version: 1.0.1
+  version: '2026020501'
   language: C++
   build: cmake
   license: MIT
@@ -12,7 +12,7 @@ extension:
   vcpkg_commit: 'dd3097e305afa53f7b4312371f62058d2e665320'
 repo:
   github: midwork-finds-jobs/duckdb-webdavfs
-  ref: 9c422545c211133e1c70c5a937098b5c688990cf
+  ref: 359f4c05601798855c07954cf560a6e3beb6fc10
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary

All midwork-finds-jobs extensions now use version branch strategy:
- v1.4 branch tracks DuckDB v1.4-andium
- v1.5 branch tracks DuckDB v1.5-variegata  
- main branch tracks DuckDB main (development)

Updated refs point to v1.4 branches for stable builds.
Updated versions to date-based format (2026020501).

## Extensions updated

- cloudfront
- crawler
- html_query
- html_readability
- http_request
- llm
- sitemap
- sshfs
- valhalla_routing
- warc
- web_search
- webdavfs

## Test plan

- [ ] Build all updated extensions
- [ ] Verify refs point to valid commits on v1.4 branches