### PR TITLE
bump h5db

### DIFF
--- a/extensions/h5db/description.yml
+++ b/extensions/h5db/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: h5db
   description: Read HDF5 datasets and attributes
-  version: 1.1.1
+  version: 1.1.2
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
     - jokasimr
 repo:
   github: jokasimr/h5db
-  ref: v1.1.1
+  ref: v1.1.2
   andium: v0.3.0
 
 docs:


### PR DESCRIPTION
* Use pushed down filters to filter globbed files in `h5_tree` and `h5_ls`
* Error messages include filename of file that triggered error