### PR TITLE
Update sitting_duck to v1.6.1

### DIFF
--- a/extensions/sitting_duck/description.yml
+++ b/extensions/sitting_duck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: sitting_duck
   description: Parse and analyze source code ASTs from 27 programming languages with tree-sitter grammars, pattern matching, and structural search
-  version: 1.6.0
+  version: 1.6.1
   language: C++
   build: cmake
   license: MIT
@@ -9,7 +9,7 @@ extension:
     - teaguesterling
 repo:
   github: teaguesterling/sitting_duck
-  ref: 908927e016cbe01f0786582fb00cf8e0de9c6009
+  ref: dac9084c0a6af1ba769c3cbd09762a87899bce36
 docs:
   hello_world: |
     -- Parse Python code and find function definitions


### PR DESCRIPTION
Patch release fixing two silent bugs in `ast_select`'s pseudo-class handling that made several v1.6.0 headline examples return wrong results.

## Bug fixes

**`:not(:pseudo-class)` now works.** Previously `:not()` only handled `:not(:has(...))`, so `:not(:is-called)`, `:not(:is-referenced)`, and the dead-code patterns documented in the v1.6.0 selector guide were silently dropped from the filter — queries returned the unfiltered set instead of the filtered one.

**Unknown pseudo-classes now raise a clear error.** Typos like `:unreferenced` or `:callers(2)` used to fall through to `ELSE true` in the dispatch CASE and silently match everything. There is now an enumerated allow-list and `error()` call.

## Fix details

- Extended `pseudo_classes` CTE in `css_selectors.sql` with a `negated` column via `UNION ALL` that picks up pseudo-classes directly inside a top-level `:not()`
- Filter clause changed from `WHERE NOT CASE ... END` to `WHERE pc.negated = CASE ... END` — unsatisfied when both are true (negated pc matches) or both are false (non-negated pc doesn't match)
- `:not(:has(...))` still routes through the existing `not_has_conditions` CTE unchanged
- Added `pseudo_class_validation` CTE enumerating the 30 known pseudo-class names and calling `error()` on any unknown name

## Docs

Audited all selector guide pages:
- Fixed four broken example selectors in `tutorial.md` and `examples.md`
- Documented eight previously-undocumented semantic type aliases (`.external`, `.typedef`, `.pattern`, `.statement`, `.syntax`, `.transform`, `.label`, `.comp`)
- Noted `::previous-sibling` as an alias for `::prev-sibling`

## Test plan

- [x] All 93 existing tests pass (4682 assertions, up from 4671)
- [x] New pseudo-class tests added for:
  - [x] `:not(:is-called)` / `:is-called` partitioning
  - [x] `:not(:is-referenced)` / `:is-referenced` partitioning
  - [x] `:exported:not(:is-referenced)` (the index.md example)
  - [x] Compound `:named:not(:is-called)`
  - [x] `:not(:has())` regression coverage
  - [x] Unknown pseudo-class errors at top level and inside `:not()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)