### PR TITLE
Update crawler to v1.4 branch ref

### DIFF
--- a/extensions/crawler/description.yml
+++ b/extensions/crawler/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: crawler
   description: SQL-native web crawler with HTML extraction and MERGE support
-  version: 0.2.1
+  version: '2026020501'
   language: C++
   build: cmake
   license: MIT
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb-crawler
-  ref: dd318c51c679a5de891b4470b5fb8d6b05faf4f2
+  ref: f0aad857435a2ce138c567e8af11f9d4f8ae0c25
 
 docs:
   hello_world: |


### PR DESCRIPTION
Update crawler to use v1.4 branch ref.

Now uses version branch strategy:
- v1.4 branch tracks DuckDB v1.4-andium
- v1.5 branch tracks DuckDB v1.5-variegata
- main branch tracks DuckDB main (development)