### PR TITLE
Add duck_geoarrow extension and update duck_dggs version

### DIFF
--- a/extensions/duck_dggs/description.yml
+++ b/extensions/duck_dggs/description.yml
@@ -1,7 +1,8 @@
 extension:
   name: duck_dggs
-  description: DuckDB extension for discrete global grid systems (DGGS) powered by DGGRID v8, Built against DuckDB v1.5.1.
-  version: 0.1.4
+  description: DuckDB extension for discrete global grid systems (DGGS) powered by DGGRID v8.
+  
+  version: 0.1.6
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +11,7 @@ extension:
 
 repo:
   github: am2222/duckdb-dggs
-  ref: 76879e82509152bac193a1451c96f97561e36a21
+  ref: 25b51cb5f0bdb04ffe236956e640e3e01f8440e2
 
 docs:
   hello_world: |
@@ -121,3 +122,19 @@ docs:
     - `seqnum_to_z3` / `z3_to_seqnum` — Z3 index (aperture 3 only)
     - `seqnum_to_z7` / `z7_to_seqnum` — Z7 index (aperture 7 only)
     - `seqnum_to_vertex2dd` / `vertex2dd_to_seqnum` — vertex-based 2D coordinates
+
+    **IGEO7 / Z7 bit-level operations** (operate directly on the packed 64-bit Z7 index;
+    no `dggs_params` needed; logic ported from [`allixender/igeo7_duckdb`](https://github.com/allixender/igeo7_duckdb)):
+
+    - `igeo7_from_string` / `igeo7_to_string` — compact string ↔ packed 64-bit index
+    - `igeo7_encode` — pack base cell + 20 three-bit digit slots
+    - `igeo7_encode_at_resolution` — `igeo7_encode` then truncate to a target resolution
+    - `igeo7_get_resolution` — resolution (0–20) from a packed index
+    - `igeo7_get_base_cell` — base cell ID (0–11)
+    - `igeo7_get_digit` — extract the i-th digit (1–20)
+    - `igeo7_parent` / `igeo7_parent_at` — ancestor at res-1 or a specific resolution
+    - `igeo7_get_neighbours` / `igeo7_get_neighbour` — all 6 neighbours or one by direction
+    - `igeo7_first_non_zero` — position of the first non-zero digit slot
+    - `igeo7_is_valid` — false only for the `UINT64_MAX` invalid-neighbour sentinel
+    - `igeo7_decode_str` — verbose `base-d1.d2…d20` form showing all 20 slots (SQL macro)
+    - `igeo7_string_parent` / `igeo7_string_local_pos` / `igeo7_string_is_center` — compact-string helpers (SQL macros)

--- a/extensions/duck_geoarrow/description.yml
+++ b/extensions/duck_geoarrow/description.yml
@@ -1,0 +1,71 @@
+extension:
+  name: duck_geoarrow
+  description: DuckDB extension for converting GEOMETRY/WKB to and from GeoArrow native encodings, powered by geoarrow-c. Built against DuckDB v1.5.2.
+  version: 0.1.0
+  language: C++
+  build: cmake
+  license: MIT
+  maintainers:
+    - am2222
+
+repo:
+  github: am2222/duck_geoarrow
+  ref: 3d0e6c597842753591633173826446b50f35b2b3
+
+docs:
+  hello_world: |
+    INSTALL duck_geoarrow FROM community;
+    LOAD duck_geoarrow;
+
+    -- Convert a WKB point to GeoArrow struct
+    SELECT st_asgeoarrow('\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xF0\x3F\x00\x00\x00\x00\x00\x00\x00\x40'::BLOB);
+    -- → {geometry_type: 1, xs: [1.0], ys: [2.0], ring_offsets: [], geom_offsets: []}
+
+    -- With the spatial extension loaded, use GEOMETRY directly
+    LOAD spatial;
+    SELECT st_asgeoarrow(ST_Point(1.0, 2.0)::GEOMETRY);
+
+    -- Convert back: GeoArrow struct → GEOMETRY (WKB)
+    SELECT st_geomfromgeoarrow(st_asgeoarrow(ST_Point(30, 10)::GEOMETRY));
+
+    -- Native-typed point extraction (returns STRUCT<x, y>)
+    SELECT st_asgeoarrowpoint(ST_Point(30, 10)::GEOMETRY);
+    -- → {x: 30.0, y: 10.0}
+
+    -- Native-typed linestring (returns List<Struct<x, y>>)
+    SELECT st_asgeoarrowlinestring(ST_GeomFromText('LINESTRING(0 0, 1 1, 2 2)')::GEOMETRY);
+
+    -- Native-typed polygon (returns List<List<Struct<x, y>>>)
+    SELECT st_asgeoarrowpolygon(ST_GeomFromText('POLYGON((0 0, 4 0, 4 4, 0 4, 0 0))')::GEOMETRY);
+
+    -- Version info
+    SELECT duck_geoarrow_version();
+
+  extended_description: |
+    `duck_geoarrow` converts between DuckDB's WKB-based `GEOMETRY`/`BLOB` type and
+    [GeoArrow](https://geoarrow.org) native struct encodings, powered by
+    [geoarrow-c](https://github.com/geoarrow/geoarrow-c).
+
+    **Generic conversion functions** (accept `GEOMETRY` or `BLOB` containing WKB):
+
+    - `st_asgeoarrow(geom)` — WKB → GeoArrow struct with geometry_type, xs, ys, ring_offsets, geom_offsets
+    - `st_geomfromgeoarrow(struct)` — GeoArrow struct → WKB `GEOMETRY`
+
+    **Native-typed functions** (return Arrow-native nested types for direct columnar use):
+
+    | Function | Arrow type |
+    |---|---|
+    | `st_asgeoarrowpoint` | `Struct<x: DOUBLE, y: DOUBLE>` |
+    | `st_asgeoarrowlinestring` | `List<Struct<x, y>>` |
+    | `st_asgeoarrowpolygon` | `List<List<Struct<x, y>>>` |
+    | `st_asgeoarrowmultipoint` | `List<Struct<x, y>>` |
+    | `st_asgeoarrowmultilinestring` | `List<List<Struct<x, y>>>` |
+    | `st_asgeoarrowmultipolygon` | `List<List<List<Struct<x, y>>>>` |
+
+    **Utility:**
+
+    - `duck_geoarrow_version()` — returns extension and geoarrow-c version info
+
+    All functions accept both `GEOMETRY` (from the spatial extension) and raw `BLOB`
+    containing valid WKB. The native-typed functions validate that the input geometry
+    matches the expected type and raise an error on mismatch.


### PR DESCRIPTION
Introduce the `duck_geoarrow` extension for converting between GEOMETRY/WKB and GeoArrow native encodings, along with an update to the `duck_dggs` extension version and refined documentation.