### PR TITLE
Update plinking_duck to v0.4.1

### DIFF
--- a/extensions/plinking_duck/description.yml
+++ b/extensions/plinking_duck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: plinking_duck
   description: Read PLINK 2 genomics file formats and run common genetic analyses directly in SQL
-  version: 0.4.0
+  version: 0.4.1
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: teaguesterling/plinking_duck
-  ref: 50612cfc91659347291359c97cf9ae845581b82c
+  ref: 77be4d088b52382ed3e0568a43427e355cb2d114
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary
- Update plinking_duck from v0.4.0 to v0.4.1
- Biobank-scale bind performance: region-filtered `read_pfile` bind on 1M+ samples × 1.5M variants drops from ~8000ms to ~7ms (measured on synthetic parquet companions). Projected sub-100ms at the 100M+ variant panel scale.
- Columnar `VariantMetadataIndex` replaces the synthesized text-buffer+re-parse round-trip; parquet region filters are pushed into the scan via `WHERE CHROM = ? AND POS BETWEEN ? AND ?` with `file_row_number`; `iid_to_idx` is lazy; ParseRegion / CPRA lookups use binary search on POS.
- Hardening: text `.pvar`/`.bim` parser rejects truncated rows with a clear error; non-contiguous chroms in generic SQL-view sources are caught; region-pushdown SQL uses prepared statements.
- No SQL API changes.

## Release
https://github.com/teaguesterling/plinking_duck/releases/tag/v0.4.1