### PR TITLE
ducklake_cdc: v0.4.0

### DIFF
--- a/extensions/ducklake_cdc/description.yml
+++ b/extensions/ducklake_cdc/description.yml
@@ -1,0 +1,16 @@
+extension:
+  name: ducklake_cdc
+  description: "Stream changes from your DuckLake — durable consumer cursors, single-reader windows, typed DDL events."
+  version: "0.4.0"
+  language: C++
+  build: cmake
+  license: Apache-2.0
+  excluded_platforms: ""
+  requires_toolchains: ""
+  test_config: '{"test_env_variables":{"LINUX_CI_IN_DOCKER":"0"}}'
+  maintainers:
+    - "ekkuleivonen"
+
+repo:
+  github: "ekkuleivonen/ducklake-cdc-extension"
+  ref: "4c3dae487dcfc926035935bdaa7c6c479ba6e40e"


### PR DESCRIPTION
Hi ya'll!

Introducing my take on implementing CDC on top of ducklake's existing change data feed.

More details here: [ducklake-cdc-extension on github](https://github.com/ekkuleivonen/ducklake-cdc-extension)


---

Automated descriptor update for [ekkuleivonen/ducklake-cdc-extension@v0.4.0](https://github.com/ekkuleivonen/ducklake-cdc-extension/releases/tag/v0.4.0).

Release SHA: `4c3dae487dcfc926035935bdaa7c6c479ba6e40e`

Generated by [.github/workflows/release.yml](https://github.com/ekkuleivonen/ducklake-cdc-extension/blob/4c3dae487dcfc926035935bdaa7c6c479ba6e40e/.github/workflows/release.yml).
