### PR TITLE
fix: web_search 0.4.1 - DuckDB 1.5.2 compatibility

### DIFF
--- a/extensions/web_search/description.yml
+++ b/extensions/web_search/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb-web-search
-  ref: 0b16e39d408621cd00ad00d6a0c97487f2dedb34
+  ref: 31b017c382f3d9122b77c2b06f84413002395199
 
 docs:
   hello_world: |

--- a/extensions/web_search/description.yml
+++ b/extensions/web_search/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: web_search
   description: Query Google Custom Search API directly from SQL with filter pushdowns
-  version: 0.4.0
+  version: 0.4.1
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb-web-search
-  ref: 7993d775af7f1ab07bb4be1a0a1a68cf65ab8e9b
+  ref: 0b16e39d408621cd00ad00d6a0c97487f2dedb34
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary

- Add explicit `#include "duckdb/optimizer/optimizer_extension.hpp"` (required in 1.5.x)
- Use `OptimizerExtension::Register()` static method instead of direct `config.optimizer_extensions.push_back()` (removed in 1.5.x)
- Bump version to 0.4.1, update CI to target `v1.5.2`

## Changes

`midwork-finds-jobs/duckdb-web-search@0b16e39`

```diff
+#include "duckdb/optimizer/optimizer_extension.hpp"

-auto &config = DBConfig::GetConfig(db);
 OptimizerExtension optimizer;
 optimizer.optimize_function = WebSearchOptimizer;
-config.optimizer_extensions.push_back(std::move(optimizer));
+OptimizerExtension::Register(DBConfig::GetConfig(db), std::move(optimizer));
```