### PR TITLE
Allow to provide ci_tools_version as input

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ on:
         type: string
       duckdb_version:
         type: string
+      ci_tools_version:
+        type: string
       duckdb_tag:
         type: string
       deploy:
@@ -96,7 +98,7 @@ jobs:
     with:
       duckdb_version: ${{ inputs.duckdb_version || 'v1.4.4' }}
       duckdb_tag: ${{ inputs.duckdb_tag || '' }}
-      ci_tools_version: 'v1.4-andium'
+      ci_tools_version: ${{ inputs.ci_tools_version || 'v1.4-andium' }}
       exclude_archs: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_EXCLUDE_PLATFORMS }}
       opt_in_archs: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_OPT_IN_PLATFORMS}}
       test_config: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_TEST_CONFIG }}
@@ -144,7 +146,7 @@ jobs:
       deploy_latest: true
       duckdb_version: ${{ inputs.duckdb_version || 'v1.4.4' }}
       duckdb_tag: ${{ inputs.duckdb_tag || '' }}
-      ci_tools_version: 'v1.4-andium'
+      ci_tools_version: ${{ inputs.ci_tools_version || 'v1.4-andium' }}
       exclude_archs: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_EXCLUDE_PLATFORMS }}
       opt_in_archs: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_OPT_IN_PLATFORMS}}
       extension_name: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_NAME }}


### PR DESCRIPTION
Required before being able to properly test https://github.com/duckdb/community-extensions/pull/1302