### PR TITLE
Update financial technical analysis - talib extension to v0.1.1

### DIFF
--- a/extensions/talib/description.yml
+++ b/extensions/talib/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: talib
   description: "Technical Analysis Library (TA-Lib) functions for DuckDB -- 100+ indicators for financial market analysis"
-  version: 0.1.0
+  version: 0.1.1
   language: C++
   build: cmake
   license: MIT
@@ -11,18 +11,33 @@ extension:
 
 repo:
   github: neuesql/atm_talib
-  ref: e13ee1f9f321f7a7552647e4ded47d2aa23b72d8
+  ref: e3f6fb79dda4e930e0fa25ce68a6a0a2383645da
 
 docs:
   hello_world: |
-    -- Moving averages and RSI on financial data
-    SELECT ta_sma([1.0, 2.0, 3.0, 4.0, 5.0], 3);
-  extended_description: |
-    100+ TA-Lib technical analysis indicators as native DuckDB functions.
-    Includes momentum (RSI, MACD, Stochastic), overlap studies (SMA, EMA, BBANDS),
-    volatility (ATR, NATR), 49 candlestick pattern recognizers, volume indicators,
-    cycle indicators, and math/statistics functions.
+    -- Scalar form: operate on a pre-collected list
+    SELECT t_sma([1.0, 2.0, 3.0, 4.0, 5.0], 3);
 
-    Functions are available in two modes:
-    - Scalar (ta_* prefix): operate on pre-collected lists
-    - Window/Aggregate (taw_* prefix): use OVER() for row-by-row computation
+    -- Aggregate/window form: use OVER() for row-by-row SMA
+    SELECT date, close,
+           ta_sma(close, 14) OVER (ORDER BY date
+                                   ROWS BETWEEN 13 PRECEDING AND CURRENT ROW) AS sma_14
+    FROM ohlc;
+
+    -- Multi-output indicators return structs (MACD, Bollinger Bands)
+    SELECT t_macd(list(close ORDER BY date), 12, 26, 9) FROM ohlc;
+    SELECT t_bbands(list(close ORDER BY date), 20, 2.0, 2.0, 0) FROM ohlc;
+
+    -- Candlestick pattern recognition
+    SELECT t_cdldoji(list(open  ORDER BY date), list(high  ORDER BY date),
+                     list(low   ORDER BY date), list(close ORDER BY date))
+    FROM ohlc;
+  extended_description: |
+    100+ TA-Lib indicators as native DuckDB functions: overlap studies
+    (SMA, EMA, BBANDS), momentum (RSI, MACD, Stochastic), volatility
+    (ATR, NATR), volume and cycle indicators, math/statistics, and
+    candlestick pattern recognizers.
+
+    Every function is registered in two forms:
+    - Scalar (`t_*`): pass pre-collected lists, returns a list
+    - Aggregate/window (`ta_*`): use with `OVER()` for row-by-row results


### PR DESCRIPTION
## Summary
- Bump `talib` ref to `e3f6fb79dda4e930e0fa25ce68a6a0a2383645da` (latest `main` of neuesql/atm_talib)
- Version: `0.1.0` → `0.1.1`
- Refresh `hello_world` / `extended_description` to reflect the new function-naming convention. Previous docs referenced the older `ta_*` / `taw_*` split.

| Aspect | Old Convention 0.1.0 | New Convention 0.1.1 |
|---|---|---|
| Scalar functions | `ta_*` | `t_*` |
| Aggregate-window functions | `taw_*` | `ta_*` |


- Expand with diverse examples: SMA (window OVER), MACD, Bollinger Bands, and a candlestick pattern recognizer.

## Test plan
- [x] Community Extensions CI builds `talib` at the new ref across the non-excluded platforms
- [x] `t_sma`, `ta_sma OVER (...)`, `t_macd`, `t_bbands`, `t_cdldoji` are queryable from the resulting extension

```sql
-- 1️⃣ List form (shortest & fastest): whole-series, returns a LIST<DOUBLE>
SELECT t_sma(list(close ORDER BY date), 14) FROM ohlc WHERE ticker = 'NVDA';

-- 2️⃣ Window, bounded frame (fast, one row per input): recommended for dashboards
SELECT date, close, ta_sma(close, 14) OVER (ORDER BY date ROWS BETWEEN 13 PRECEDING AND CURRENT ROW) AS sma_14 FROM ohlc WHERE ticker = 'NVDA';

-- 3️⃣ Window, default frame (shortest SQL, but O(N²) — to avoid on large tables)
SELECT date, close, ta_sma(close, 14) OVER (ORDER BY date) AS sma_14 FROM ohlc WHERE ticker = 'NVDA';

```
## More Example 
```sql
-- 📐 MACD with STRUCT output
SELECT t_macd(list(close ORDER BY date), 12, 26, 9) FROM ohlc WHERE ticker = 'NVDA';
-- 🕯️ Candlestick pattern detection
SELECT t_cdldoji(list(open ORDER BY date), list(high ORDER BY date), list(low ORDER BY date), list(close ORDER BY date)) FROM ohlc WHERE ticker = 'NVDA';
```
