### PR TITLE
feat: add duckdb_delta_sharing community extension

### DIFF
--- a/extensions/duckdb_delta_sharing/description.yml
+++ b/extensions/duckdb_delta_sharing/description.yml
@@ -1,0 +1,61 @@
+extension:
+  name: duckdb_delta_sharing
+  description: The most efficient way to query Delta Lake tables directly from DuckDB via the Delta Sharing protocol.
+  version: 0.1.0
+  language: C++
+  build: cmake
+  license: Apache-2.0
+  maintainers:
+    - prequel-co
+
+repo:
+  github: prequel-co/DuckDB-Delta-Sharing
+  ref: a20b8d26afa4ef25e390fa7fe6f75cab55168d62
+
+docs:
+  hello_world: |
+    INSTALL duckdb_delta_sharing;
+    LOAD duckdb_delta_sharing;
+    -- Required for network access
+    INSTALL httpfs;
+    LOAD httpfs;
+
+    -- Basic Configuration
+    SET delta_sharing_endpoint = 'https://your-delta-sharing-server.com/api/2.0/delta-sharing';
+    SET delta_sharing_bearer_token = 'your_private_token';
+
+    -- Discovering Content
+    SELECT * FROM delta_share_list();
+    SELECT * FROM delta_share_list('my_share');
+
+    -- Reading Tables
+    SELECT * FROM delta_share_read('my_share', 'my_schema', 'my_table') 
+    WHERE year = 2024 
+    LIMIT 100;
+
+    -- Time Travel
+    SELECT count(*) 
+    FROM delta_share_read('my_share', 'my_schema', 'my_table', '2024-04-09 12:00:00');
+
+    -- Change Data Feed (CDF)
+    SELECT * 
+    FROM delta_share_change_data_feed('my_share', 'my_schema', 'my_table', 10);
+
+  extended_description: |
+    duckdb_delta_sharing is an extension for **querying Delta Lake tables directly
+    from DuckDB**. It implements the Delta Sharing protocol, allowing you to stream
+    data from remote Delta Sharing servers with native performance.
+
+    **Capabilities:**
+    - **Ultra-Fast Native Reader**: Built directly on DuckDB's `MultiFileReader` and C++ Parquet scanner. No Python overhead.
+    - **Time Travel**: Query your data as it existed at any point in history.
+    - **Change Data Feed (CDF)**: Easily track incremental additions, removals, and updates.
+    - **Advanced Predicate Pushdown**: Filters are pushed to the server to minimize data transfer.
+    - **Secure by Design**: Supports OAuth/Bearer token authentication and industry-standard encryption.
+    - **Query Telemetry**: Optional SQL tracking to help administrators optimize performance.
+
+    **Architecture:**
+    Traditional Delta Sharing clients often rely on heavy frameworks like Spark. This extension allows
+    DuckDB to pull Parquet files directly into its memory. It natively handles partition discovery
+    (automatically mapping folder structures to columns), deletion vectors (row-level deletes without
+    rewriting files), and schema evolution (safely mapping Delta types to DuckDB's native types).


### PR DESCRIPTION
## Add a new community extension: **duckdb_delta_sharing**

This a fully feature complete Delta Sharing client extension for DuckDB. There is already `duck_delta_share` but our extension is a lot more robust. That extension essentially composes `read_parquet()` queries and cannot leverage any Delta Lake specific format options like deletion vectors. This extension supports:

- [x] multi threaded reads
- [x] predicate pushdown
- [x] time travel
- [x] change data feeds
- [x] deletion vectors

## Notes
- Repo: https://github.com/prequel-co/duckdb-delta-sharing
- License: Apache2
- Build: cmake 
- Pinned DuckDB: v1.5.2