### PR TITLE
Bump NetQuack to v1.11.2

### DIFF
--- a/extensions/netquack/description.yml
+++ b/extensions/netquack/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: netquack
   description: DuckDB extension for parsing, extracting, and analyzing domains, URIs, and paths with ease.
-  version: 1.11.1
+  version: 1.11.2
   language: C++
   build: cmake
   license: MIT
@@ -10,8 +10,8 @@ extension:
 
 repo:
   github: hatamiarash7/duckdb-netquack
-  andium: b38e6e530c836c9e10564e92489765fc8fa0bd7b
-  ref: b38e6e530c836c9e10564e92489765fc8fa0bd7b
+  andium: 6fef8d4e04dc091d5f1e32bb2822bc9030ed86ae
+  ref: 6fef8d4e04dc091d5f1e32bb2822bc9030ed86ae
 
 docs:
   extended_description: |


### PR DESCRIPTION
## What's Changed

* Support DuckDB v1.5.2

---

**Full Changelog**: https://github.com/hatamiarash7/duckdb-netquack/compare/1.11.1...1.11.2