### PR TITLE
Add lastra extension: columnar time-series format reader

### DIFF
--- a/extensions/lastra/description.yml
+++ b/extensions/lastra/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: QTSurfer/duckdb-lastra
-  ref: b806675ff958ba896a9ca486bb3fdd8b2896d037
+  ref: 0b8932b2bf5121140f5398d3ddc75451c6d810ea
 
 docs:
   hello_world: |

--- a/extensions/lastra/description.yml
+++ b/extensions/lastra/description.yml
@@ -1,0 +1,28 @@
+extension:
+  name: lastra
+  description: Reader for the Lastra columnar time-series format
+  version: 0.1.0
+  language: C++
+  build: cmake
+  license: Apache-2.0
+  maintainers:
+    - mrmx
+
+repo:
+  github: QTSurfer/duckdb-lastra
+  ref: b806675ff958ba896a9ca486bb3fdd8b2896d037
+
+docs:
+  hello_world: |
+    SELECT * FROM read_lastra('data.lastra') LIMIT 10;
+  extended_description: |
+    Reads Lastra (.lastra) columnar time-series files with per-column codec
+    selection. Designed for financial tick data (OHLCV), IoT sensor readings,
+    and strategy execution results.
+
+    Supported codecs: ALP (adaptive lossless floating-point), Gorilla (XOR),
+    Pongo (decimal-aware), delta-varint (timestamps), ZSTD (binary).
+
+    Features row groups with per-group timestamp statistics for efficient
+    temporal range queries — only row groups overlapping the WHERE clause
+    are decoded.

--- a/extensions/lastra/description.yml
+++ b/extensions/lastra/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: QTSurfer/duckdb-lastra
-  ref: 717cb3a985db33d7a1632bcebd04ee2f394708e7
+  ref: d859527024fb3c4336d2b149f638af7753ce1a60
 
 docs:
   hello_world: |

--- a/extensions/lastra/description.yml
+++ b/extensions/lastra/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: QTSurfer/duckdb-lastra
-  ref: 0b8932b2bf5121140f5398d3ddc75451c6d810ea
+  ref: 75965f773b89ae16fc194383a07e1dc55bd69f92
 
 docs:
   hello_world: |

--- a/extensions/lastra/description.yml
+++ b/extensions/lastra/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: QTSurfer/duckdb-lastra
-  ref: 75965f773b89ae16fc194383a07e1dc55bd69f92
+  ref: 717cb3a985db33d7a1632bcebd04ee2f394708e7
 
 docs:
   hello_world: |


### PR DESCRIPTION
 ## Summary

  Adds the **lastra** extension for reading `.lastra` columnar time-series files natively in DuckDB.

## Usage

  ```sql
  INSTALL lastra FROM community;
  LOAD lastra;

  SELECT * FROM read_lastra('data.lastra');
  SELECT * FROM 'data.lastra';

  -- Temporal filtering with row group pushdown
  SELECT * FROM 'daily_btc.lastra'
  WHERE ts >= 1711155600000 AND ts < 1711159200000;
  ```

 ## About Lastra

  https://github.com/QTSurfer/lastra-java is a columnar time-series file format with per-column codec selection:

  - ALP — adaptive lossless floating-point (~3-4 bits/value for 2dp financial data)
  - Gorilla — XOR compression (Facebook VLDB 2015)
  - Pongo — decimal-aware erasure + Gorilla XOR
  - Delta-varint — timestamps (~1 byte/value for regular intervals)
  - ZSTD — binary/string data

  Features row groups with per-group timestamp statistics for efficient range queries.

  Implementations: https://github.com/QTSurfer/lastra-java (writer+reader), https://github.com/QTSurfer/lastra-ts (reader+Arrow interop), C++ (this DuckDB extension).

  Extension repo

  https://github.com/QTSurfer/duckdb-lastra

  https://github.com/QTSurfer/duckdb-lastra/actions/workflows/build.yml
