### PR TITLE
Update web_search to v1.4 branch ref

### DIFF
--- a/extensions/web_search/description.yml
+++ b/extensions/web_search/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: web_search
   description: Query Google Custom Search API directly from SQL with filter pushdowns
-  version: 0.4.0
+  version: '2026020501'
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb-web-search
-  ref: 7993d775af7f1ab07bb4be1a0a1a68cf65ab8e9b
+  ref: cbfe75a10fbe513d5e3ae30151be427f22cfb4e5
 
 docs:
   hello_world: |


### PR DESCRIPTION
Update web_search to use v1.4 branch ref.

Now uses version branch strategy:
- v1.4 branch tracks DuckDB v1.4-andium
- v1.5 branch tracks DuckDB v1.5-variegata
- main branch tracks DuckDB main (development)