### PR TITLE
Update scalarfs to v1.4.0

### DIFF
--- a/extensions/scalarfs/description.yml
+++ b/extensions/scalarfs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: scalarfs
   description: A collection of virtual filesystems for working with scalars
-  version: 1.3.2
+  version: 1.4.0
   language: C++
   build: cmake
   license: MIT
@@ -9,8 +9,9 @@ extension:
     - teaguesterling
 repo:
   github: teaguesterling/duckdb_scalarfs
-  andium: f1b17a25ad0635520186b22cf8158730b1c68712
-  ref: f1b17a25ad0635520186b22cf8158730b1c68712
+  andium: 1e283b92ab821cc0138b5f1369fa66a86fb8c494
+  ref: 1e283b92ab821cc0138b5f1369fa66a86fb8c494
+  ref_next: 1e283b92ab821cc0138b5f1369fa66a86fb8c494
 docs:
   hello_world: |
     LOAD scalarfs;


### PR DESCRIPTION
## Summary
- Update \`scalarfs\` extension to v1.4.0
- Adds \`ATTACH\` support for the \`pathvariable:\` protocol via a DuckDB \`StorageExtension\`, allowing a session variable to hold the database file path:

  \`\`\`sql
  SET VARIABLE db_path = '/data/warehouse.duckdb';
  ATTACH 'pathvariable:db_path' AS wh;
  \`\`\`

  Fixes teaguesterling/duckdb_scalarfs#7.

## Test plan
- [x] Extension builds and passes all tests (754 assertions in 18 test cases) locally
- [x] Upstream release: https://github.com/teaguesterling/duckdb_scalarfs/releases/tag/v1.4.0
- [ ] CI: verify stable, next, and LTS builds all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)