### PR TITLE
ducklake_cdc: v0.2.0

### DIFF
--- a/extensions/ducklake_cdc/description.yml
+++ b/extensions/ducklake_cdc/description.yml
@@ -1,0 +1,15 @@
+extension:
+  name: ducklake_cdc
+  description: "Stream changes from your DuckLake — durable consumer cursors, single-reader windows, typed DDL events."
+  version: "0.2.0"
+  language: C++
+  build: cmake
+  license: Apache-2.0
+  excluded_platforms: ""
+  requires_toolchains: ""
+  maintainers:
+    - "ekkuleivonen"
+
+repo:
+  github: "ekkuleivonen/ducklake-cdc-extension"
+  ref: "a3a682a2eba102526ed4b67755b0819edc93728c"


### PR DESCRIPTION
Automated descriptor update for [ekkuleivonen/ducklake-cdc-extension@v0.2.0](https://github.com/ekkuleivonen/ducklake-cdc-extension/releases/tag/v0.2.0).

Release SHA: `a3a682a2eba102526ed4b67755b0819edc93728c`

Generated by [.github/workflows/release.yml](https://github.com/ekkuleivonen/ducklake-cdc-extension/blob/a3a682a2eba102526ed4b67755b0819edc93728c/.github/workflows/release.yml).
