### PR TITLE
[mongo] Bump to v0.2.1

### DIFF
--- a/extensions/mongo/description.yml
+++ b/extensions/mongo/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: mongo
   description: Integrates DuckDB with MongoDB, enabling direct SQL queries over MongoDB collections without exporting data or ETL
-  version: 0.2.0
+  version: 0.2.1
   language: C++
   build: cmake
   license: MIT
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: stephaniewang526/duckdb-mongo
-  ref: 256ea859969564f79ba11403cbba4e3631911f01
+  ref: 3bcdfeb85a3922c0b00dd54bf26f388c8d12669d
 
 docs:
   hello_world: |


### PR DESCRIPTION
- Bump mongo extension from v0.2.0 to v0.2.1
- Uses random `$sample` for schema inference to detect sparse/optional fields (fixes https://github.com/stephaniewang526/duckdb-mongo/issues/30)
- Merges struct fields across LIST(STRUCT) types during type conflict resolution
- Adds compatibility with DuckDB main 