### PR TITLE
Update warc to v1.4 branch ref

### DIFF
--- a/extensions/warc/description.yml
+++ b/extensions/warc/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: warc
   description: Parse WARC (Web ARChive) records for Common Crawl data processing
-  version: 0.1.0
+  version: '2026020501'
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb_warc
-  ref: 7184683eec41abd8dbe34b8457c780cd80648cae
+  ref: e724cf786900d4b32736136799997286bf4458e0
 
 docs:
   hello_world: |


### PR DESCRIPTION
Update warc to use v1.4 branch ref.

Now uses version branch strategy:
- v1.4 branch tracks DuckDB v1.4-andium
- v1.5 branch tracks DuckDB v1.5-variegata
- main branch tracks DuckDB main (development)