### PR TITLE
ducklake_cdc: v0.3.0

### DIFF
--- a/extensions/ducklake_cdc/description.yml
+++ b/extensions/ducklake_cdc/description.yml
@@ -1,0 +1,15 @@
+extension:
+  name: ducklake_cdc
+  description: "Stream changes from your DuckLake — durable consumer cursors, single-reader windows, typed DDL events."
+  version: "0.3.0"
+  language: C++
+  build: cmake
+  license: Apache-2.0
+  excluded_platforms: ""
+  requires_toolchains: ""
+  maintainers:
+    - "ekkuleivonen"
+
+repo:
+  github: "ekkuleivonen/ducklake-cdc-extension"
+  ref: "0cf02924af0cd06e4c26c76314f483707bca40ff"


### PR DESCRIPTION
Automated descriptor update for [ekkuleivonen/ducklake-cdc-extension@v0.3.0](https://github.com/ekkuleivonen/ducklake-cdc-extension/releases/tag/v0.3.0).

Release SHA: `0cf02924af0cd06e4c26c76314f483707bca40ff`

Generated by [.github/workflows/release.yml](https://github.com/ekkuleivonen/ducklake-cdc-extension/blob/0cf02924af0cd06e4c26c76314f483707bca40ff/.github/workflows/release.yml).
