### PR TITLE
Update GitHub reference in description.yml

### DIFF
--- a/extensions/pic2vec/description.yml
+++ b/extensions/pic2vec/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: nkwork9999/pic2vec
-  ref: e5757c8277015bd4b845ffce64868487ef026939
+  ref: cf194463acbb4c5fa27cb6fb779698160b848a69
 
 docs:
   hello_world: |


### PR DESCRIPTION
The previous ref shipped without the bundled model because tiny_model_data.cpp
is .gitignored (131MB, over GitHub's per-file limit). The new commit ships the
22MB .onnx in assets/ and has CMake auto-embed it at configure time, so the
CI build now produces a binary where pic_bundled_info() reports the model and
pic_embed() works zero-setup as advertised in description.yml.