### PR TITLE
bump zeek to 0.4.1

### DIFF
--- a/extensions/zeek/description.yml
+++ b/extensions/zeek/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: zeek
   description: Read Zeek network security monitor log files with automatic schema detection and type-aware parsing
-  version: 0.4.0
+  version: 0.4.1
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: ynadji/zeek-duckdb
-  ref: 47e6491094f188e6987d105c178b72d272c05539
+  ref: ad3580e3ba6130d0da395ad283cfca4e9cbb2024
 
 docs:
   hello_world: |


### PR DESCRIPTION
on 0.4.0 my extension was pinned to 1.5.1 still. this bumps it to 1.5.2. 

is that why i'm [not seeing the newer version](https://github.com/duckdb/community-extensions/pull/1738#issuecomment-4260337282)? still figuring out the process here.