### PR TITLE
Update crawler to v0.4.0: add html.hydration for SPA state extraction

### DIFF
--- a/extensions/crawler/description.yml
+++ b/extensions/crawler/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: crawler
-  description: SQL-native web crawler with HTML extraction and MERGE support
-  version: '2026020501'
+  description: SQL-native web crawler with HTML/SPA extraction and MERGE support
+  version: '2026040201'
   language: C++
   build: cmake
   license: MIT
@@ -13,8 +13,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb-crawler
-  andium: f0aad857435a2ce138c567e8af11f9d4f8ae0c25
-  ref: 7725ede99eff1657a2cee770048be33328ae9f02
+  ref: 3830ded85ce76c67ab9c63ce8667758c8fa1dd76
 
 docs:
   hello_world: |
@@ -31,21 +30,24 @@ docs:
     - `jq()` and `htmlpath()` functions for CSS selector-based extraction
     - `html.readability` for article extraction
     - `html.schema` for JSON-LD/microdata parsing
+    - `html.hydration` for SPA framework state (Next.js, Nuxt, Vue/Pinia, Apollo)
     - `CRAWLING MERGE INTO` syntax for upsert operations
+
+    New in v0.4.0 - SPA hydration state extraction:
+    ```sql
+    -- Extract Next.js page data without regex
+    SELECT html.hydration['__NEXT_DATA__']->'props'->'pageProps' as data
+    FROM crawl(['https://prisma.fi/']);
+
+    -- Extract Nuxt/Vue product data
+    SELECT html.hydration['unified_datalayer_product']->>'name' as name,
+           html.hydration['unified_datalayer_product']->>'price' as price
+    FROM crawl(['https://www.lidl.fi/p/milbona-mozzarella/p10032843']);
+    ```
 
     Example with read_html (like Google Sheets =IMPORTHTML):
     ```sql
     SELECT * FROM read_html('https://en.wikipedia.org/wiki/...', 'table.wikitable', 1);
-    SELECT * FROM read_html('https://example.com/page', 'js=jobs');
-    ```
-
-    Example with extraction:
-    ```sql
-    SELECT
-        url,
-        jq(html.document, '.price', 'data-amount') as price,
-        html.readability.title as article_title
-    FROM crawl(['https://example.com/products']);
     ```
 
     Example with MERGE:


### PR DESCRIPTION
## Summary
- New `html.hydration` field (`MAP(VARCHAR, JSON)`) extracts embedded SPA framework state from HTML
- Supports Next.js (`__NEXT_DATA__`), Nuxt (`__NUXT__`, `__NUXT_DATA__`), Vue/Pinia, Apollo, and generic `window.X` assignments
- Switched JS parser from SWC to tree-sitter-javascript (lighter dependency, better error recovery for malformed scripts)
- Added devalue format deserializer for Pinia/Nuxt serialized reference arrays
- Added `htmlescape` + `json5` crates for HTML entity decoding and loose JSON parsing

## Test plan
- [x] Builds locally on macOS arm64 with `make release GEN=ninja`
- [x] Tested on example.com (empty hydration map), Lidl.fi (Nuxt/Pinia), Prisma.fi (Next.js), Verkkokauppa.com (custom React)
- [x] Existing html.schema, html.js, html.meta, html.readability fields unchanged
- [x] Rust unit tests pass (21/22, 1 pre-existing failure in jsonld test)