### PR TITLE
Bump duckpgq to fix build errors

### DIFF
--- a/extensions/duckpgq/description.yml
+++ b/extensions/duckpgq/description.yml
@@ -11,7 +11,7 @@ extension:
 repo:
   github: cwida/duckpgq-extension
   andium: 42eea114b22fad93f04cb7edf50d2b0077e464fa
-  ref: 78c7a6cd5e0e03926b28ed7ec2cdb2fe333b0c0b 
+  ref: cbe4d9e58ebc3984d725a83c4dd46e6acd723cec 
 
 docs:
   hello_world: |


### PR DESCRIPTION
Attempt to fix: 
```sql 
memory D force install duckpgq from community; 
memory D load duckpgq; 
Invalid Input Error:
Initialization function "duckpgq_duckdb_cpp_init" from file "/Users/danieltenwolde/.duckdb/extensions/v1.5.1/osx_arm64/duckpgq.duckdb_extension" threw an exception: "vector"
```