### PR TITLE
Bump chaos for v1.5.0

### DIFF
--- a/extensions/chaos/description.yml
+++ b/extensions/chaos/description.yml
@@ -9,7 +9,8 @@ extension:
     - taniabogatsch
 repo:
   github: taniabogatsch/duckdb-chaos
-  ref: e112242b794466d2a4a577af0a92fce836708a71
+  ref: 46ef95bf98ef008078c1cf753fa3d78e418b1456
+  ref_next: f076132edafe0a2b150d34af3ad0743bfb937c9f
 
 docs:
   hello_world: |


### PR DESCRIPTION
Add `next_ref`, which now points to a version that builds for `v1.5-variegata`.
Also bump the current `ref`, since that is now on a separate branch containing some pushes.