### PR TITLE
Update Elasticsearch extension

### DIFF
--- a/extensions/elasticsearch/description.yml
+++ b/extensions/elasticsearch/description.yml
@@ -9,7 +9,7 @@ extension:
     - tlinhart
 repo:
   github: tlinhart/duckdb-elasticsearch
-  ref: f7e5f93c4e7b3997d799d8172d53e67d27a453bb
+  ref: ea88cc2e09378c1ceb286926755727df909699f5
 docs:
   hello_world: |
     -- Basic query.
@@ -34,7 +34,17 @@ docs:
     )
     WHERE category = 'electronics' AND price > 100;
 
-    -- Combine with a base Elasticsearch query.
+    -- Geospatial query pushdown (requires the DuckDB spatial extension).
+    INSTALL spatial;
+    LOAD spatial;
+
+    SELECT name FROM elasticsearch_query(
+        host := 'localhost',
+        index := 'places'
+    )
+    WHERE ST_Intersects(ST_GeomFromGeoJSON(geometry), ST_Point(-122.4194, 37.7749));
+
+    -- Combine WHERE clause with a base Elasticsearch query.
     SELECT title, author FROM elasticsearch_query(
         host := 'localhost',
         index := 'books',


### PR DESCRIPTION
- Update examples to include geospatial pushdown
- Bump to DuckDB v1.4.4