### PR TITLE
agent_data: bump source ref for DuckDB 1.5.2

### DIFF
--- a/extensions/agent_data/description.yml
+++ b/extensions/agent_data/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: axsaucedo/agent_data_duckdb
-  ref: 4199362e20e4be2997b731d769f6ea96ad4c4e07
+  ref: 41993629dfdd259055327213f119b9b83a4a5826
 
 docs:
   hello_world: |

--- a/extensions/agent_data/description.yml
+++ b/extensions/agent_data/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: axsaucedo/agent_data_duckdb
-  ref: 1348a6d1a25ada29f78087e1469dfbff3bb095e1
+  ref: 4199362e20e4be2997b731d769f6ea96ad4c4e07
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary
- bumps `extensions/agent_data/description.yml` `repo.ref` to `41993629dfdd259055327213f119b9b83a4a5826`
- the new source ref targets DuckDB `v1.5.2`, `duckdb`/`libduckdb-sys` crate `1.10502.0`, and `extension-ci-tools` `v1.5-variegata`
- this should restore latest-stable community binaries so `agent_data` appears in the generated DuckDB community extension list again

## Validation in source repo
Source PR: https://github.com/axsaucedo/agent_data_duckdb/pull/3

Local validation performed there:
- `cargo metadata --locked --format-version 1`
- `cargo check --locked`
- `make configure`
- `make debug`
- `make test`
- `cargo test --locked`
- `cd examples/tui && uv run pytest` (42 passed)
- manual DuckDB/Python smoke queries against `build/debug/agent_data.duckdb_extension` for Claude and Copilot synthetic data

## Current public baseline
- `https://duckdb.org/community_extensions/extensions/agent_data.html` returns 200
- `https://community-extensions.duckdb.org/v1.5.2/osx_arm64/agent_data.duckdb_extension.gz` returns 404
- aggregate list membership for `agent_data` is currently 0
- `INSTALL agent_data FROM community` currently fails on DuckDB 1.5.2 with HTTPException
