### PR TITLE
Update astro extension to v1.4.1 (FITS file I/O + DuckDB v1.5.2)

### DIFF
--- a/extensions/astro/description.yml
+++ b/extensions/astro/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: astro
-  description: Astronomical calculations - coordinate transforms, photometry, cosmology, dust extinction, sidereal time
-  version: 1.3.0
+  description: Astronomical calculations + FITS file I/O - coordinate transforms, photometry, cosmology, dust extinction, sidereal time
+  version: 1.4.0
   language: C++
   build: cmake
   license: MIT
@@ -10,18 +10,21 @@ extension:
 
 repo:
   github: synapticore-io/astro-duck
-  ref: 72d996fc93b40c42564d6c94ed6ed042b5a858f4
+  ref: 039eaf58664d4a61db0ba90d29d7fccb315f9514
 
 docs:
   hello_world: |
     SELECT astro_angular_separation(10.68, 41.27, 83.82, -5.39) AS separation_deg;
   extended_description: |
-    The astro extension adds 53+ astronomical calculation functions to
-    DuckDB: coordinate transforms (equatorial / galactic frames, RA/Dec
-    to XYZ), angular separation, photometry (magnitude/flux, distance
-    modulus, absolute magnitude), CCM89 + O'Donnell 1994 dust extinction
-    with UBVRIJHK bands, cosmological distances (luminosity, comoving),
-    celestial body models (stars, brown dwarfs, planets, black holes,
-    asteroids), Keplerian orbital mechanics, 3D octree spatial sectors,
-    and sidereal time / observation planning (GMST, LMST, hour angle,
-    equatorial to horizontal alt/az conversion).
+    The astro extension adds 62 functions (59 scalar + 3 FITS table
+    functions) to DuckDB: coordinate transforms (equatorial / galactic
+    frames, RA/Dec to XYZ), angular separation, photometry
+    (magnitude/flux, distance modulus, absolute magnitude), CCM89 +
+    O'Donnell 1994 dust extinction with UBVRIJHK bands, cosmological
+    distances (luminosity, comoving), celestial body models (stars,
+    brown dwarfs, planets, black holes, asteroids), Keplerian orbital
+    mechanics, 3D octree spatial sectors, sidereal time / observation
+    planning (GMST, LMST, hour angle, equatorial to horizontal alt/az
+    conversion), and FITS file I/O (fits_hdus, fits_header, read_fits
+    via cfitsio) for reading astronomical catalogs and images directly
+    from SQL.

--- a/extensions/astro/description.yml
+++ b/extensions/astro/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: astro
   description: Astronomical calculations + FITS file I/O - coordinate transforms, photometry, cosmology, dust extinction, sidereal time
-  version: 1.4.0
+  version: 1.4.1
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: synapticore-io/astro-duck
-  ref: 039eaf58664d4a61db0ba90d29d7fccb315f9514
+  ref: a9f49d72ff4fd4c56a4ae0927172c15b204b910b
 
 docs:
   hello_world: |


### PR DESCRIPTION
Update the astro extension from v1.3.0 to **v1.4.1**.

### What's new in v1.4.0 → v1.4.1

**v1.4.0** — FITS file I/O via vendored [cfitsio](https://heasarc.gsfc.nasa.gov/fitsio/):

| Function | Description |
|----------|-------------|
| `fits_hdus(path)` | List all HDUs in a FITS file |
| `fits_header(path, hdu:=N)` | Read header keywords |
| `read_fits(path, hdu:=N, header:=false, flatten:=true)` | Read BINTABLE or IMAGE HDU as rows |

**v1.4.1** — bump to DuckDB **v1.5.2** (submodules + CI pinned to the v1.5.2 tag, previously tracking the v1.5-variegata dev branch).

### Release

- Tag: [v1.4.1](https://github.com/synapticore-io/astro-duck/releases/tag/v1.4.1)
- CI on v1.4.0: all platforms green (linux_amd64, linux_arm64, osx_amd64, osx_arm64, windows_amd64, wasm_mvp, wasm_eh, wasm_threads)
- Total functions: **62** (59 scalar + 3 FITS table functions)

### Checklist

- [x] Bump `version` to 1.4.1
- [x] Update `ref` to the v1.4.1 tag commit (a9f49d72ff4fd4c56a4ae0927172c15b204b910b)
- [x] Extend description to mention FITS support
- [x] Built against DuckDB v1.5.2