### PR TITLE
bump zeek extension to v0.4.0

### DIFF
--- a/extensions/zeek/description.yml
+++ b/extensions/zeek/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: zeek
   description: Read Zeek network security monitor log files with automatic schema detection and type-aware parsing
-  version: 0.3.0
+  version: 0.4.0
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: ynadji/zeek-duckdb
-  ref: ab066a172af13a632540ff96bb9aacc2cbd83c96
+  ref: 47e6491094f188e6987d105c178b72d272c05539
 
 docs:
   hello_world: |


### PR DESCRIPTION
this adds an option `ignore_file_errors` that silently ignores corrupt/malformed files. thanks @keithjjones!