### PR TITLE
Add protoduck v0.1.0

### DIFF
--- a/extensions/protoduck/description.yml
+++ b/extensions/protoduck/description.yml
@@ -1,0 +1,50 @@
+extension:
+  name: protoduck
+  description: Deserialize Protocol Buffer messages stored in DuckDB columns
+  version: 0.1.0
+  language: Rust
+  build: cmake
+  license: MIT
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads"
+  requires_toolchains: "rust;python3"
+  maintainers:
+    - fcsnk
+
+repo:
+  github: fcsnk/protoduck
+  ref: c5bbd3a20fea31ebf21bb9ca3ca8c0771f83a0ea
+
+docs:
+  hello_world: |
+    INSTALL protoduck FROM community;
+    LOAD protoduck;
+
+    -- Register a protobuf schema at runtime
+    SELECT proto_schema_add('
+        syntax = "proto3";
+        package demo;
+        message Person {
+            string name = 1;
+            int32 age = 2;
+        }
+    ');
+
+    -- Decode a protobuf BLOB to JSON
+    SELECT proto_to_json(data, 'demo.Person') FROM people;
+
+    -- Extract a single field via dot-notation path
+    SELECT proto_get(data, 'demo.Person', 'name') FROM people;
+  extended_description: |
+    ProtoDuck is a DuckDB extension for deserializing Protocol Buffer messages
+    stored directly in table columns (BLOBs), rather than from files. It is aimed
+    at querying protobuf-encoded payloads in data lakes and analytics pipelines.
+
+    Schemas are registered at runtime via `proto_schema_add` (from `.proto`
+    source) or `proto_schema_add_binary` (from a compiled `FileDescriptorSet`).
+    Once registered, messages can be decoded to JSON with `proto_to_json` /
+    `proto_decode`, or individual fields can be pulled out with `proto_get`
+    using a path syntax that supports nested messages, repeated fields
+    (`items[0]`), and maps (`metadata["key"]`).
+
+    All protobuf scalar types, enums, oneofs, maps, and nested messages are
+    supported.


### PR DESCRIPTION
## Summary

New community extension: [ProtoDuck](https://github.com/fcsnk/protoduck) v0.1.0 - protobuf deserialization for DuckDB columns.

ProtoDuck lets you register protobuf schemas at runtime, then decode BLOB columns to JSON or pull out individual fields with path expressions.

## Functions

- `proto_schema_add(proto_content)` / `proto_schema_add_binary(descriptor_set)` - register schemas from `.proto` text or a compiled `FileDescriptorSet`
- `proto_describe(message_type)` - show a readable description of a registered message type
- `proto_to_json(data, message_type)` / `proto_decode(data, message_type)` - decode protobuf payloads to JSON
- `proto_get(data, message_type, field_path)` - extract a specific field with nested, repeated, and map-path support

## Build

Rust extension built through DuckDB's `extension-ci-tools` using the CMake integration path. The descriptor is pinned to the validated commit SHA `c5bbd3a20fea31ebf21bb9ca3ca8c0771f83a0ea`.

## Platform support

Excluded: `wasm_mvp`, `wasm_eh`, `wasm_threads`.

Builds on the standard non-wasm community-extension targets with `rust` and `python3` toolchains.
