### PR TITLE
Update raquet extension to v0.2.3

### DIFF
--- a/extensions/raquet/description.yml
+++ b/extensions/raquet/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: jatorre/duckdb-raquet
-  ref: 1b5506298812cd905a2fec1afe004d17336016c5
+  ref: 931b5ff1aea9b98e9d77214fbf6c800210b39b60
 
 docs:
   hello_world: |

--- a/extensions/raquet/description.yml
+++ b/extensions/raquet/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: raquet
   description: "Raster analytics on Raquet files with QUADBIN spatial indexing, raster ingestion, and PostGIS-style functions"
-  version: 0.2.2
+  version: 0.2.3
   language: C++
   build: cmake
   license: Apache-2.0
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: jatorre/duckdb-raquet
-  ref: e2a2193565a45c329be5d066556ee0aaeae77de4
+  ref: 1b5506298812cd905a2fec1afe004d17336016c5
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary

- Bump DuckDB submodule from v1.5.0 to v1.5.2 (bug fixes for Parquet, geometry, memory)
- Enable GDAL network support (`curl`/`openssl`) so `read_raster()` can access remote files via `/vsicurl/` URLs
- Fix SIGSEGV in `read_raster()` with `ORDER BY` (race condition in overview phase)

## Changes

- `version`: 0.2.2 → 0.2.3
- `ref`: e2a2193 → 1b55062

All 224 existing tests pass against DuckDB v1.5.2.