### PR TITLE
Bump us_address_standardizer to v0.2.0

### DIFF
--- a/extensions/us_address_standardizer/description.yml
+++ b/extensions/us_address_standardizer/description.yml
@@ -1,19 +1,19 @@
 extension:
   name: us_address_standardizer
   description: US address parsing and standardization (PAGC + Rust addrust)
-  version: 0.1.0
+  version: 0.2.0
   language: C/Rust
   build: cmake
   license: MIT
   maintainers:
     - ericmanning
     - sj-io
-  excluded_platforms: "osx_amd64;windows_amd64;wasm_mvp;wasm_eh;wasm_threads"
+  excluded_platforms: "osx_amd64;wasm_mvp;wasm_eh;wasm_threads"
   requires_toolchains: "python3;rust"
 
 repo:
   github: ericmanning/duckdb-address-standardizer
-  ref: 2d1522898b2d9d20b34c90ee112900789cedf955
+  ref: 8da70a76d3ade131a094a0e746aa5d06605e3f80
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary

Bump [us_address_standardizer](https://github.com/ericmanning/duckdb-address-standardizer) from v0.1.0 to v0.2.0.

w/ @sj-io

## What's new

- Windows MSVC support
- `addrust` dependency bump to v0.1.2

## Platform support

Added: `windows_amd64` (MSVC).
Continues: `linux_amd64`, `linux_arm64`, `osx_arm64`, `windows_amd64_mingw`.
Excluded: `osx_amd64`, `wasm_*` (unchanged from v0.1.0).

All platforms verified green in [the v0.2.0 CI run](https://github.com/ericmanning/duckdb-address-standardizer/actions/runs/25573962130).

## Release

- Pin SHA: `8da70a76d3ade131a094a0e746aa5d06605e3f80` (merge commit on main)
- GitHub release: https://github.com/ericmanning/duckdb-address-standardizer/releases/tag/v0.2.0