### PR TITLE
Bump keboola to v0.1.5

### DIFF
--- a/extensions/keboola/description.yml
+++ b/extensions/keboola/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: keboola
   description: "DuckDB extension for Keboola Storage — query and write Keboola tables using standard SQL"
-  version: "0.1.4"
+  version: "0.1.5"
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: keboola/duckdb-extension
-  ref: 734fc53e46a3c76d7612d2db1dfacd01ae634a8a
+  ref: f06bafb6f39d7446d5748d8198904e0a127a9650
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary

Updates the `keboola` extension to **v0.1.5** ([keboola/duckdb-extension@v0.1.5](https://github.com/keboola/duckdb-extension/releases/tag/v0.1.5)).

### Bug fix — workspace storage visibility

The per-session Keboola workspace was previously created without `readOnlyStorageAccess`, so its Snowflake role had no view of any storage bucket. Queries like `SELECT * FROM kbc."in.c-bucket"."tbl"` failed with `Schema "..." does not exist or not authorized` even when the token had read access to the bucket. The fix sets `readOnlyStorageAccess: true` by default — the token still governs visibility, this only surfaces existing read permissions to the workspace's Snowflake role. A new `READ_ONLY_STORAGE` ATTACH option (default `true`) is available for least-privilege opt-out.

### Build

- Builds against **DuckDB v1.5.2** (was v1.5.0).
- Compatibility maintained against DuckDB nightly `main` (uses public `GetExpressionClass()` / `GetExpressionType()` getters, `FlatVector::GetDataMutable<T>` and `BoundSimpleFunction::GetName()` via `__has_include` guards; `ConstantFilter::Compare` open-coded).

### Note

The previous registry entry had `version: 0.1.4` pointing at `734fc53` (pre-fix), but the keboola repo never tagged that commit. To avoid version-number ambiguity for users already on 0.1.4, this PR bumps the registry to v0.1.5 with `ref: f06bafb` (the actual tagged release containing the fix).