### PR TITLE
Update webdavfs to v1.4 branch ref

### DIFF
--- a/extensions/webdavfs/description.yml
+++ b/extensions/webdavfs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: webdavfs
   description: Allows reading and writing files over WebDAV protocol
-  version: 1.0.1
+  version: '2026020501'
   language: C++
   build: cmake
   license: MIT
@@ -12,7 +12,7 @@ extension:
   vcpkg_commit: 'dd3097e305afa53f7b4312371f62058d2e665320'
 repo:
   github: midwork-finds-jobs/duckdb-webdavfs
-  ref: 9c422545c211133e1c70c5a937098b5c688990cf
+  ref: 359f4c05601798855c07954cf560a6e3beb6fc10
 
 docs:
   hello_world: |


### PR DESCRIPTION
Update webdavfs to use v1.4 branch ref.

Now uses version branch strategy:
- v1.4 branch tracks DuckDB v1.4-andium
- v1.5 branch tracks DuckDB v1.5-variegata
- main branch tracks DuckDB main (development)