### PR TITLE
duckhog: v0.2.0 for DuckDB v1.5.2

### DIFF
--- a/extensions/duckhog/description.yml
+++ b/extensions/duckhog/description.yml
@@ -1,6 +1,6 @@
 extension:
   name: duckhog
-  description: Query PostHog data warehouse from DuckDB over Arrow Flight SQL
+  description: Query Arrow Flight SQL servers that expose DuckLake-based catalogs and tables directly from DuckDB using standard SQL — including PostHog's managed data warehouse via [Duckgres](https://github.com/PostHog/duckgres).
   version: 0.2.0
   language: C++
   build: cmake

--- a/extensions/duckhog/description.yml
+++ b/extensions/duckhog/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duckhog
   description: Query PostHog data warehouse from DuckDB over Arrow Flight SQL
-  version: 0.1.0
+  version: 0.2.0
   language: C++
   build: cmake
   # duckhog requires Arrow Flight/FlightSQL via vcpkg; Arrow does not support wasm32-emscripten.
@@ -10,11 +10,11 @@ extension:
   requires_toolchains: parser_tools
   license: MIT
   maintainers:
-    - bill-ph
+    - PostHog
 
 repo:
   github: PostHog/duckhog
-  ref: 996199891ebb47e9fcff64bb04586b1b7de5e2f2
+  ref: v0.2.0
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary

- Bump `extension.version` to `0.2.0`
- Update `repo.ref` to [`v0.2.0`](https://github.com/PostHog/duckhog/releases/tag/v0.2.0) (commit [`00e9b86`](https://github.com/PostHog/duckhog/commit/00e9b863dd88b2eafeaebaf8a85c517ffe6e83fa), merge of [PostHog/duckhog#92](https://github.com/PostHog/duckhog/pull/92))
- Move `maintainers` from `bill-ph` (personal) to the `PostHog` org

## Changes in the extension repo since v0.1.0

| PR | Change |
|---|---|
| [#84](https://github.com/PostHog/duckhog/pull/84) | RM14: Structured type support — list, struct, and map |
| [#86](https://github.com/PostHog/duckhog/pull/86) | Security tests; fix D5 identifier quoting |
| [#92](https://github.com/PostHog/duckhog/pull/92) | Upgrade to DuckDB v1.5.2 baseline |

## Test plan

- [x] PostHog/duckhog#92 distribution pipeline green across all non-WASM platforms — Linux x86_64/ARM64, macOS x86_64/arm64, Windows MSVC, Windows MinGW, Tidy Check (uses the same `_extension_distribution.yml` reusable workflow this registry uses)
- [x] community-extensions rebuild pipeline green across all platforms

WASM remains excluded — Arrow has no `wasm32-emscripten` support.