### PR TITLE
Add pbi_scanner extension

### DIFF
--- a/extensions/pbi_scanner/description.yml
+++ b/extensions/pbi_scanner/description.yml
@@ -1,22 +1,14 @@
 docs:
   extended_description: |
-    Query Power BI Semantic Models from DuckDB using DAX/XMLA. The example below uses DuckDB's Azure extension and Azure CLI credential chain; run `az login` first and replace the workspace and semantic model placeholders with values you can access.
+    Query Power BI Semantic Models from DuckDB using DAX/XMLA. Authenticate with Azure CLI first (`az login`), then use `SET pbi_scanner_auth_mode='azure_cli'` for session-default auth and replace the workspace and semantic model placeholders with values you can access.
   hello_world: |
-    INSTALL azure;
-    LOAD azure;
-
-    CREATE SECRET pbi_cli (
-        TYPE azure,
-        PROVIDER credential_chain,
-        CHAIN 'cli'
-    );
-
     INSTALL pbi_scanner FROM community;
     LOAD pbi_scanner;
+    SET pbi_scanner_auth_mode = 'azure_cli';
 
     SELECT *
     FROM dax_query(
-        'Data Source=powerbi://api.powerbi.com/v1.0/myorg/Example%20Workspace;Initial Catalog=example_semantic_model;Secret=pbi_cli;',
+        'Data Source=powerbi://api.powerbi.com/v1.0/myorg/Example%20Workspace;Initial Catalog=example_semantic_model;',
         'EVALUATE ROW("probe_ok", 1)'
     );
 extension:

--- a/extensions/pbi_scanner/description.yml
+++ b/extensions/pbi_scanner/description.yml
@@ -31,4 +31,4 @@ extension:
     - crazy-treyn
 repo:
   github: crazy-treyn/pbi_scanner
-  ref: ac6c022727d49036cefd86e34f600780ef68d44e
+  ref: 40b57db8bbe73a869e356fe4a54b494565539f3c

--- a/extensions/pbi_scanner/description.yml
+++ b/extensions/pbi_scanner/description.yml
@@ -23,4 +23,4 @@ extension:
     - crazy-treyn
 repo:
   github: crazy-treyn/pbi_scanner
-  ref: 40b57db8bbe73a869e356fe4a54b494565539f3c
+  ref: 20799696c1375e93a7f540123e19323b89c3850e

--- a/extensions/pbi_scanner/description.yml
+++ b/extensions/pbi_scanner/description.yml
@@ -1,0 +1,26 @@
+docs:
+  extended_description: |
+    Query Power BI Semantic Models from DuckDB using DAX/XMLA.
+  hello_world: |
+    INSTALL pbi_scanner FROM community;
+    LOAD pbi_scanner;
+
+    SELECT *
+    FROM dax_query(
+        'Data Source=powerbi://api.powerbi.com/v1.0/myorg/Example%20Workspace;Initial Catalog=example_semantic_model;',
+        'EVALUATE ROW("probe_ok", 1)',
+        auth_mode := 'azure_cli'
+    );
+extension:
+  name: pbi_scanner
+  description: DuckDB extension for querying Power BI Semantic Models with DAX.
+  version: '0.0.1'
+  language: C++
+  build: cmake
+  license: MIT
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;osx_amd64"
+  maintainers:
+    - crazy-treyn
+repo:
+  github: crazy-treyn/pbi_scanner
+  ref: 1548aa5483319a5b930bb85e296099ff7f4cb65f

--- a/extensions/pbi_scanner/description.yml
+++ b/extensions/pbi_scanner/description.yml
@@ -31,4 +31,4 @@ extension:
     - crazy-treyn
 repo:
   github: crazy-treyn/pbi_scanner
-  ref: f601c23036191dea9888b8f96a03ebbdd32d50fa
+  ref: ac6c022727d49036cefd86e34f600780ef68d44e

--- a/extensions/pbi_scanner/description.yml
+++ b/extensions/pbi_scanner/description.yml
@@ -1,15 +1,23 @@
 docs:
   extended_description: |
-    Query Power BI Semantic Models from DuckDB using DAX/XMLA.
+    Query Power BI Semantic Models from DuckDB using DAX/XMLA. The example below uses DuckDB's Azure extension and Azure CLI credential chain; run `az login` first and replace the workspace and semantic model placeholders with values you can access.
   hello_world: |
+    INSTALL azure;
+    LOAD azure;
+
+    CREATE SECRET pbi_cli (
+        TYPE azure,
+        PROVIDER credential_chain,
+        CHAIN 'cli'
+    );
+
     INSTALL pbi_scanner FROM community;
     LOAD pbi_scanner;
 
     SELECT *
     FROM dax_query(
-        'Data Source=powerbi://api.powerbi.com/v1.0/myorg/Example%20Workspace;Initial Catalog=example_semantic_model;',
-        'EVALUATE ROW("probe_ok", 1)',
-        auth_mode := 'azure_cli'
+        'Data Source=powerbi://api.powerbi.com/v1.0/myorg/Example%20Workspace;Initial Catalog=example_semantic_model;Secret=pbi_cli;',
+        'EVALUATE ROW("probe_ok", 1)'
     );
 extension:
   name: pbi_scanner

--- a/extensions/pbi_scanner/description.yml
+++ b/extensions/pbi_scanner/description.yml
@@ -23,4 +23,4 @@ extension:
     - crazy-treyn
 repo:
   github: crazy-treyn/pbi_scanner
-  ref: 1548aa5483319a5b930bb85e296099ff7f4cb65f
+  ref: f601c23036191dea9888b8f96a03ebbdd32d50fa


### PR DESCRIPTION
## Summary

Add the `pbi_scanner` DuckDB community extension descriptor.

`pbi_scanner` queries Power BI Semantic Models through DAX/XMLA and exposes DuckDB table functions for data and metadata access.

## Descriptor

- Extension repo: `crazy-treyn/pbi_scanner`
- Extension ref: `20799696c1375e93a7f540123e19323b89c3850e` (`v0.0.1`)
- DuckDB stable target in source repo: `v1.5.2`
- Excluded platforms: `wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;osx_amd64`

## Docs

- `hello_world` installs/loads DuckDB's `azure` extension.
- `hello_world` creates an Azure CLI credential-chain secret named `pbi_cli`.
- `hello_world` passes `Secret=pbi_cli` in the Power BI connection string.
- Source README now includes the same community hello-world setup.

## Validation

- Parsed descriptor with `scripts/build.py` using `ALL_CHANGED_FILES=extensions/pbi_scanner/description.yml`, `DUCKDB_VERSION=v1.5.2`, and `DUCKDB_LATEST_STABLE=v1.5.2`.
- Source repo submodule refs confirmed for DuckDB 1.5.2:
  - `duckdb`: `8a5851971fae891f292c2714d86046ee018e9737` (`v1.5.2`)
  - `extension-ci-tools`: `ec20f45aabeb9fcfcfa044dda249597f066d4826`
- Source repo pinned `v1.5.2` release build passed locally.
- Source repo focused sqllogictest passed: `test/sql/pbi_scanner.test`.
- Source repo Python helper syntax checks passed:
  - `python3 -m py_compile query_semantic_model_minimal.py query_semantic_model_sql_minimal.py`
- Source repo changes for this ref include session auth mode support (`SET pbi_scanner_auth_mode`) and updated minimal helper behavior.
- Source repo release published: [v0.0.1](https://github.com/crazy-treyn/pbi_scanner/releases/tag/v0.0.1)