### PR TITLE
Bump keboola to v0.1.6

### DIFF
--- a/extensions/keboola/description.yml
+++ b/extensions/keboola/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: keboola
   description: "DuckDB extension for Keboola Storage — query and write Keboola tables using standard SQL"
-  version: "0.1.5"
+  version: "0.1.6"
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: keboola/duckdb-extension
-  ref: f06bafb6f39d7446d5748d8198904e0a127a9650
+  ref: 0559b174fedc95afbca09a428770b55094a76923
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary

Updates the `keboola` extension to **v0.1.6** ([keboola/duckdb-extension@v0.1.6](https://github.com/keboola/duckdb-extension/releases/tag/v0.1.6)).

### Bug fix — linked-bucket SQL routing (issue #17)

Buckets the user has read access to are not always materialised as a schema in the workspace's local Snowflake DB.  Linked buckets (shared from another Keboola project) live in the source project's DB and are exposed to the workspace via Snowflake secure data sharing — but only under their original `<sourceDB>."<sourceBucketPath>"` qualified name.  Storage API `data-preview` masks this by routing through HTTP, but QueryService passes SQL straight through to Snowflake.

Before this release, `SELECT * FROM kbc."in.c-hr"."employee"` (where `in.c-hr` is a linked bucket) failed with `Schema 'KBC_USE4_<project>."in.c-hr"' does not exist or not authorized`, even though the token had read access. The 0.1.5 fix (`readOnlyStorageAccess: true` on the workspace) was necessary but not sufficient.

v0.1.6:

- `KeboolaBucketInfo` and `KeboolaTableInfo` now carry `is_linked`, `sf_database`, `sf_schema`, parsed from the Storage API `isLinkedBucket` and `backendPath` fields.
- `KeboolaSqlGenerator::SnowflakeQualifiedRef(table)` returns `"<sf_database>"."<sf_schema>"."<name>"` when both fields are set, falling back to the legacy id-split form otherwise. All SELECT paths route through it (live scan, snapshot pull, UPDATE-side fetch, schema stats).
- INSERT, UPDATE, DELETE and `CREATE TABLE` reject linked buckets upfront with a clear `NotImplementedException`.
- `keboola_version()` now returns the build's `EXT_VERSION_KEBOOLA` (commit short SHA) instead of the misleading hardcoded `"0.1.0"` literal.