### PR TITLE
Bump mpduck to v0.0.2

### DIFF
--- a/extensions/mpduck/description.yml
+++ b/extensions/mpduck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: mpduck
   description: Read and write FIS Prophet files (.rpt, .prn, .fac)
-  version: 0.0.1
+  version: 0.0.2
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,8 @@ extension:
 
 repo:
   github: MatthewMooreZA/mpduck
-  ref: 5ef84a7a00f77671772390cd84615d8aa34634de
+  andium: fca5bd23355a269e00d259607fb3f0d9505b7ca1
+  ref: b3952a8bd779940290e0e5aa70eb8961fbcfccee
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary
- Bump version to `0.0.2`
- Update `ref` to HEAD of `main` branch (`b3952a8b`)
- Add `andium` ref pointing to HEAD of `v1.4-andium` branch (`fca5bd23`)