### PR TITLE
Update rate limit fs to v0.0.2

### DIFF
--- a/extensions/rate_limit_fs/description.yml
+++ b/extensions/rate_limit_fs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: rate_limit_fs
   description: Perform rate and burst limit on filesystem operations
-  version: 0.0.1
+  version: 0.0.2
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: dentiny/duckdb-rate-limit-filesystem
-  ref: d61d1c4de440f7ad8fb9258699c7db40f610f47f
+  ref: 2d70a9f86b5d31fd6104980d5bfd47db82fcd020
 
 docs:
   hello_world: |


### PR DESCRIPTION
This PR mainly updates extension-ci-tools to point to duckdb v1.4.4