### PR TITLE
ducklake_cdc: v0.5.1

### DIFF
--- a/extensions/ducklake_cdc/description.yml
+++ b/extensions/ducklake_cdc/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: ducklake_cdc
   description: "Stream changes from your DuckLake — durable consumer cursors, single-reader windows, typed DDL events."
-  version: "0.5.0"
+  version: "0.5.1"
   language: C++
   build: cmake
   license: Apache-2.0
@@ -13,4 +13,4 @@ extension:
 
 repo:
   github: "ekkuleivonen/ducklake-cdc-extension"
-  ref: "f5d2e373e9efde1be38f9eaa5fd429ce4c8b4bce"
+  ref: "723dcf85f6051215689e4f07b08a4bc6017c165e"


### PR DESCRIPTION
This update includes mostly tiny additive API alignments to get things rolling with the [matching python client](https://pypi.org/project/ducklake-cdc-client/) that I whipped together.

...Along with some internal cleanup.

---

Automated descriptor update for [ekkuleivonen/ducklake-cdc-extension@v0.5.1](https://github.com/ekkuleivonen/ducklake-cdc-extension/releases/tag/v0.5.1).

Release SHA: `723dcf85f6051215689e4f07b08a4bc6017c165e`

Generated manually after the release workflow completed the build/tag steps but could not create PRs from GitHub Actions.