### PR TITLE
Update llm to v1.4 branch ref

### DIFF
--- a/extensions/llm/description.yml
+++ b/extensions/llm/description.yml
@@ -80,7 +80,7 @@ extension:
   name: llm
   requires_extensions:
     - http_request
-  version: 0.2.0
+  version: '2026020501'
 repo:
   github: midwork-finds-jobs/duckdb-llm
-  ref: d3415f76c722737df109236591f9273d81a7b904
+  ref: 2de6c4d2a7d1bc6cefe8adfac8ecb16c1e7b2f3e


### PR DESCRIPTION
Update llm to use v1.4 branch ref.

Now uses version branch strategy:
- v1.4 branch tracks DuckDB v1.4-andium
- v1.5 branch tracks DuckDB v1.5-variegata
- main branch tracks DuckDB main (development)