### PR TITLE
Update pbi_scanner to 0.0.4

### DIFF
--- a/extensions/pbi_scanner/description.yml
+++ b/extensions/pbi_scanner/description.yml
@@ -23,7 +23,7 @@ docs:
 extension:
   name: pbi_scanner
   description: DuckDB extension for querying Power BI Semantic Models with DAX.
-  version: '0.0.3'
+  version: '0.0.4'
   language: C++
   build: cmake
   license: MIT
@@ -32,4 +32,4 @@ extension:
     - crazy-treyn
 repo:
   github: crazy-treyn/pbi_scanner
-  ref: dcde225628f30353a26d1c60c3dfc951d12ba7a6
+  ref: 6ae413fb6d6c9eb7e9b97758f41f346ac85b45a1


### PR DESCRIPTION
## Summary
Bump `pbi_scanner` community descriptor to extension **0.0.4** with `repo.ref` at validated release commit [`6ae413fb6d6c9eb7e9b97758f41f346ac85b45a1`](https://github.com/crazy-treyn/pbi_scanner/commit/6ae413fb6d6c9eb7e9b97758f41f346ac85b45a1).

## Validation evidence
- **Release**: GitHub tag [`v0.0.4`](https://github.com/crazy-treyn/pbi_scanner/releases/tag/v0.0.4) points at the same commit.
- **CI**: Upstream `pbi_scanner` workflows on `crazy-treyn/pbi_scanner` `main` / tag `v0.0.4`.
- **Local** (release commit): `make format-check`, `make release`, `./build/release/test/unittest "test/sql/pbi_scanner.test"`, `make tidy-check` — all passed.

## Descriptor
- `extension.version`: `0.0.4`
- `repo.ref`: `6ae413fb6d6c9eb7e9b97758f41f346ac85b45a1`
- `excluded_platforms`: unchanged (`wasm_*`, `windows_amd64_mingw`, `osx_amd64`).