### PR TITLE
Add laduck: LLM inference inside DuckDB via llama.cpp

### DIFF
--- a/extensions/laduck/description.yml
+++ b/extensions/laduck/description.yml
@@ -1,0 +1,46 @@
+extension:
+  name: laduck
+  description: Run LLMs inside DuckDB. Text generation, embeddings, and zero-shot classification from SQL via llama.cpp
+  version: 0.1.0
+  language: C++
+  build: cmake
+  license: MIT
+  maintainers:
+    - hamidr
+  excluded_platforms:
+    - wasm_mvp
+    - wasm_eh
+
+repo:
+  github: hamidr/laduck
+  ref: 5ae28c7ae05717c349dbb8613cca788ce5f6bf35
+
+docs:
+  hello_world: |
+    LOAD laduck;
+    SELECT llm_load_model('hf://Qwen/Qwen2-0.5B-Instruct-GGUF/qwen2-0_5b-instruct-q2_k.gguf', 'qwen');
+    SELECT llm_complete('Explain SQL joins in one sentence:', 'qwen');
+    SELECT * FROM llm_models();
+
+  extended_description: |
+    LaDuck embeds llama.cpp directly into DuckDB for local LLM inference from SQL.
+    No API keys, no external services, everything runs in-process.
+
+    ## Features
+    - **Text generation**: `llm_complete(text, model)` generates text completions
+    - **Embeddings**: `llm_embed(text, model)` returns float arrays for semantic search
+    - **Classification**: `llm_classify(text, model, labels)` zero-shot classification in a single forward pass
+    - **Model sources**: Load from local files, HuggingFace (`hf://`), or DuckDB storage (`db://`)
+    - **Portable databases**: Store models inside `.duckdb` files with `llm_store_model()`
+    - **GPU acceleration**: Metal (macOS), CUDA (NVIDIA), Vulkan/ROCm (AMD)
+
+    ## Functions
+    - `llm_load_model(source, name)` - Load a GGUF model
+    - `llm_complete(text, model [, max_tokens, temperature, top_p])` - Generate text
+    - `llm_embed(text, model)` - Compute embedding vector
+    - `llm_classify(text, model, labels)` - Zero-shot classification
+    - `llm_models()` - List loaded models
+    - `llm_backends()` - List available compute backends
+    - `llm_unload_model(name)` - Free model from memory
+    - `llm_store_model(name)` - Save model into DuckDB database
+    - `llm_delete_model(name)` - Remove stored model

--- a/extensions/laduck/description.yml
+++ b/extensions/laduck/description.yml
@@ -32,7 +32,7 @@ docs:
     - **Classification**: `llm_classify(text, model, labels)` zero-shot classification in a single forward pass
     - **Model sources**: Load from local files, HuggingFace (`hf://`), or DuckDB storage (`db://`)
     - **Portable databases**: Store models inside `.duckdb` files with `llm_store_model()`
-    - **GPU acceleration**: Metal (macOS), CUDA (NVIDIA), Vulkan/ROCm (AMD)
+    - **GPU acceleration**: Metal, CUDA, Vulkan, and ROCm supported when built from source
 
     ## Functions
     - `llm_load_model(source, name)` - Load a GGUF model

--- a/extensions/laduck/description.yml
+++ b/extensions/laduck/description.yml
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: hamidr/laduck
-  ref: 5ae28c7ae05717c349dbb8613cca788ce5f6bf35
+  ref: d0a42dcc63ecf4926875f455096b97ff56d0cb20
 
 docs:
   hello_world: |

--- a/extensions/laduck/description.yml
+++ b/extensions/laduck/description.yml
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: hamidr/laduck
-  ref: d0a42dcc63ecf4926875f455096b97ff56d0cb20
+  ref: 330c94635c68be5d23cbd98f498c4bb4534cbfbd
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary

Adds **laduck**, a DuckDB extension that embeds [llama.cpp](https://github.com/ggml-org/llama.cpp) for local LLM inference directly from SQL.

- **Text generation**: `llm_complete(text, model)`
- **Embeddings**: `llm_embed(text, model)` returns float arrays
- **Zero-shot classification**: `llm_classify(text, model, labels)` in a single forward pass
- **Model sources**: Local files, HuggingFace (`hf://`), or DuckDB internal storage (`db://`)
- **Portable databases**: Store GGUF models inside `.duckdb` files
- **GPU acceleration**: Metal, CUDA, Vulkan, and ROCm supported when built from source

## Build notes

llama.cpp is included as a git submodule (`third_party/llama.cpp`) and statically linked. The submodule adds build time but has no runtime dependencies. WASM platforms are excluded since llama.cpp requires native execution.

## Repository

https://github.com/hamidr/laduck