### PR TITLE
Bump miint

### DIFF
--- a/extensions/miint/description.yml
+++ b/extensions/miint/description.yml
@@ -14,7 +14,7 @@ extension:
 
 repo:
   github: the-miint/duckdb-miint
-  ref: 53902e65b6cb8bb06946e5134a78546f5d9e0428
+  ref: 7a081072aa61f5d9db63ffc209b8dea66d9c2401
 
 docs:
   hello_world: |

--- a/extensions/miint/description.yml
+++ b/extensions/miint/description.yml
@@ -9,12 +9,12 @@ extension:
   maintainers:
     - wasade
   requires:
-    duckdb: "1.5.1"
+    duckdb: "1.5.2"
   requires_toolchains: rust
 
 repo:
   github: the-miint/duckdb-miint
-  ref: f247559c6db67501448605360e36d0372c6f069e
+  ref: 53902e65b6cb8bb06946e5134a78546f5d9e0428
 
 docs:
   hello_world: |


### PR DESCRIPTION
This bump carries a considerable expansion of functionality including:

- Retrieval of data from EBI/ENA
- Extraction of newick from jplace
- Exposes placement resolution
- Embeds and exposes VSEARCH (near complete) and MAFFT (parttree) 
- Adds depth of coverage
- Adds alignment slicing
- Adds Deblur
- And various performance tweaks and minor bug fixes

When testing the new `shell.duckdb.org`, we realized some HDF5 symbols were unexpectedly carried forward into WASM resulting in a failure to load the extension. Even though the WASM builds succeeded, the load of the extension failed. Those symbols have been removed, and as far as we can tell the WASM extension works. However, we don't have a means to test locally -- if this PR does not restore WASM capability, we will move to establish a local testing environment rather than commit wack-a-mole 