### PR TITLE
snowflake: v0.4.0 for DuckDB v1.5.2

### DIFF
--- a/extensions/snowflake/description.yml
+++ b/extensions/snowflake/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: snowflake
   description: Snowflake data source extension - query Snowflake databases directly from DuckDB
-  version: 0.3.0
+  version: 0.4.0
   language: C++
   build: cmake
   license: MIT
@@ -10,10 +10,10 @@ extension:
 
 repo:
   github: iqea-ai/duckdb-snowflake
-  ref: a2a3aed55b92e9a15dcc2f2ee57ac249dde5e07b
+  ref: be9f4cd25beec33556a3ae6f6d267c6acbd4710e
 
 install_notes: |
-  **Important:** This extension requires DuckDB 1.5.0 and the Apache Arrow ADBC Snowflake driver to function properly.
+  **Important:** This extension requires DuckDB 1.5.2 and the Apache Arrow ADBC Snowflake driver to function properly.
   
   **You must install the ADBC driver separately after installing this extension.** The extension will not work without the driver.
   
@@ -58,10 +58,10 @@ docs:
   extended_description: |
     This community-maintained extension allows DuckDB to connect to Snowflake using Arrow ADBC drivers. 
     It provides seamless connectivity between DuckDB and Snowflake, supporting multiple authentication methods 
-    (password, external browser/SSO, key pair), predicate pushdown optimization, and comprehensive SQL operations.
+    (password, key pair, OAuth, external browser/SSO, Okta), predicate pushdown optimization, and comprehensive SQL operations.
     
     **Features:**
-    - Multiple authentication methods (Password, External Browser/SSO, Key Pair)
+    - Multiple authentication methods (Password, Key Pair, OAuth, External Browser/SSO, Okta)
     - Direct SQL passthrough via `snowflake_query()` function
     - ATTACH support for mounting Snowflake databases as DuckDB catalogs
     - Predicate pushdown optimization (optional)


### PR DESCRIPTION
## Summary

- Bump `extension.version` to `0.4.0`
- Update `repo.ref` to [`be9f4cd2`](https://github.com/iqea-ai/duckdb-snowflake/commit/be9f4cd25beec33556a3ae6f6d267c6acbd4710e) (merge of [iqea-ai/duckdb-snowflake#31](https://github.com/iqea-ai/duckdb-snowflake/pull/31))
- `install_notes`: requires DuckDB `1.5.0` → `1.5.2`
- Correct the advertised auth-method list in `extended_description` — v0.3.0 already supported OAuth and Okta via the `AuthType` enum but only listed three; now shows five: Password, Key Pair, OAuth, External Browser/SSO, Okta

## Changes in the extension repo since v0.3.0

| PR | Change |
|---|---|
| [#25](https://github.com/iqea-ai/duckdb-snowflake/pull/25) | Fix `snowflake_query` projection crash under DuckDB v1.5 Arrow scanner |
| [#27](https://github.com/iqea-ai/duckdb-snowflake/pull/27) | Fix PEM parsing regression (Issue #26) and snowflake_query segfault (Issue #21); harden OAuth / Okta code paths |
| [#30](https://github.com/iqea-ai/duckdb-snowflake/pull/30) | Fix ADBC option keys for OAuth token, Okta URL, keep-alive |
| [#31](https://github.com/iqea-ai/duckdb-snowflake/pull/31) | Bump DuckDB submodule to v1.5.2, pin all workflow refs, update docs |

No new functions, types, or SECRET parameters were added — all changes are bug fixes and hardening of existing surface.

## Test plan

- [x] `make release` against DuckDB v1.5.2 builds clean
- [x] `./build/release/test/unittest -d yes "*snowflake_*"` — 16/16 cases, 1892/1892 assertions (2 OAuth skipped for missing `SNOWFLAKE_OAUTH_USER`)
- [x] `./build/release/test/unittest -d yes "[pushdown]"` — 10/10 cases, 276 assertions
- [x] Smoke test: `./build/release/duckdb` (v1.5.2) loads the built extension; `snowflake_version()` returns `Snowflake Extension v0.1.0`
- [x] community-extensions rebuild pipeline green across all platforms