### PR TITLE
Bump `decimal_arithmetic`

### DIFF
--- a/extensions/decimal_arithmetic/description.yml
+++ b/extensions/decimal_arithmetic/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: decimal_arithmetic
   description: Extension that adds support special decimal arithmetic functions 
-  version: 0.0.1
+  version: 0.0.2
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: duckdb/duckdb-decimal-arithmetic
-  ref: 16dd3862eb982875b8b81910c5a377a8b2196258 
+  ref: f446d50383a7034cbe0f9bc106ecdb0ed68ec2f4 
 
 docs:
   hello_world: |


### PR DESCRIPTION
Changed the behaviour of `decimal_avg` to make the output type be equal to the input type (Used to default to width of 38, and scale based on input)