### PR TITLE
ducklake_cdc: v0.0.0

### DIFF
--- a/extensions/ducklake_cdc/description.yml
+++ b/extensions/ducklake_cdc/description.yml
@@ -1,0 +1,15 @@
+extension:
+  name: ducklake_cdc
+  description: "Stream changes from your DuckLake — durable consumer cursors, single-reader windows, typed DDL events."
+  version: "0.0.0"
+  language: C++
+  build: cmake
+  license: Apache-2.0
+  excluded_platforms: ""
+  requires_toolchains: ""
+  maintainers:
+    - "ekkuleivonen"
+
+repo:
+  github: "ekkuleivonen/ducklake-cdc-extension"
+  ref: "61c7da5a1352b281e33150487e798fecca7f669b"


### PR DESCRIPTION
Automated descriptor update for [ekkuleivonen/ducklake-cdc-extension@v0.0.0](https://github.com/ekkuleivonen/ducklake-cdc-extension/releases/tag/v0.0.0).

Release SHA: `61c7da5a1352b281e33150487e798fecca7f669b`

Generated by [.github/workflows/release.yml](https://github.com/ekkuleivonen/ducklake-cdc-extension/blob/61c7da5a1352b281e33150487e798fecca7f669b/.github/workflows/release.yml).
