### PR TITLE
Add us_address_standardizer v0.1.0

### DIFF
--- a/extensions/us_address_standardizer/description.yml
+++ b/extensions/us_address_standardizer/description.yml
@@ -1,0 +1,38 @@
+extension:
+  name: us_address_standardizer
+  description: US address parsing and standardization (PAGC + Rust addrust)
+  version: 0.1.0
+  language: C/Rust
+  build: cmake
+  license: MIT
+  maintainers:
+    - ericmanning
+    - sj-io
+  excluded_platforms: "osx_amd64;windows_amd64;wasm_mvp;wasm_eh;wasm_threads"
+  requires_toolchains: "python3;rust"
+
+repo:
+  github: ericmanning/duckdb-address-standardizer
+  ref: 2d1522898b2d9d20b34c90ee112900789cedf955
+
+docs:
+  hello_world: |
+    -- addrust parser (no reference tables required)
+    SELECT addrust_parse('123 N Main St Apt 4, Springfield IL 62704');
+
+    -- PAGC (Postgis) standardizer (loads reference tables from embedded data)
+    SELECT load_us_address_data();
+    SELECT standardize_address('us_lex', 'us_gaz', 'us_rules',
+        '123 Main Street', 'Kansas City, MO 45678');
+  extended_description: |
+    Provides two US address parsers:
+
+    - `addrust_parse` — Rust-based parser from the
+      [addrust](https://github.com/EvictionLab/addrust) project, with
+      optional TOML configuration for customizable parsing pipelines.
+    - `parse_address` / `standardize_address` — PAGC rule-based parsers
+      ported from the
+      [PostGIS address_standardizer](https://github.com/postgis/address_standardizer).
+      Call `load_us_address_data()` first to populate the reference tables
+      from data embedded in the extension binary.
+    - For more information, visit the [GitHub repository](https://github.com/ericmanning/duckdb-address-standardizer).


### PR DESCRIPTION
## Summary

New community extension: [us_address_standardizer](https://github.com/ericmanning/duckdb-address-standardizer) v0.1.0 — US address parsing and standardization.

w/ @sj-io

## Functions

- `addrust_parse(addr)` / `addrust_parse(addr, toml_config_path)` — Rust-based parser via the [addrust](https://github.com/EvictionLab/addrust) crate; returns a 15-field struct.
- `parse_address(addr)` — PAGC regex-based parser; returns a 9-field struct.
- `standardize_address(...)` — full PAGC rule-based standardization (4- and 5-arg forms); requires reference tables.
- `load_us_address_data([schema])` — populates `us_lex`, `us_gaz`, `us_rules` from data embedded in the extension binary.
- `debug_standardize_address(...)` — debug trace variant.

Ported from the [PostGIS address_standardizer](https://github.com/postgis/address_standardizer).

## Build

C API extension (`USE_UNSTABLE_C_API=0`, `TARGET_DUCKDB_VERSION=v1.2.0`) with a Rust static library for the `addrust` parser. Built via CMake + `extension-ci-tools` v1.5.2.

## Platform support

Excluded: `osx_amd64`, `windows_amd64` (MSVC), `wasm_*`. Builds on: `linux_amd64`, `linux_arm64`, `osx_arm64`, `windows_amd64_mingw` — all verified green in [our v1.5.2 CI run](https://github.com/ericmanning/duckdb-address-standardizer/actions/runs/24671048155).