### PR TITLE
Update crawler to v0.3.0

### DIFF
--- a/extensions/crawler/description.yml
+++ b/extensions/crawler/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: crawler
   description: SQL-native web crawler with HTML extraction and MERGE support
-  version: '2026020501'
+  version: '2026020801'
   language: C++
   build: cmake
   license: MIT
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb-crawler
-  ref: f0aad857435a2ce138c567e8af11f9d4f8ae0c25
+  ref: 0f2832d06b3bedf9c470bc32012d14f6ac794dd7
 
 docs:
   hello_world: |
@@ -28,8 +28,11 @@ docs:
     - `sitemap()` for XML sitemap parsing
     - `read_html()` for Google Sheets-style IMPORTHTML (tables, lists, JS variables)
     - `jq()` and `htmlpath()` functions for CSS selector-based extraction
+    - `page_info()` for token-efficient page inventory (LLM agents)
     - `html.readability` for article extraction
+    - `html.meta` for meta tag extraction
     - `html.schema` for JSON-LD/microdata parsing
+    - `final_url` column showing redirect destinations
     - `CRAWLING MERGE INTO` syntax for upsert operations
 
     Example with read_html (like Google Sheets =IMPORTHTML):


### PR DESCRIPTION
## Summary
- Add `page_info(html, url)` function: token-efficient page inventory for LLM agents (returns compact JSON with meta, og, readability summary, schema types+sizes, JS variable names+types+sizes, link/table counts)
- Add `html.meta` field: meta tags as JSON in `crawl()` html struct
- Add `final_url` column: shows redirect destination in `crawl()` output
- Replace `discover()` with `page_info()` (breaking change)

## Test plan
- [x] All existing SQL tests pass (htmlpath, read_html, crawl)
- [x] 17 new page_info() assertions pass
- [x] Manual testing: `html.meta`, `final_url` with redirects, `page_info()` with real pages