### PR TITLE
Add oast extension: validate, decode, and extract OAST domains in SQL

### DIFF
--- a/extensions/oast/description.yml
+++ b/extensions/oast/description.yml
@@ -1,0 +1,35 @@
+extension:
+  name: oast
+  description: Validate, decode, and extract OAST (Out-of-Band Application Security Testing) domains in SQL
+  version: 0.1.0
+  language: C
+  build: cmake
+  license: MIT
+  requires_toolchains: "python3"
+  maintainers:
+    - hrbrmstr
+
+repo:
+  github: hrbrmstr/duckdb-oast
+  ref: 61164985f09e98900bf05d012e740199dfe3b4bd
+
+docs:
+  hello_world: |
+    -- Check if a domain is a valid OAST callback
+    SELECT oast_validate('c58bduhe008dovpvhvugcfemp9yyyyyyn.oast.pro') AS is_oast;
+    -- Decode OAST metadata (timestamp, machine ID, campaign)
+    SELECT oast_struct('c58bduhe008dovpvhvugcfemp9yyyyyyn.oast.pro').*;
+    -- Extract OAST domains from arbitrary text
+    SELECT oast_extract('GET /c58bduhe008dovpvhvugcfemp9yyyyyyn.oast.pro HTTP/1.1');
+  extended_description: |
+    The oast extension provides functions for working with OAST (Out-of-Band Application Security Testing)
+    domains directly in SQL. OAST domains are used by security testing tools like ProjectDiscovery Interactsh
+    to detect out-of-band interactions during vulnerability scanning.
+
+    Functions include validation (oast_validate), metadata decoding (oast_struct, oast_decode_json),
+    domain extraction from text (oast_extract, oast_extract_decode), and convenience macros for
+    field access (oast_campaign, oast_timestamp, oast_ksort, oast_machine_id).
+
+    Supports domains from: oast.pro, oast.live, oast.site, oast.online, oast.fun, oast.me, interact.sh, interactsh.com.
+
+    Pure C implementation with no external dependencies. Uses DuckDB stable C API (v1.2.0+).


### PR DESCRIPTION
Adds the `oast` extension — a pure C extension for working with OAST (Out-of-Band Application Security Testing) domains directly in DuckDB.

OAST domains are generated by security testing tools like [ProjectDiscovery's Interactsh](https://github.com/projectdiscovery/interactsh) to detect out-of-band callbacks during vulnerability scanning. Each domain encodes a timestamp, machine ID, campaign identifier, and other metadata in a base32hex preamble.

### Functions

Scalar functions (C API):

- `oast_validate(domain)` → BOOLEAN — check if a string is a valid OAST domain
- `oast_decode_json(domain)` → VARCHAR — decode metadata as JSON
- `oast_extract(text)` → VARCHAR — find all OAST domains in arbitrary text
- `oast_extract_decode(text)` → VARCHAR — extract and decode in one call

SQL macros (ergonomic wrappers):

- `oast_struct(domain)` / `oast_summary(domain)` — decode to native STRUCT
- `oast_timestamp(domain)` / `oast_campaign(domain)` / `oast_ksort(domain)` / `oast_machine_id(domain)` — field accessors
- `oast_count(text)` / `oast_has_oast(text)` / `oast_extract_structs(text)` — extraction helpers

Supports domains from: oast.pro, oast.live, oast.site, oast.online, oast.fun, oast.me, interact.sh, interactsh.com.

### Implementation

- Pure C99, no external dependencies
- Stable C API only (v1.2.0+)
- Hand-rolled domain extractor (no regex dependency)
- Vectorized processing for batch operations

### Example

```sql
SELECT oast_struct('c58bduhe008dovpvhvugcfemp9yyyyyyn.oast.pro').*;
```

| original | valid | ts | machine_id | pid | counter | ksort | campaign | nonce |
|----------|-------|----|------------|-----|---------|-------|----------|-------|
| c58bduhe008dovpvhvugcfemp9yyyyyyn.oast.pro | true | 1632679674 | 2e:00:10 | 56447 | 4165629 | c58bdu | he008 | cfemp9yyyyyyn |
