### PR TITLE
Add Sudan extension

### DIFF
--- a/extensions/sudan/description.yml
+++ b/extensions/sudan/description.yml
@@ -7,7 +7,7 @@ extension:
   license: MIT
   maintainers:
     - Osman-Geomatics93
-  excluded_platforms: wasm_mvp;wasm_eh;wasm_threads
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw"
 
 repo:
   github: Osman-Geomatics93/duckdb-sudan-


### PR DESCRIPTION
## Summary

- Adds the **Sudan** extension: unified SQL access to Sudan's humanitarian, development, and geospatial data from 5 international APIs
- 12 SQL functions covering World Bank, WHO, FAO, UNHCR, ILO data + geospatial boundaries
- Bilingual support (Arabic/English) for state names and provider metadata

## Extension Details

| Field | Value |
|-------|-------|
| Name | `sudan` |
| Language | C++ |
| License | MIT |
| Repository | [Osman-Geomatics93/duckdb-sudan-](https://github.com/Osman-Geomatics93/duckdb-sudan-) |

## What it does

Sudan is experiencing one of the world's largest humanitarian crises, yet its data is scattered across dozens of international APIs. This extension brings all publicly available Sudan data into DuckDB:

- **World Bank** — Development indicators, GDP, population, education
- **WHO** — Health indicators, disease burden, mortality rates
- **FAO** — Agricultural production, food security, land use
- **UNHCR** — Refugees, IDPs, asylum seekers, displacement data (2.4M+ refugees in 2025)
- **ILO** — Employment, labor force, unemployment statistics

Plus embedded GeoJSON boundaries for Sudan's 18 states and bilingual (Arabic/English) metadata.

## Example usage

```sql
INSTALL sudan FROM community;
LOAD sudan;

-- List providers
SELECT * FROM SUDAN_Providers();

-- Sudan population
SELECT year, value FROM SUDAN_WorldBank('SP.POP.TOTL') WHERE year >= 2020;

-- Refugees from Sudan
SELECT year, value FROM SUDAN_UNHCR('refugees') WHERE year >= 2022;

-- 18 states with Arabic names
SELECT state_name, state_name_ar, iso_code FROM SUDAN_States();
```

## Test plan

- [x] All 9 test cases pass (47 assertions)
- [x] Tested interactively on Windows with DuckDB v1.4.4
- [x] All 5 API providers return live data
- [x] Builds with CMake + Ninja + MSVC

🤖 Generated with [Claude Code](https://claude.com/claude-code)