### PR TITLE
Add DICOM extension: Import medical imaging data directly into DuckDB

### DIFF
--- a/extensions/dicom/description.yml
+++ b/extensions/dicom/description.yml
@@ -1,0 +1,49 @@
+extension:
+  name: dicom
+  description: |
+    DuckDB integration with medical imaging data (DICOM - Digital Imaging and Communication in
+    Medicine).
+  version: 1.0.0
+  language: C++
+  build: cmake
+  licence: MIT
+  maintainers:
+    - nmontesg
+
+repo:
+  github: nmontesg/duck-dicom
+  ref: 9e2d499471a9ba57b6c2cd2868a836119c5fde12
+
+docs:
+  hello_world: |
+    INSTALL dicom FROM community;
+    LOAD dicom;
+    FROM read_dicom('path/to/dicom_file.dcm');
+
+  extended_description: |
+    The dicom extension for DuckDB provides functionality to import medical imaging data (DICOM,
+    Digital Imaging and Communication in Medicine) directly into DuckDB. It uses the powerful DCMTK
+    C++ library to read DICOM files and convert them into JSON format.
+
+    -- read one file
+    FROM read_dicom('path/to/dicom_file.dcm');
+
+    -- use glob pattern
+    FROM read_dicom('path/to/dicoms/**/*.dcm');
+
+    -- import pixel data
+    FROM read_dicom('path/to/dicom_file.dcm', load_pixel_data=true);
+
+    -- extract series description per series instance
+    SELECT
+        dicom_content->'0020000E'->'Value' AS series_instance_uid,
+        any_value(dicom_content->'0008103E'->'Value') AS series_description
+    FROM read_dicom('/Users/nmontes/Downloads/slicer_export/**/*.dcm')
+    GROUP BY 1;
+
+    -- extract study description per study instance
+    SELECT
+        dicom_content->'0020000D'->'Value' AS study_instance_uid,
+        any_value(dicom_content->'00081030'->'Value') AS study_description
+    FROM read_dicom('/Users/nmontes/Downloads/slicer_export/**/*.dcm')
+    GROUP BY 1;

--- a/extensions/dicom/description.yml
+++ b/extensions/dicom/description.yml
@@ -6,6 +6,7 @@ extension:
   version: 0.1.0
   language: C++
   build: cmake
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads"
   licence: MIT
   maintainers:
     - nmontesg

--- a/extensions/dicom/description.yml
+++ b/extensions/dicom/description.yml
@@ -3,7 +3,7 @@ extension:
   description: |
     DuckDB integration with medical imaging data (DICOM - Digital Imaging and Communication in
     Medicine).
-  version: 1.0.0
+  version: 0.1.0
   language: C++
   build: cmake
   licence: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: nmontesg/duck-dicom
-  ref: 9e2d499471a9ba57b6c2cd2868a836119c5fde12
+  ref: 91524cf0a885e7f5f236490b0eea02e5d46fa978
 
 docs:
   hello_world: |


### PR DESCRIPTION
# Summary

Functionality to import medical imaging data (DICOM, Digital Imaging and Communication in Medicine) directly into DuckDB. It uses the industry standard [DCMTK library](https://dicom.offis.de/dcmtk.php.en) to read DICOM files and convert them into JSON format.

# Quickstart

```sql
INSTALL dicom FROM community;
LOAD dicom;

-- read one file
FROM read_dicom('path/to/dicom_file.dcm');
```

# Functions

`read_dicom(filepath[, load_pixel_data=false])` : Read DICOM files directly into DuckDB, return one row per file with columns `path (VARCHAR)` (path to the file) and `dicom_content (JSON)` (JSON-formatted contents of the DICOM file). Supports glob patterns.

# Platforms

WASM targets excluded (wasm_mvp, wasm_eh, wasm_threads) due to incompatibility with third-party DCMTK