### PR TITLE
Update astro extension to v1.3.0 (DuckDB v1.5.1)

### DIFF
--- a/extensions/astro/description.yml
+++ b/extensions/astro/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: astro
   description: Astronomical calculations - coordinate transforms, photometry, cosmology, dust extinction, sidereal time
-  version: 1.2.0
+  version: 1.3.0
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: synapticore-io/astro-duck
-  ref: 10a6655e71b3a685bf870b993c1664e6ed2f9a2e
+  ref: 72d996fc93b40c42564d6c94ed6ed042b5a858f4
 
 docs:
   hello_world: |


### PR DESCRIPTION
Update the astro extension to v1.3.0 targeting DuckDB v1.5.1.

**Changes:**
- `version`: 1.2.0 → 1.3.0
- `ref`: updated to commit with DuckDB v1.5.1 support
- `astro_jd_from_timestamp` now accepts both TIMESTAMP and TIMESTAMPTZ

CI in extension repo already green for all platforms:
https://github.com/synapticore-io/astro-duck/actions/runs/24245910721