### PR TITLE
ducklake_cdc: v0.3.1

### DIFF
--- a/extensions/ducklake_cdc/description.yml
+++ b/extensions/ducklake_cdc/description.yml
@@ -1,0 +1,15 @@
+extension:
+  name: ducklake_cdc
+  description: "Stream changes from your DuckLake — durable consumer cursors, single-reader windows, typed DDL events."
+  version: "0.3.1"
+  language: C++
+  build: cmake
+  license: Apache-2.0
+  excluded_platforms: ""
+  requires_toolchains: ""
+  maintainers:
+    - "ekkuleivonen"
+
+repo:
+  github: "ekkuleivonen/ducklake-cdc-extension"
+  ref: "cda493e06944c8fb2312cb539be2166d8735b1ee"


### PR DESCRIPTION
Automated descriptor update for [ekkuleivonen/ducklake-cdc-extension@v0.3.1](https://github.com/ekkuleivonen/ducklake-cdc-extension/releases/tag/v0.3.1).

Release SHA: `cda493e06944c8fb2312cb539be2166d8735b1ee`

Generated by [.github/workflows/release.yml](https://github.com/ekkuleivonen/ducklake-cdc-extension/blob/cda493e06944c8fb2312cb539be2166d8735b1ee/.github/workflows/release.yml).
