### PR TITLE
fix: exclude linux_amd64_musl for cassandra extension

### DIFF
--- a/extensions/cassandra/description.yml
+++ b/extensions/cassandra/description.yml
@@ -4,7 +4,7 @@ extension:
   version: 1.0.0
   language: C++
   build: cmake
-  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;"
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;linux_amd64_musl"
   license: MIT
   requires_toolchains: "cmake, openssl"
   maintainers:


### PR DESCRIPTION
## Summary
- Add `linux_amd64_musl` to `excluded_platforms` for the cassandra extension
- The DataStax C++ driver and libuv dependencies do not build reliably on musl/Alpine Linux (static linking issues with musl libc)
- This follows the same pattern used by 30+ other community extensions (e.g., `pbix`, `prql`, `nats_js`, `sshfs`, `otlp`)

## Changes
```diff
- excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;"
+ excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;linux_amd64_musl"
```

## Test plan
- [ ] Verify CI passes on all non-excluded platforms (linux_amd64, linux_arm64, macOS, Windows, Wasm)
- [ ] Confirm `linux_amd64_musl` job is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)