### PR TITLE
fix: dd_login claims filter support and version bump to 0.0.6

### DIFF
--- a/extensions/dazzleduck/description.yml
+++ b/extensions/dazzleduck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: dazzleduck
   description: Arrow IPC over HTTP client with array functions and bloom filters
-  version: 0.0.5
+  version: 0.0.6
   language: C++
   build: cmake
   license: Apache-2.0
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: dazzleduck-web/dazzleduck-sql-duckdb
-  ref: v0.0.5
+  ref: v0.0.6
 
 docs:
   hello_world: |


### PR DESCRIPTION
- Fix BuildLoginJson to forward all claims fields generically using yyjson_obj_foreach instead of hardcoding only database/schema/table, enabling filter claims (e.g. tenant_id = 1) to flow through to JWT
- Fix use-after-free: keep claims_doc alive until after yyjson_mut_write since key strings are raw pointers into claims_doc memory
- Add dd_login integration test covering claims with filter fields
- Fix dd_read_arrow_aggregation_pushdown test to use JWT auth token since unauthenticated access is no longer supported
- Bump version to 0.0.6