### PR TITLE
Update DuckDB Elasticsearch extension references

### DIFF
--- a/extensions/elasticsearch/description.yml
+++ b/extensions/elasticsearch/description.yml
@@ -9,8 +9,8 @@ extension:
     - tlinhart
 repo:
   github: tlinhart/duckdb-elasticsearch
-  ref: 7c10995f0b03db4b2979e32aa4805e04001aeefe
-  ref_next: d889b24d551e20b30874aa88eafbb5e7c92d3e90
+  ref: 5b340f5460e22e282f469eb3e021d3cce0b9d747
+  ref_next: e89032ec14cd3746917645c7542171409a97f2f3
 docs:
   hello_world: |
     -- Basic query.


### PR DESCRIPTION
Bump to DuckDB core v1.5.2.