### PR TITLE
Update duckhts to version 1.1.6

### DIFF
--- a/extensions/duckhts/description.yml
+++ b/extensions/duckhts/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: "RGenomicsETL/duckhts"
-  ref: "ce0fa60801081677e902604e5bfb000050bb7710"
+  ref: "975b301dde48492aa81ae4361696b15803389055"
 
 docs:
   hello_world: |

--- a/extensions/duckhts/description.yml
+++ b/extensions/duckhts/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: "duckhts"
   description: "DuckDB extension for reading HTS file formats via htslib"
-  version: "1.1.4"
+  version: "1.1.6"
   language: "C"
   build: "cmake"
   license: "MIT"
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: "RGenomicsETL/duckhts"
-  ref: "c9197d51159f03b87d0eb7afd5874b1a23c1ddc8"
+  ref: "ce0fa60801081677e902604e5bfb000050bb7710"
 
 docs:
   hello_world: |


### PR DESCRIPTION
This submission provide some bug fixes and synchronize the plugin version with the submitted R package CRAN release. Notable changes from last submission

- threading related  bug fixes for the liftover UDFs added to the previous
  version of package.
- more tests for BCF  specification compliance
- alter the schema of the bam reader for downstream applications