### PR TITLE
ducklake_cdc: v0.5.0

### DIFF
--- a/extensions/ducklake_cdc/description.yml
+++ b/extensions/ducklake_cdc/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: ducklake_cdc
   description: "Stream changes from your DuckLake — durable consumer cursors, single-reader windows, typed DDL events."
-  version: "0.4.0"
+  version: "0.5.0"
   language: C++
   build: cmake
   license: Apache-2.0
@@ -13,4 +13,4 @@ extension:
 
 repo:
   github: "ekkuleivonen/ducklake-cdc-extension"
-  ref: "4c3dae487dcfc926035935bdaa7c6c479ba6e40e"
+  ref: "f5d2e373e9efde1be38f9eaa5fd429ce4c8b4bce"


### PR DESCRIPTION
v0.5.0 Hopefully marks the spot after which the public API will no longer undergo larger changes. 

This release also includes the first layer of performance optimizations on the DML changes hot path.

...Work continues.

[Readme](https://github.com/ekkuleivonen/ducklake-cdc-extension) should also do a better job at explaining what the extension is all about.

---

Automated descriptor update for [ekkuleivonen/ducklake-cdc-extension@v0.5.0](https://github.com/ekkuleivonen/ducklake-cdc-extension/releases/tag/v0.5.0).

Release SHA: `f5d2e373e9efde1be38f9eaa5fd429ce4c8b4bce`

Generated by [.github/workflows/release.yml](https://github.com/ekkuleivonen/ducklake-cdc-extension/blob/f5d2e373e9efde1be38f9eaa5fd429ce4c8b4bce/.github/workflows/release.yml).
