### PR TITLE
Bump pic2vec ref (bundled-model embed fix)

### DIFF
--- a/extensions/pic2vec/description.yml
+++ b/extensions/pic2vec/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: nkwork9999/pic2vec
-  ref: 85c0f15c4841882f7c8acb2b7ec9de9e7a89e4ad
+  ref: 6739bc08a198a4eab6fc24c7e8d9f277d413ed43
 
 docs:
   hello_world: |

--- a/extensions/pic2vec/description.yml
+++ b/extensions/pic2vec/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: nkwork9999/pic2vec
-  ref: cf194463acbb4c5fa27cb6fb779698160b848a69
+  ref: 85c0f15c4841882f7c8acb2b7ec9de9e7a89e4ad
 
 docs:
   hello_world: |

--- a/extensions/pic2vec/description.yml
+++ b/extensions/pic2vec/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: nkwork9999/pic2vec
-  ref: 6739bc08a198a4eab6fc24c7e8d9f277d413ed43
+  ref: d39ef33b1389e670e1b19861ec1b6a51c3717273
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary

Bumps the `pic2vec` ref to [`85c0f15`](https://github.com/nkwork9999/pic2vec/commit/85c0f15c4841882f7c8acb2b7ec9de9e7a89e4ad), which fixes the bundled EUPE ViT-T model not being embedded in the published binary.

## Why this is needed

The previous ref (`cf19446`) attempted to ship the 22MB `.onnx` in `assets/` and have CMake derive `tiny_model_data.cpp` at configure time. The CI build ran successfully (and the macOS arm64 deploy was green), but the resulting binary on community-extensions.duckdb.org has no model bundled.

CI log for the `cf19446` build of pic2vec on macOS arm64:

```
pic2vec: embedding bundled model from .../assets/eupe_vit_t16_fp16.onnx
pic2vec: embed_tiny_model.sh failed (rc=0):
.../src/embedded/tiny_model_data.cpp:
pic2vec: bundled tiny model not present; generated stub at .../tiny_model_data_stub.cpp
```

Root cause: the script wrote to `src/embedded/tiny_model_data.cpp`, but `src/embedded/` wasn't tracked in git (the `.cpp` was `.gitignored`, the empty directory wasn't committed). On a fresh CI clone the directory didn't exist, the `} > "$OUT"` redirect failed with "No such file or directory", and bash's `set -e` doesn't fire on a brace-group redirect failure. Script returned `rc=0`, CMake's `EXISTS .cpp` check fell through to a zero-byte stub branch with only a `WARNING`, and the build shipped a binary where `pic_bundled_info()` returns "No model is bundled" and `pic_embed()` fails at runtime with "no model loaded".

## What 85c0f15 changes

Three changes that together make this category of silent failure impossible:

1. **Generated `.cpp` is written to `${CMAKE_BINARY_DIR}/generated/`**, never to the source tree. No more `.gitignore` covering a build artifact, which was the structural reason `src/embedded/` was treated as ignorable.
2. **`embed_tiny_model.sh` fails loudly on any I/O error**: `mkdir -p`, probe writability with `: > "$OUT.tmp"` before doing the heavy `xxd` work, write to a temp file, sanity-check the result is at least as large as the input, atomic `mv`. No path returns 0 without producing valid output.
3. **CMakeLists.txt aborts the build on any failure**: stub fallback removed. Missing `.onnx`, missing script, script `rc≠0`, or `rc=0` with no output file — all `message(FATAL_ERROR)` with full stdout/stderr from the script.

Verified locally with:
- 4 cmake -P cases covering happy + 3 failure paths
- 4 script smoke tests
- Full `make release` on macOS arm64: `pic2vec.duckdb_extension` is 43.8MB (was 23MB stub-built); `pic_bundled_info()` reports `Bundled: EUPE ViT-T/16 (6M params, 192-d embeddings, FP16) (22237478 bytes)`.

## Test plan

- [ ] Community Extension Build CI succeeds on all platforms
- [ ] Deployed binary loads in DuckDB v1.4.x via `INSTALL pic2vec FROM community; LOAD pic2vec;`
- [ ] `SELECT pic_bundled_info();` reports real bytes (not "No model is bundled")
- [ ] `SELECT pic_embed_blob((SELECT content FROM read_blob('https://raw.githubusercontent.com/vzat/comparing_images/master/images/pcb1.jpg')));` returns a 192-d embedding