### PR TITLE
Update sshfs to v1.4 branch ref

### DIFF
--- a/extensions/sshfs/description.yml
+++ b/extensions/sshfs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: sshfs
   description: Allows reading and writing files over SSH
-  version: 1.0.1
+  version: '2026020501'
   language: C++
   build: cmake
   license: MIT
@@ -12,7 +12,7 @@ extension:
   vcpkg_commit: 'dd3097e305afa53f7b4312371f62058d2e665320'
 repo:
   github: midwork-finds-jobs/duckdb-sshfs
-  ref: 913e81ac5d8eb2940e12d85a3247077a408a944d
+  ref: 644366f21a80397d38979e6200fd26a544b98e7e
 
 docs:
   hello_world: |


### PR DESCRIPTION
Update sshfs to use v1.4 branch ref.

Now uses version branch strategy:
- v1.4 branch tracks DuckDB v1.4-andium
- v1.5 branch tracks DuckDB v1.5-variegata
- main branch tracks DuckDB main (development)