### PR TITLE
Update dplyr community extension descriptor

### DIFF
--- a/extensions/dplyr/description.yml
+++ b/extensions/dplyr/description.yml
@@ -19,7 +19,7 @@ extension:
 
 repo:
   github: mrchypark/libdplyr
-  ref: 01961b7ebf2888e0f29e18c0eb7154dde027e422
+  ref: v0.3.3
 
 docs:
   hello_world: |

--- a/extensions/dplyr/description.yml
+++ b/extensions/dplyr/description.yml
@@ -8,17 +8,18 @@
 extension:
   name: dplyr
   description: R dplyr pipeline syntax support for DuckDB - transpiles dplyr verbs to SQL
-  version: 0.3.1
-  language: C++
+  version: 0.3.3
+  language: Rust & C++
   build: cmake
   license: MIT
+  excluded_platforms: "windows_amd64_rtools"
   requires_toolchains: "rust"
   maintainers:
     - mrchypark
 
 repo:
   github: mrchypark/libdplyr
-  ref: 734061b2658b6ac7897398c6da051ed61b8ae3b4
+  ref: 01961b7ebf2888e0f29e18c0eb7154dde027e422
 
 docs:
   hello_world: |
@@ -78,28 +79,22 @@ docs:
     It transpiles dplyr pipeline syntax (using the `%>%` pipe operator) directly to SQL,
     allowing R users to write familiar data manipulation code in DuckDB.
 
-    ## Supported Functions
-    
-    ### Core Verbs
-    | Function | Description | Example |
-    | :--- | :--- | :--- |
-    | `select()` | Select/rename columns | `select(id, name)` |
-    | `filter()` | Filter rows | `filter(age > 18)` |
-    | `mutate()` | Create/modify columns | `mutate(total = price * qty)` |
-    | `rename()` | Rename columns | `rename(new = old)` |
-    | `arrange()` | Sort rows | `arrange(desc(date))` |
-    | `group_by()` | Group rows | `group_by(dept)` |
-    | `summarise()` | Aggregate data | `summarise(avg = mean(val))` |
-    | `*_join()` | Joins (inner, left, etc.) | `left_join(other, by="id")` |
-    | Set Ops | union, intersect, setdiff | `union(other)` |
-    
-    ### Helper Functions
-    *   **Aggregation**: `mean`, `sum`, `min`, `max`, `n`, `count`, `median`*, `mode`*
-    *   **Window**: `row_number`, `rank`, `lead`, `lag`, `ntile`
-    *   **Math**: `abs`, `sqrt`, `round`, `floor`, `log`, `exp`
-    *   **String**: `tolower`, `toupper`, `substr`, `trimws`
-    *   **Logic**: `ifelse`, `is.na`, `coalesce`
+    **Supported dplyr Verbs:**
+    - `select()` - Choose columns by name
+    - `filter()` - Filter rows based on conditions
+    - `mutate()` - Create new columns or modify existing ones
+    - `arrange()` - Sort rows (supports `desc()` for descending order)
+    - `group_by()` - Group data by one or more columns
+    - `summarise()` / `summarize()` - Aggregate grouped data
+    - `rename()` - Rename columns
 
+    **Aggregation Functions:**
+    - `n()` - Count rows
+    - `mean()` / `avg()` - Average
+    - `sum()` - Sum
+    - `min()` / `max()` - Minimum / Maximum
+    - `median()` / `mode()` - DuckDB-specific aggregates
+    - Other aggregate function names are passed through to DuckDB (uppercased).
 
     **Key Features:**
     - Native R dplyr syntax support with `%>%` pipe operator

--- a/extensions/dplyr/description.yml
+++ b/extensions/dplyr/description.yml
@@ -19,7 +19,7 @@ extension:
 
 repo:
   github: mrchypark/libdplyr
-  ref: v0.3.3
+  ref: a0ce561ced49c3da1187b02bc4d9be1b1e5913ae
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary
- update the `dplyr` community extension descriptor to the current `libdplyr` submission snapshot
- mark the extension as a mixed Rust/C++ build with a Rust toolchain requirement
- exclude `windows_amd64_rtools`, which is not part of this extension's supported toolchain path
- point `repo.ref` to the tested `libdplyr` submission commit

## Notes
- `libdplyr` uses a Rust core with a C API bridge and a DuckDB C++ extension adapter.
- The community descriptor is targeted at the current latest stable DuckDB line.
- Repository CI still keeps a separate DuckDB `1.4.0` compatibility lane, but this should be read as a source compatibility check rather than a claim that one distributed unstable/C++ extension binary spans both `1.4.x` and `1.5.x`.
- The extension exposes parser-extension syntax such as `%>%` and embedded pipelines `(| ... |)`, so the `extended_description` was tightened to explain that behavior more directly.

## Upstream source snapshot
- `mrchypark/libdplyr@01961b7ebf2888e0f29e18c0eb7154dde027e422`
