### PR TITLE
Bump lastra to 0.1.1: ALP per-vector iteration fix

### DIFF
--- a/extensions/lastra/description.yml
+++ b/extensions/lastra/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: lastra
   description: Reader for the Lastra columnar time-series format
-  version: 0.1.0
+  version: 0.1.1
   language: C++
   build: cmake
   license: Apache-2.0
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: QTSurfer/duckdb-lastra
-  ref: d859527024fb3c4336d2b149f638af7753ce1a60
+  ref: ddc821958e10fdef844fb2ac6549eb44a51a3ae7
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary

Patch release for [lastra](https://github.com/QTSurfer/duckdb-lastra) fixing a decoder bug in the ALP codec path.

## Changes

| Field    | Was       | Now       |
|----------|-----------|-----------|
| `version`| `0.1.0`   | `0.1.1`   |
| `ref`    | `d859527` | `ddc8219` |

## What's fixed

ALP decode now iterates per-vector blocks of 1024 values, matching the row-group layout the writer emits. Files now decode correctly under the C++ extension.

- Fix: https://github.com/QTSurfer/duckdb-lastra/commit/ac7c5e3
- Bump: https://github.com/QTSurfer/duckdb-lastra/commit/ddc8219