### PR TITLE
ducklake_cdc: v0.3.2

### DIFF
--- a/extensions/ducklake_cdc/description.yml
+++ b/extensions/ducklake_cdc/description.yml
@@ -1,0 +1,16 @@
+extension:
+  name: ducklake_cdc
+  description: "Stream changes from your DuckLake — durable consumer cursors, single-reader windows, typed DDL events."
+  version: "0.3.2"
+  language: C++
+  build: cmake
+  license: Apache-2.0
+  excluded_platforms: ""
+  requires_toolchains: ""
+  test_config: '{"test_env_variables":{"LINUX_CI_IN_DOCKER":"0"}}'
+  maintainers:
+    - "ekkuleivonen"
+
+repo:
+  github: "ekkuleivonen/ducklake-cdc-extension"
+  ref: "6bb219eaab3ebaf01e6a95fe3c0306a268ef4c3e"


### PR DESCRIPTION

Hi ya'll!

Introducing my take on implementing CDC on top of ducklake's existing change data feed.

More details here: [ducklake-cdc-extension on github](https://github.com/ekkuleivonen/ducklake-cdc-extension)


-----

Automated descriptor update for [ekkuleivonen/ducklake-cdc-extension@v0.3.2](https://github.com/ekkuleivonen/ducklake-cdc-extension/releases/tag/v0.3.2).

Release SHA: `6bb219eaab3ebaf01e6a95fe3c0306a268ef4c3e`

This descriptor disables the community packaging SQL test phase via `test_config`; ducklake_cdc's DuckLake-dependent integration suite runs in the upstream extension repository CI instead.