### PR TITLE
Update sitting_duck to v1.7.4

### DIFF
--- a/extensions/sitting_duck/description.yml
+++ b/extensions/sitting_duck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: sitting_duck
   description: Parse and analyze source code ASTs from 27 programming languages with tree-sitter grammars, pattern matching, and structural search
-  version: 1.7.2
+  version: 1.7.4
   language: C++
   build: cmake
   license: MIT
@@ -9,7 +9,7 @@ extension:
     - teaguesterling
 repo:
   github: teaguesterling/sitting_duck
-  ref: afc126d57a0895ac51ac472b2da2a7fd552875bd
+  ref: 1eb30cf990c73640cf0cd745435b676f27d159b7
 docs:
   hello_world: |
     -- Parse Python code and find function definitions
@@ -154,7 +154,9 @@ docs:
     - `peek` - Configurable source preview
     - `qualified_name` - Scope-based path unique within a file (`C[User] F[__init__]` format; v1.7.0)
     - `signature_type`, `parameters`, `modifiers`, `annotations` - Native extraction
-    - `scope_id`, `scope_stack` - Scope resolution columns
+    - `scope` - STRUCT<current, function, class, module, stack> (v1.7.4); replaces
+      the v1.7.2 `scope_id` / `scope_stack` columns. `scope.function` lets you
+      answer "what function is this in?" as a single column read.
 
     Full schema: https://sitting-duck.readthedocs.io/en/latest/api/output-schema/
 

--- a/extensions/sitting_duck/description.yml
+++ b/extensions/sitting_duck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: sitting_duck
   description: Parse and analyze source code ASTs from 27 programming languages with tree-sitter grammars, pattern matching, and structural search
-  version: 1.7.0
+  version: 1.7.2
   language: C++
   build: cmake
   license: MIT
@@ -9,7 +9,7 @@ extension:
     - teaguesterling
 repo:
   github: teaguesterling/sitting_duck
-  ref: 21e47fe226f368bb57da5e58ae74f53d0ec6ba48
+  ref: afc126d57a0895ac51ac472b2da2a7fd552875bd
 docs:
   hello_world: |
     -- Parse Python code and find function definitions
@@ -69,7 +69,7 @@ docs:
     ```
     See: https://sitting-duck.readthedocs.io/en/latest/guide/pattern-matching/
 
-    **CSS Selector Queries (v1.6.0, enhanced in v1.7.0):**
+    **CSS Selector Queries (v1.6.0, enhanced in v1.7.0+):**
     Query AST nodes using CSS selector syntax — bootstrapped with sitting duck's own CSS grammar:
     ```sql
     SELECT name FROM ast_select('src/*.py', '.func:has(.call#execute):not(:has(try_statement))');
@@ -77,6 +77,11 @@ docs:
     -- v1.7.0: :match (current-node) vs :contains (subtree) structural patterns
     SELECT name FROM ast_select('src/*.py', '.func:contains("db.execute()")');
     SELECT name FROM ast_select('src/*.py', 'call:match("db.execute()")');
+
+    -- v1.7.2: parse once, query many — orders of magnitude faster for interactive use
+    CREATE TABLE my_ast AS SELECT * FROM read_ast('src/**/*.py');
+    SELECT * FROM ast_select_from('my_ast', '.class:named');
+    SELECT * FROM ast_select_from('my_ast', '.func:has(return_statement)');
     ```
     Supports type selectors, `#name`, `.semantic` (~80 aliases), combinators, `:has()`, `:not()`,
     `:match()` / `:contains()` structural patterns, scope/call-graph pseudo-classes, and pseudo-element navigation.
@@ -88,6 +93,7 @@ docs:
     - `parse_ast_list(content, language)` - Parse source code strings (scalar, returns LIST<STRUCT>; v1.7.0)
     - `ast_match(source, pattern, lang)` - Pattern matching for code search
     - `ast_select(source, css_selector)` - CSS selector queries
+    - `ast_select_from(table_name, selector)` - CSS selectors on pre-parsed tables (v1.7.2)
     - `ast_type_map(language)` - Node type discovery across languages
 
     **v1.7.0 extraction suffix:**

--- a/extensions/sitting_duck/description.yml
+++ b/extensions/sitting_duck/description.yml
@@ -9,7 +9,7 @@ extension:
     - teaguesterling
 repo:
   github: teaguesterling/sitting_duck
-  ref: 1eb30cf990c73640cf0cd745435b676f27d159b7
+  ref: f7b9c600116b3ee869d8b5a9dca9f1357d31569c
 docs:
   hello_world: |
     -- Parse Python code and find function definitions


### PR DESCRIPTION
## Summary

Updates sitting_duck from v1.7.0 to v1.7.4 (v1.7.2 / v1.7.3 were never shipped as community releases).

### Highlights

- **~17× faster CSS selector queries on large codebases.** Two combined bugs (compound filter leak + combinator EXISTS decorrelation) were making `ast_select` pathologically slow; fixed by restructuring the dispatch and applying filters uniformly across root selector types.
- **`scope` STRUCT replaces `scope_id` / `scope_stack`** — one typed column with precomputed `scope.function` / `scope.class` / `scope.module` shortcuts on every node, turning common call-graph queries from range joins into O(1) field reads.
- **Six CSS selector bug fixes** surfaced by the new multi-language test coverage (Python / JavaScript / Rust / Go + Rosetta code examples, 687 assertions).
- **Call-graph queries** on DuckDB-scale corpora: `ast_callers` / `ast_callees` rewritten to use `scope.function` — sub-second instead of multi-second or OOM.
- **`is_semantic_type()` predicate speedups** — literal-pattern call sites rewritten to SEMANTIC_TYPE equality (29–73× faster); cascade reorder for dynamic calls (11–19× on isolated predicates).
- **`NAMESPACE` / `NS` aliases** for DEFINITION_MODULE in `is_semantic_type()` — matches the same set as `.module` / `.mod` / `.package`, clearer naming for C++/Rust callers.

### Changes

- `version: 1.7.0` → `1.7.4`
- `ref:` updated to `1eb30cf990c73640cf0cd745435b676f27d159b7` (v1.7.4 tag)
- AST schema section updated to document the new `scope` STRUCT column

### Breaking changes (pre-public)

The v1.7.2 community release documented `scope_id` / `scope_stack` columns.
v1.7.3 / v1.7.4 consolidate these into a single `scope` STRUCT:

```
scope: STRUCT<
    current   BIGINT,   -- replaces scope_id
    function  BIGINT,   -- new: nearest function ancestor (O(1) lookup)
    class     BIGINT,   -- new: nearest class ancestor
    module    BIGINT,   -- new: nearest module/namespace ancestor
    stack     LIST<STRUCT<id BIGINT, kind SEMANTIC_TYPE>>  -- replaces scope_stack
>
```

Migration is mechanical:

| Before | After |
|---|---|
| `scope_id` | `scope.current` |
| `scope_stack` | `list_transform(scope.stack, s -> s.id)` for the same shape |
| Manual range join to find enclosing function | `scope.function` — precomputed column |

Full release notes: https://github.com/teaguesterling/sitting_duck/releases/tag/v1.7.4

## Test plan

- [ ] Community CI builds pass (all platforms including WASM)
- [ ] `INSTALL sitting_duck FROM community; LOAD sitting_duck;` works
- [ ] `SELECT scope.function FROM read_ast(...)` populates correctly
- [ ] `ast_callers` / `ast_callees` complete in reasonable time on moderately-sized projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)
