### PR TITLE
Add cache prewarm extension

### DIFF
--- a/extensions/cache_prewarm/description.yml
+++ b/extensions/cache_prewarm/description.yml
@@ -11,7 +11,7 @@ extension:
     - dentiny
 repo:
   github: dentiny/duckdb-cache-prewarm
-  ref: 48fde4a95b52ce215f74764684dcf427b86ffb4f
+  ref: c959856406f2b37420b9b92ee0b045de8a49e30a
 docs:
   hello_world: |
     -- Prewarm a table into the buffer pool


### PR DESCRIPTION
This PR adds a new community extension: cache prewarm, a DuckDB extension that preloads table data blocks into the buffer pool or OS page cache, inspired by PostgreSQL's [pg_prewarm](https://www.postgresql.org/docs/current/pgprewarm.html) extension.