### PR TITLE
Add pdfmd extension - PDF reader using MuPDF for DuckDB

### DIFF
--- a/extensions/pdfmd/description.yml
+++ b/extensions/pdfmd/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: nkwork9999/duckMuPDF
-  ref: a78cb8c123a0ba0d4f811c6ce054fb9bcd22ebec
+  ref: de3add393dc36e7e6c6a1f72f010c24f9cae03c2
 
 docs:
   hello_world: |

--- a/extensions/pdfmd/description.yml
+++ b/extensions/pdfmd/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: nkwork9999/duckMuPDF
-  ref: 3faeb617a3a49ea125cad5aa9a176cc7c4f8c5b9
+  ref: 4b44c53c41e7cf21bb36dfeb2152d6a2e0543c49
 
 docs:
   hello_world: |

--- a/extensions/pdfmd/description.yml
+++ b/extensions/pdfmd/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: nkwork9999/duckMuPDF
-  ref: 4a181cc63be9e5eb6431e08f762fcbc20674c1c7
+  ref: bd0851c87d615336a758c4519c706e76a470e1b6
 
 docs:
   hello_world: |

--- a/extensions/pdfmd/description.yml
+++ b/extensions/pdfmd/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: nkwork9999/duckMuPDF
-  ref: 56da549611bdc9a80c2a0f4dc8f24c4826ae4144
+  ref: a78cb8c123a0ba0d4f811c6ce054fb9bcd22ebec
 
 docs:
   hello_world: |

--- a/extensions/pdfmd/description.yml
+++ b/extensions/pdfmd/description.yml
@@ -5,6 +5,7 @@ extension:
   language: C++
   build: cmake
   license: MIT
+  excluded_platforms: "windows_amd64;windows_amd64_mingw;windows_amd64_rtools"
   maintainers:
     - nkwork9999
 

--- a/extensions/pdfmd/description.yml
+++ b/extensions/pdfmd/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: nkwork9999/duckMuPDF
-  ref: b4fe516c18877e1ea5a6cc24ae8e95aeb4e76a84
+  ref: b4fe516edcf93dde6c972ff581e7449f60cbe9c7
 
 docs:
   hello_world: |

--- a/extensions/pdfmd/description.yml
+++ b/extensions/pdfmd/description.yml
@@ -1,0 +1,38 @@
+extension:
+  name: pdfmd
+  description: Read PDF files from SQL using MuPDF - extract text, metadata, and convert to Markdown
+  version: 0.0.1
+  language: C++
+  build: cmake
+  license: MIT
+  maintainers:
+    - nkwork9999
+  requires_toolchains: "mupdf"
+
+repo:
+  github: nkwork9999/duckMuPDF
+  ref: b4fe516c18877e1ea5a6cc24ae8e95aeb4e76a84
+
+docs:
+  hello_world: |
+    -- Extract text from a PDF
+    SELECT pdf_text('/path/to/document.pdf');
+
+    -- Get page count
+    SELECT pdf_page_count('/path/to/document.pdf');
+
+    -- Get metadata as JSON
+    SELECT pdf_metadata('/path/to/document.pdf');
+
+    -- Convert PDF to Markdown
+    SELECT pdf_to_markdown('/path/to/document.pdf');
+
+    -- Extract text from a specific page
+    SELECT pdf_page_text('/path/to/document.pdf', 1);
+
+    -- Get all pages as a table
+    SELECT * FROM pdf_pages('/path/to/document.pdf');
+
+    -- Batch processing with glob
+    SELECT filename, pdf_page_count(filename)
+    FROM glob('/path/to/docs/*.pdf') t(filename);

--- a/extensions/pdfmd/description.yml
+++ b/extensions/pdfmd/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: nkwork9999/duckMuPDF
-  ref: ac5084bf78cddef68ce6861b810416eac34ed64a
+  ref: e6f099db36eefbb23e84e27e2b79410ab14627e1
 
 docs:
   hello_world: |

--- a/extensions/pdfmd/description.yml
+++ b/extensions/pdfmd/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: nkwork9999/duckMuPDF
-  ref: bd0851c87d615336a758c4519c706e76a470e1b6
+  ref: 56da549611bdc9a80c2a0f4dc8f24c4826ae4144
 
 docs:
   hello_world: |

--- a/extensions/pdfmd/description.yml
+++ b/extensions/pdfmd/description.yml
@@ -7,11 +7,10 @@ extension:
   license: MIT
   maintainers:
     - nkwork9999
-  requires_toolchains: "mupdf"
 
 repo:
   github: nkwork9999/duckMuPDF
-  ref: b4fe516edcf93dde6c972ff581e7449f60cbe9c7
+  ref: 4a181cc63be9e5eb6431e08f762fcbc20674c1c7
 
 docs:
   hello_world: |

--- a/extensions/pdfmd/description.yml
+++ b/extensions/pdfmd/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: nkwork9999/duckMuPDF
-  ref: de3add393dc36e7e6c6a1f72f010c24f9cae03c2
+  ref: ac5084bf78cddef68ce6861b810416eac34ed64a
 
 docs:
   hello_world: |

--- a/extensions/pdfmd/description.yml
+++ b/extensions/pdfmd/description.yml
@@ -5,7 +5,7 @@ extension:
   language: C++
   build: cmake
   license: MIT
-  excluded_platforms: "windows_amd64;windows_amd64_mingw;windows_amd64_rtools"
+  excluded_platforms: "windows_amd64;windows_amd64_mingw;windows_amd64_rtools;wasm_mvp;wasm_eh;wasm_threads"
   maintainers:
     - nkwork9999
 

--- a/extensions/pdfmd/description.yml
+++ b/extensions/pdfmd/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: nkwork9999/duckMuPDF
-  ref: e6f099db36eefbb23e84e27e2b79410ab14627e1
+  ref: 3faeb617a3a49ea125cad5aa9a176cc7c4f8c5b9
 
 docs:
   hello_world: |

--- a/extensions/pdfmd/docs/function_descriptions.csv
+++ b/extensions/pdfmd/docs/function_descriptions.csv
@@ -1,0 +1,8 @@
+function_name,function_type,description,comment,example
+pdf_text,scalar_function,Extract plain text from a PDF file,,SELECT pdf_text('document.pdf')
+pdf_to_markdown,scalar_function,Convert a PDF file to Markdown format,,SELECT pdf_to_markdown('document.pdf')
+pdf_page_count,scalar_function,Get the number of pages in a PDF file,,SELECT pdf_page_count('document.pdf')
+pdf_metadata,scalar_function,Get PDF metadata as a JSON string,,SELECT pdf_metadata('document.pdf')
+pdf_page_text,scalar_function,Extract text from a specific page of a PDF,,SELECT pdf_page_text('document.pdf', 1)
+pdf_pages,table_function,Return each page of a PDF as a row with text and dimensions,,SELECT * FROM pdf_pages('document.pdf')
+read_pdf,table_function,Read a PDF file and return structured page data,,SELECT * FROM read_pdf('document.pdf')


### PR DESCRIPTION
Summary
New community extension pdfmd that binds MuPDF C API to DuckDB, enabling PDF file reading directly from SQL.

Functions
Scalar:

pdf_text(path) - Extract plain text
pdf_to_markdown(path) - Convert to Markdown
pdf_page_count(path) - Get page count
pdf_metadata(path) - Get metadata as JSON
pdf_page_text(path, page_num) - Extract specific page text
Table:

pdf_pages(path) - Returns page_num, text, width, height
read_pdf(path) - Returns page_num, text
Example

INSTALL pdfmd FROM community;
LOAD pdfmd;

SELECT pdf_text('/path/to/document.pdf');
SELECT * FROM pdf_pages('/path/to/document.pdf');
SELECT filename, pdf_page_count(filename) FROM glob('docs/*.pdf') t(filename);
Details
Language: C++ with C wrapper for MuPDF
License: MIT
Repo: https://github.com/nkwork9999/duckMuPDF
