### PR TITLE
Update http_request to v1.4 branch ref

### DIFF
--- a/extensions/http_request/description.yml
+++ b/extensions/http_request/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: http_request
   description: HTTP client extension for DuckDB with GET/POST/PUT/PATCH/DELETE and byte-range requests
-  version: '2026020301'
+  version: '2026020501'
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb_http_request
-  ref: c3e9b06d912aa5a03d2eaefb686a081b4091d02a
+  ref: d4ad6fb9728b637996de4e23e0afcaf89b5140b4
 
 docs:
   hello_world: |


### PR DESCRIPTION
Update http_request to use v1.4 branch ref.

Now uses version branch strategy:
- v1.4 branch tracks DuckDB v1.4-andium
- v1.5 branch tracks DuckDB v1.5-variegata
- main branch tracks DuckDB main (development)