### PR TITLE
Update raquet extension to v0.2.4

### DIFF
--- a/extensions/raquet/description.yml
+++ b/extensions/raquet/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: raquet
   description: "Raster analytics on Raquet files with QUADBIN spatial indexing, raster ingestion, and PostGIS-style functions"
-  version: 0.2.3
+  version: 0.2.4
   language: C++
   build: cmake
   license: Apache-2.0
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: jatorre/duckdb-raquet
-  ref: 931b5ff1aea9b98e9d77214fbf6c800210b39b60
+  ref: a699560ad74e86f8168aa0b80af120c36e671662
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps `raquet` from 0.2.3 → 0.2.4 and updates the ref to the tip of [jatorre/duckdb-raquet:main](https://github.com/jatorre/duckdb-raquet/commits/main) (`a699560`).

## Highlights since 0.2.3

- **`read_raster()` metadata enrichment** for both `format='v0'` (raster-loader 0.9.1 byte-shape parity) and `format='v0.5.0'` (spec-compliant `width`/`height` + `STATISTICS_*`). Adds top-level `width`/`height`/`num_pixels`/`bounds`/`center`/`version`, per-band `colortable` (RGBA per palette index), and per-band stats including `quantiles`/`top_values`/`version` for v0.1.0. ([#2](https://github.com/jatorre/duckdb-raquet/pull/2))
- **New `approx` named parameter** (default `true`) toggles GDAL `approxOK` stats vs. an exact full-resolution pass for `format='v0.5.0'`.
- **Parallel correctness in `read_raster()`** ([#5](https://github.com/jatorre/duckdb-raquet/pull/5)) — four root-cause fixes:
  - Silent Phase 2 overview-tile drop past `STANDARD_VECTOR_SIZE` (~11k tiles lost on country-scale rasters).
  - `num_blocks` under-count race under parallel execution.
  - `OVERVIEW_LEVEL` transformer hint was silently dropped, forcing slow re-warps from base resolution.
  - Phase 2 fallback hardcoded `GRA_Average` — broke categorical/palette bands by inventing pixel values that don't exist in source.
- **Performance**: Phase 2 overview warping parallelised; per-thread warp transformer cache; `condition_variable` phase coordination replacing `std::this_thread::yield()` spinners. Germany full pyramid: `30:14 SIGSEGV → 6:15 clean` (-79% wall time, ~1400% CPU utilisation on 16 cores).
- **CI fix** ([#4](https://github.com/jatorre/duckdb-raquet/pull/4)): replace `struct.*` sugar with explicit field accessors for the DuckDB 1.5.2 parser, commit a small parquet test fixture in-tree to remove the GCS network dep.

## Compatibility

The Parquet column schema (`block / metadata / band_*`) is **unchanged** — metadata additions are additive, no consumer breakage. New `approx` parameter has a default. v0.1.0 output is now byte-shape-compatible with Python `raster-loader 0.9.1`'s production output.

## Validation

- All in-tree SQL tests pass (`build/release/test/unittest --test-dir . "test/sql/*"` — 224 assertions).
- End-to-end on real rasters: 1.6 MB Berlin classification, 473 MB Germany classification (53,423 tiles, full 10-zoom pyramid), 159 MB UTM 30N raster — all data-row counts match `metadata.num_blocks` and decoded pixel values are source-valid (no `GRA_Average` invention).
- Side-by-side metadata diff against the production reference table `cartobq:cayetanobv_raster.rasquet_classification_germany_cog` (produced by Python `raster-loader 0.9.1`): identical key sets and values within sample noise.