### PR TITLE
Update duck_tails to v1.4.0

### DIFF
--- a/extensions/duck_tails/description.yml
+++ b/extensions/duck_tails/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duck_tails
   description: Smart Development Intelligence for DuckDB - Git-aware data analysis capabilities that allow querying git history, accessing files at any revision, and performing version-aware data analysis with SQL.
-  version: 1.3.1
+  version: 1.4.0
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
     - teaguesterling
 repo:
   github: teaguesterling/duck_tails
-  ref: 8bff511c120afb01137b6e79baa9964c572b20b7
+  ref: 9f3ebcaf989ed132b9d3ee6ab9369735773752d5
 
 docs:
   hello_world: |

--- a/extensions/duck_tails/description.yml
+++ b/extensions/duck_tails/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duck_tails
   description: Smart Development Intelligence for DuckDB - Git-aware data analysis capabilities that allow querying git history, accessing files at any revision, and performing version-aware data analysis with SQL.
-  version: 1.4.0
+  version: 1.4.1
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
     - teaguesterling
 repo:
   github: teaguesterling/duck_tails
-  ref: 9f3ebcaf989ed132b9d3ee6ab9369735773752d5
+  ref: dca8ff3b3f5d423beb474c11349b547c88e99e70
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary
- Bump duck_tails from 1.3.1 to 1.4.0
- New: `git_blame()` / `git_blame_hunks()` table functions (plus LATERAL `_each` variants) for line/hunk-level blame queries (issue #18)
- Fix: `git_read` now honors the explicit `repo_path` named parameter for relative `git://` URIs and bare filesystem paths (issue #17)

## Test plan
- [x] `make release` builds cleanly
- [x] `make test` — 895 assertions across 54 test cases pass
- [x] Manifest `ref` points at upstream tag v1.4.0 (commit 9f3ebca)