### PR TITLE
Add astro extension

### DIFF
--- a/extensions/astro/description.yml
+++ b/extensions/astro/description.yml
@@ -1,0 +1,22 @@
+extension:
+  name: astro
+  description: Astronomical calculations - coordinate transforms, angular separation, photometry, cosmology
+  version: 1.1.0
+  language: C++
+  build: cmake
+  license: MIT
+  maintainers:
+    - bjoernbethge
+
+repo:
+  github: synapticore-io/astro-duck
+  ref: e2b760ad14fc36499889db04a031fdece668ba8d
+
+docs:
+  hello_world: |
+    SELECT angular_separation(10.68, 41.27, 83.82, -5.39) AS separation_deg;
+  extended_description: |
+    The astro extension adds astronomical calculation functions to DuckDB:
+    equatorial/galactic coordinate transforms, angular separation on the
+    celestial sphere, photometry helpers (magnitude/flux conversions),
+    and cosmology utilities (redshift, distance moduli).

--- a/extensions/astro/description.yml
+++ b/extensions/astro/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: astro
-  description: Astronomical calculations - coordinate transforms, angular separation, photometry, cosmology
-  version: 1.1.0
+  description: Astronomical calculations - coordinate transforms, photometry, cosmology, CCM89 dust extinction
+  version: 1.1.1
   language: C++
   build: cmake
   license: MIT
@@ -10,13 +10,17 @@ extension:
 
 repo:
   github: synapticore-io/astro-duck
-  ref: e2b760ad14fc36499889db04a031fdece668ba8d
+  ref: a7385041bfcdf7d1125c61798dc148e26d3269de
 
 docs:
   hello_world: |
-    SELECT angular_separation(10.68, 41.27, 83.82, -5.39) AS separation_deg;
+    SELECT astro_angular_separation(10.68, 41.27, 83.82, -5.39) AS separation_deg;
   extended_description: |
     The astro extension adds astronomical calculation functions to DuckDB:
-    equatorial/galactic coordinate transforms, angular separation on the
-    celestial sphere, photometry helpers (magnitude/flux conversions),
-    and cosmology utilities (redshift, distance moduli).
+    coordinate transforms (equatorial / galactic frames, RA/Dec to XYZ),
+    angular separation on the celestial sphere, photometry helpers
+    (magnitude/flux conversions, distance modulus, absolute magnitude),
+    cosmology (luminosity and comoving distance), celestial body models
+    (stars, brown dwarfs, planets, black holes, asteroids), orbital
+    mechanics, 3D octree spatial sectors, and CCM89 + O'Donnell 1994
+    dust extinction with standard UBVRIJHK photometric bands.

--- a/extensions/astro/description.yml
+++ b/extensions/astro/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: astro
-  description: Astronomical calculations - coordinate transforms, photometry, cosmology, CCM89 dust extinction
-  version: 1.1.1
+  description: Astronomical calculations - coordinate transforms, photometry, cosmology, dust extinction, sidereal time
+  version: 1.2.0
   language: C++
   build: cmake
   license: MIT
@@ -10,17 +10,18 @@ extension:
 
 repo:
   github: synapticore-io/astro-duck
-  ref: a7385041bfcdf7d1125c61798dc148e26d3269de
+  ref: 10a6655e71b3a685bf870b993c1664e6ed2f9a2e
 
 docs:
   hello_world: |
     SELECT astro_angular_separation(10.68, 41.27, 83.82, -5.39) AS separation_deg;
   extended_description: |
-    The astro extension adds astronomical calculation functions to DuckDB:
-    coordinate transforms (equatorial / galactic frames, RA/Dec to XYZ),
-    angular separation on the celestial sphere, photometry helpers
-    (magnitude/flux conversions, distance modulus, absolute magnitude),
-    cosmology (luminosity and comoving distance), celestial body models
-    (stars, brown dwarfs, planets, black holes, asteroids), orbital
-    mechanics, 3D octree spatial sectors, and CCM89 + O'Donnell 1994
-    dust extinction with standard UBVRIJHK photometric bands.
+    The astro extension adds 53+ astronomical calculation functions to
+    DuckDB: coordinate transforms (equatorial / galactic frames, RA/Dec
+    to XYZ), angular separation, photometry (magnitude/flux, distance
+    modulus, absolute magnitude), CCM89 + O'Donnell 1994 dust extinction
+    with UBVRIJHK bands, cosmological distances (luminosity, comoving),
+    celestial body models (stars, brown dwarfs, planets, black holes,
+    asteroids), Keplerian orbital mechanics, 3D octree spatial sectors,
+    and sidereal time / observation planning (GMST, LMST, hour angle,
+    equatorial to horizontal alt/az conversion).


### PR DESCRIPTION
## Summary

Adds the `astro` community extension — astronomical calculations for DuckDB.

- Repo: https://github.com/synapticore-io/astro-duck
- Version: 1.1.0
- DuckDB: v1.4.3
- License: MIT

## Features

- Equatorial / galactic coordinate transforms
- Angular separation on the celestial sphere
- Photometry helpers (magnitude / flux conversions)
- Cosmology utilities (redshift, distance moduli)

## Hello world

```sql
INSTALL astro FROM community;
LOAD astro;
SELECT angular_separation(10.68, 41.27, 83.82, -5.39) AS separation_deg;
```

The extension is based on the official `extension-template` and uses the `extension-ci-tools` submodule, so it should build out of the box with the community CI toolchain.