### PR TITLE
[Eurostat] Build extension for WASM

### DIFF
--- a/extensions/eurostat/description.yml
+++ b/extensions/eurostat/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: ahuarte47/duckdb-eurostat
-  ref: a98ba30b07e80f137995ccac5f8be2cc70ef67cf
+  ref: 8c1deef2189469a31b371732c618343283878b0e
 
 docs:
   hello_world: |


### PR DESCRIPTION
Hi, this is a retry of https://github.com/duckdb/community-extensions/pull/1247, extension was successfully built for WASM, but some libs were not linked statically.

<img width="946" height="357" alt="image" src="https://github.com/user-attachments/assets/579534ca-437b-48d5-9f1f-847e6561c147" />

My apologies, I am not able to check this in my env.

