### PR TITLE
Add talib extension

### DIFF
--- a/extensions/talib/description.yml
+++ b/extensions/talib/description.yml
@@ -1,0 +1,28 @@
+extension:
+  name: talib
+  description: "Technical Analysis Library (TA-Lib) functions for DuckDB -- 100+ indicators for financial market analysis"
+  version: 0.1.0
+  language: C++
+  build: cmake
+  license: MIT
+  maintainers:
+    - neuesql
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw"
+
+repo:
+  github: neuesql/atm_talib
+  ref: e13ee1f9f321f7a7552647e4ded47d2aa23b72d8
+
+docs:
+  hello_world: |
+    -- Moving averages and RSI on financial data
+    SELECT ta_sma([1.0, 2.0, 3.0, 4.0, 5.0], 3);
+  extended_description: |
+    100+ TA-Lib technical analysis indicators as native DuckDB functions.
+    Includes momentum (RSI, MACD, Stochastic), overlap studies (SMA, EMA, BBANDS),
+    volatility (ATR, NATR), 49 candlestick pattern recognizers, volume indicators,
+    cycle indicators, and math/statistics functions.
+
+    Functions are available in two modes:
+    - Scalar (ta_* prefix): operate on pre-collected lists
+    - Window/Aggregate (taw_* prefix): use OVER() for row-by-row computation


### PR DESCRIPTION
## Summary

- Adds the `talib` extension: 100+ TA-Lib technical analysis indicators as native DuckDB functions
- Includes momentum (RSI, MACD), overlap studies (SMA, EMA, BBANDS), volatility (ATR), 49 candlestick pattern recognizers, volume/cycle indicators, and math/statistics functions
- Functions available in scalar (`ta_*`) and window/aggregate (`taw_*`) modes

## Extension details

- **Source:** https://github.com/neuesql/atm_talib
- **Language:** C++
- **License:** MIT
- **Build:** cmake (uses FetchContent to pull TA-Lib v0.6.4)
- **Excluded platforms:** wasm_mvp, wasm_eh, wasm_threads, windows_amd64_rtools, windows_amd64_mingw

## Quick example

```sql
 # INSTALL talib FROM community; 
INSTALL talib FROM 'https://neuesql.github.io/atm_talib';   # install with repository                                
  LOAD talib;

  -- Simple Moving Average                                                                                                                         
  SELECT ta_sma([1.0, 2.0, 3.0, 4.0, 5.0], 3);
  -- [NULL, NULL, 2.0, 3.0, 4.0]                                                                                                                   
                                                                                                                                                   
  -- RSI on a window
  SELECT symbol, taw_rsi(close, 14) OVER (PARTITION BY symbol ORDER BY date)                                                                       
  FROM stock_prices;  

```
