### PR TITLE
Update sitting_duck to v1.6.0

### DIFF
--- a/extensions/sitting_duck/description.yml
+++ b/extensions/sitting_duck/description.yml
@@ -9,7 +9,7 @@ extension:
     - teaguesterling
 repo:
   github: teaguesterling/sitting_duck
-  ref: fa5454689bdd869d997a54bbfa28e8fde166b3a8
+  ref: 908927e016cbe01f0786582fb00cf8e0de9c6009
 docs:
   hello_world: |
     -- Parse Python code and find function definitions

--- a/extensions/sitting_duck/description.yml
+++ b/extensions/sitting_duck/description.yml
@@ -9,7 +9,7 @@ extension:
     - teaguesterling
 repo:
   github: teaguesterling/sitting_duck
-  ref: 286322cb7a32ee023de1ad5117eb90c4c8e955c2
+  ref: fa5454689bdd869d997a54bbfa28e8fde166b3a8
 docs:
   hello_world: |
     -- Parse Python code and find function definitions

--- a/extensions/sitting_duck/description.yml
+++ b/extensions/sitting_duck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: sitting_duck
   description: Parse and analyze source code ASTs from 27 programming languages with tree-sitter grammars, pattern matching, and structural search
-  version: 1.5.0
+  version: 1.6.0
   language: C++
   build: cmake
   license: MIT
@@ -9,7 +9,7 @@ extension:
     - teaguesterling
 repo:
   github: teaguesterling/sitting_duck
-  ref: 96cf501d4a8d04f9718fd26e66bc807ac676a8c4
+  ref: 286322cb7a32ee023de1ad5117eb90c4c8e955c2
 docs:
   hello_world: |
     -- Parse Python code and find function definitions
@@ -69,10 +69,20 @@ docs:
     ```
     See: https://sitting-duck.readthedocs.io/en/latest/guide/pattern-matching/
 
+    **CSS Selector Queries (v1.6.0):**
+    Query AST nodes using CSS selector syntax — bootstrapped with sitting duck's own CSS grammar:
+    ```sql
+    SELECT name FROM ast_select('src/*.py', '.func:has(.call#execute):not(:has(try_statement))');
+    ```
+    Supports type selectors, `#name`, `.semantic` (~80 aliases), combinators, `:has()`, `:not(:has())`.
+    Bare type matching: `if` matches `if` + `if_statement` + `if_clause`.
+
     **Table Functions:**
-    - `read_ast(file_pattern, language := NULL)` - Parse source files into AST rows
+    - `read_ast(file_pattern, language := NULL)` - Parse source files into AST rows (parallel)
     - `parse_ast(content, language)` - Parse source code strings
     - `ast_match(source, pattern, lang)` - Pattern matching for code search
+    - `ast_select(source, css_selector)` - CSS selector queries
+    - `ast_type_map(language)` - Node type discovery across languages
 
     **Relational Predicates (v1.5.0):**
     - `ast_has(source, parent_type, child_type)` - Check containment relationships


### PR DESCRIPTION
## Summary
- Update sitting_duck extension from v1.5.0 to v1.6.0
- New: `ast_select()` — CSS selector query language bootstrapped with tree-sitter-css
- New: `ast_type_map()` — node type discovery across 27 languages
- New: ~80 semantic type aliases (.func, .if, .except, .import, etc.)
- New: NAME_ROLE flags (is_name_definition, is_name_reference, is_scope)
- New: True parallel file parsing via DuckDB init_local + MaxThreads API
- New: Bare type prefix matching (`if` matches `if` + `if_statement` + `if_clause`)
- Fix: Relaxed wildcard child matching (async/modifier tolerant)
- Fix: sibling_index UINT32 → INT32 (no more unsigned overflow)

## Release
https://github.com/teaguesterling/sitting_duck/releases/tag/v1.6.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)