### PR TITLE
[Raster] Update extension to v0.4.0

### DIFF
--- a/extensions/raster/description.yml
+++ b/extensions/raster/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: raster
   description: DuckDB Extension for reading and writing raster files using SQL.
-  version: 0.3.1
+  version: 0.4.0
   language: C++
   build: cmake
   excluded_platforms: "windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads"
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: ahuarte47/duckdb-raster
-  ref: df2ce5b18eb791c4f5743b65a5ecda839ca33ed0
+  ref: 710884da7d20b73f4928d34df7dd882b97d59f60
 
 docs:
   hello_world: |
@@ -53,6 +53,8 @@ docs:
     │       │           │            │ }                              │                         │       │        │        │       │       │            │            │
     └───────┴───────────┴────────────┴────────────────────────────────┴─────────────────────────┴───────┴────────┴────────┴───────┴───────┴────────────┴────────────┘
 
+    -- Example transforming the BLOB data of the bands into arrays of integers, to allow analyzing the raster data:
+
     SELECT
         RT_Blob2ArrayInt32(databand_1, true) AS r,
         RT_Blob2ArrayInt32(databand_2, true) AS g,
@@ -60,6 +62,23 @@ docs:
     FROM
         RT_Read('path/to/raster/file.tif')
     ;
+
+    -- Example of using COPY to export the data table to a new raster file:
+
+    COPY (
+        SELECT geometry, databand_1, databand_2, databand_3 FROM RT_Read('./path/to/raster/file.tif')
+    )
+    TO './path/to/raster/newfile.tif'
+    WITH (
+        FORMAT RASTER,
+        DRIVER 'COG',
+        CREATION_OPTIONS ('COMPRESS=LZW','BIGTIFF=YES'),
+        RESAMPLING 'nearest',
+        ENVELOPE [545539.750, 4724420.250, 545699.750, 4724510.250],
+        SRS 'EPSG:25830',
+        GEOMETRY_COLUMN 'geometry',
+        DATABAND_COLUMNS ['databand_3', 'databand_2', 'databand_1']
+    );
 
   extended_description: |
     Extension for DuckDB for reading and writing raster files using SQL.
@@ -91,8 +110,19 @@ docs:
     `RT_Read` supports filter pushdown on the non-BLOB columns, which allows you to prefilter the tiles that are loaded based on their metadata or
     spatial location. For example, you can filter the tiles that intersect with a certain geometry or that have a certain value in the metadata.
 
+    `COPY TO` with `FORMAT RASTER` allows to export a table with the same structure as the one returned by `RT_Read` to a new raster file.
+    You can specify the driver and several creation options:
+
+    - `DRIVER`: The GDAL driver to use for writing the raster file. For example, `GTiff` or `COG`.
+    - `CREATION_OPTIONS`: A list of creation options to pass to the GDAL driver, specified as strings in the format `KEY=VALUE`.
+    - `RESAMPLING`: The resampling method to use when writing the raster file. For example, `nearest`, `bilinear`, `cubic`, etc.
+    - `ENVELOPE`: The spatial extent of the raster file, specified as a list of four values: `[xmin, ymin, xmax, ymax]`.
+    - `SRS`: The spatial reference system of the raster file, specified as an EPSG code (e.g. `EPSG:4326`) or a WKT string.
+    - `GEOMETRY_COLUMN`: The name of the column that contains the geometry of the tiles. This column will be used to determine the spatial location and the resolution of the tiles in the output raster file.
+    - `DATABAND_COLUMNS`: A list with the names of the columns that contain the data of the bands. The order of the columns in the list will determine the order of the bands in the output raster file.
+
     This extension is still in early development, and there are many features that I want to add in the future:
 
-    - `COPY` function to write raster files from the loaded tables.
+    - Add functions to convert from arrays of numeric values to BLOB databand columns.
     - Compression formats for the data band BLOBs (`GZip`, `ZSTD`?).
     - Integration with DuckDB File System.

--- a/extensions/raster/docs/function_descriptions.csv
+++ b/extensions/raster/docs/function_descriptions.csv
@@ -2,3 +2,4 @@ function,description,comment,example
 RT_Drivers,"Returns the list of supported GDAL raster drivers.","","SELECT RT_Drivers();"
 RT_Read,"Reads a raster file and returns a table with the raster data.","","SELECT * FROM RT_Read('path/to/raster/file.tif');"
 RT_Blob2Array,"Transforms the BLOB data of the data band columns into an array of a numeric data type.","","SELECT RT_Blob2ArrayInt32(databand_1, true) AS r FROM RT_Read('path/to/raster/file.tif');"
+COPY TO,"Exports the data table to a new raster file.","","COPY ( SELECT geometry, databand_1 FROM RT_Read('path/to/raster/file.tif') ) TO 'path/to/raster/newfile.tif' WITH (FORMAT RASTER, DRIVER 'COG'...);"

--- a/extensions/raster/docs/functions.md
+++ b/extensions/raster/docs/functions.md
@@ -7,6 +7,7 @@
 | --- | --- |
 | [`RT_Drivers`](#rt_drivers) | Returns the list of supported GDAL RASTER drivers and file formats. |
 | [`RT_Read`](#rt_read) | Reads a raster file and returns a table with the raster data. |
+| [`COPY TO`](#rt_write) | Exports the data table to a new raster file. |
 
 **[Scalar Functions](#scalar-functions)**
 
@@ -121,7 +122,103 @@ The data band columns are a BLOB with the following internal structure:
 
 By using `RT_Read`, the extension also provides “replacement scans” for common raster file formats, allowing you to query files of these formats as if they were tables directly.
 
-`RT_Read` supports filter pushdown on the non-BLOB columns, which allows you to prefilter the tiles that are loaded based on their metadata or spatial location. For example, you can filter the tiles that intersect with a certain geometry or that have a certain value in the metadata.
+`RT_Read` supports filter pushdown on the non-BLOB columns, which allows you to prefilter the tiles that are loaded based on their metadata or spatial location.
+As you have noticed, `bbox` and `geometry` columns are available for spatial filtering, so for example, you can filter the tiles that intersect with a certain geometry.
+
+----
+
+### RT_Write
+
+Aka `COPY TO` with `FORMAT RASTER`
+
+#### Signature
+
+```sql
+COPY (
+	SELECT ...
+)
+TO 'path/to/output/file.tif'
+WITH (
+	FORMAT RASTER,
+	...
+);
+```
+
+#### Description
+
+You can write raster files using the `COPY` command in DuckDB.
+
+The extension fetches the geometry and data band columns of the input table and creates a raster file with the desired properties. The `geometry` column is used to calculate the spatial extent and the resolution of the output raster,
+and the data band columns are used to populate the pixel values of the output raster.
+
+The extension provides the format `RASTER` and a set of options to control the writing process:
+
+| Parameter | Type | Description |
+| --------- | -----| ----------- |
+| `FORMAT` | VARCHAR | Must be set to 'RASTER' to use the raster writing functionality. |
+| `DRIVER` | VARCHAR | The GDAL driver to use to write the raster file. You can check available drivers using `RT_Drivers` function. |
+| `CREATION_OPTIONS` | VARCHAR[] | A list of key-value pairs that are passed to the GDAL driver to control the creation of the file. Read GDAL documentation for available options. |
+| `RESAMPLING` | VARCHAR | The resampling method to use when the tile size of the input data does not match the block size of the output raster. Available options are `nearest`, `bilinear`, `cubic`, `cubicspline`, `lanczos`, `average`, `mode`, and `max`. `nearest` is the default. |
+| `ENVELOPE` | DOUBLE[] | The spatial extent of the output raster in the format [xmin, ymin, xmax, ymax]. If not provided, the extent will be calculated from the input tiles. |
+| `SRS` | VARCHAR | The spatial reference system of the output raster in WKT or EPSG code format. |
+| `GEOMETRY_COLUMN` | VARCHAR | The name of the column that contains the geometry of the tiles. This column will be used to calculate the spatial extent and resolution of the output raster. It must be a column of type `GEOMETRY`. `geometry` is the default. |
+| `DATABAND_COLUMNS` | VARCHAR[] | A list of columns that contain the data bands of the raster. These columns must be of type BLOB and have the same internal structure as the data band columns returned by `RT_Read`. |
+
+Raster rotation is not supported, so the input `geometry` column must contain axis-aligned polygons that represent the footprint of each tile.
+
+For example, you can write a new raster file from an existing one by running:
+
+```sql
+COPY (
+   	SELECT
+		geometry,
+		databand_1, databand_2, databand_3
+	FROM
+		RT_Read('./test/data/overlay-sample.tiff')
+)
+TO './test/data/copytoraster.tiff'
+WITH (
+	FORMAT RASTER,
+	DRIVER 'COG',
+	CREATION_OPTIONS ('COMPRESS=LZW'),
+	RESAMPLING 'nearest',
+	ENVELOPE [545539.750, 4724420.250, 545699.750, 4724510.250],
+	SRS 'EPSG:25830',
+	GEOMETRY_COLUMN 'geometry',
+	DATABAND_COLUMNS ['databand_3', 'databand_2', 'databand_1']
+);
+```
+
+Also, because the `geometry` column is available, you can create a new `geoparquet` file (or any other geospatial
+format supported by the `spatial` extension) with the tile data and their geometries by just running:
+
+```sql
+COPY (
+   	SELECT
+		* EXCLUDE(databand_1,databand_2,databand_3)
+   	FROM
+		RT_Read('path/to/raster/file.tif')
+)
+TO 'path/to/output/file.parquet'
+WITH (
+	FORMAT PARQUET, GEOPARQUET_VERSION 'V1'
+);
+
+-- Or using the spatial extension, for example, writing a GeoPackage file:
+
+LOAD spatial;
+
+COPY (
+	SELECT
+		* EXCLUDE(databand_1,databand_2,databand_3)
+	FROM
+		RT_Read('path/to/raster/file.tif')
+)
+TO 'path/to/output/file.gpkg'
+WITH (
+	FORMAT GDAL, DRIVER 'GPKG', SRS 'EPSG:4326'
+);
+```
 
 ----
 
@@ -189,7 +286,7 @@ Functions return a struct with the following fields:
 + `no_data` (DOUBLE): NoData value for the tile (To consider when applying algebra operations). `-infinity` if not defined.
 + `values` (ARRAY): An array with the pixel values of the tile for the corresponding band and data type.
 
-This allows you to do algebra operations with the data of the tiles directly in SQL:
+This allows you to do algebraic operations with the data of the tiles directly in SQL:
 
 ```sql
 WITH __input AS (
@@ -206,5 +303,10 @@ FROM
 	__input
 ;
 ```
+
+Choose carefully which `RT_Blob2Array<type>` function you invoke, if the array element type in the output does
+not match the data type in the BLOB data column, the function need to adjust values accordingly, and the
+performance may	be affected. You can check the data type of the bands in the `metadata` column returned
+by `RT_Read`.
 
 ----


### PR DESCRIPTION
Changes:
* Add support for writing raster files using the `COPY` command in DuckDB.
* Update to GDAL 3.12.3 & support for more raster formats.
* Fix `RT_Read` function to handle nodata values NaN correctly.
