### PR TITLE
Bump h5db

### DIFF
--- a/extensions/h5db/description.yml
+++ b/extensions/h5db/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: h5db
   description: Read HDF5 datasets and attributes
-  version: 1.0.0
+  version: 1.1.0
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
     - jokasimr
 repo:
   github: jokasimr/h5db
-  ref: v1.0.0
+  ref: v1.1.0
   andium: v0.3.0
 
 docs:

--- a/extensions/h5db/description.yml
+++ b/extensions/h5db/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: h5db
   description: Read HDF5 datasets and attributes
-  version: 0.5.1
+  version: 1.0.0
   language: C++
   build: cmake
   license: MIT
@@ -11,24 +11,27 @@ extension:
     - jokasimr
 repo:
   github: jokasimr/h5db
-  ref: v0.5.1
+  ref: v1.0.0
   andium: v0.3.0
 
 docs:
   hello_world: |
     FROM h5_read('file.h5', '/some/dataset', '/another');
   extended_description: |
-    This extension provides table functions for reading data and metadata from HDF5 files.
+    This extension provides functions for reading data and metadata from HDF5 files.
 
     Features include:
-    - `h5_tree()` table function to list groups and datasets in a file.
     - `h5_read()` table function to read datasets.
-    - `h5_attributes()` table function to access attributes.
-    - Multiple datasets: Read and combine multiple datasets in a single query.
+    - `h5_tree()` table function to list groups and datasets in a file, optionally including projected attributes.
+    - `h5_attributes()` table function to read attributes.
+    - `h5_ls()` table and scalar functions to list entries in groups.
+    - Multiple datasets: Read multiple datasets into separate columns.
     - Multi-dimensional arrays: Support for 1D to 4D datasets.
-    - Projection pushdown: Reads only the datasets that are actually needed.
-    - Index column: Optionally adds an `index` column that supports pushdown of constant range filters (`>`, `<=`, `BETWEEN`, etc.) for efficient selective reads.
+    - Projection pushdown: Read only the datasets that are actually needed.
+    - Index column: Optionally adds an `index` column that supports predicate pushdown of constant range filters (`>`, `<=`, `BETWEEN`, etc.) for efficient selective reads.
     - Reads datasets that are larger than memory.
-    - Remote dataset reads via the `httpfs` extension.
+    - Remote reads over HTTPS, S3, etc., via the DuckDB `httpfs` extension.
+    - Remote reads over SFTP via a built-in SFTP client.
+    - Globbing: Combine datasets from multiple files vertically (UNION ALL).
 
     For full documentation, see: [https://github.com/jokasimr/h5db](https://github.com/jokasimr/h5db).

--- a/extensions/h5db/description.yml
+++ b/extensions/h5db/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: h5db
   description: Read HDF5 datasets and attributes
-  version: 1.1.0
+  version: 1.1.1
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
     - jokasimr
 repo:
   github: jokasimr/h5db
-  ref: v1.1.0
+  ref: v1.1.1
   andium: v0.3.0
 
 docs:


### PR DESCRIPTION
## v1.0.0 release summary :fireworks: 

The biggest changes are

1. `sftp://` support, including SSH-agent authentication.
2. Multi-file queries through globs and `VARCHAR[]` filename lists.
3. A new `h5_ls(...)` interface for shallow namespace inspection.
4. Attribute projections in `h5_tree(...)` and `h5_ls(...)`.