### PR TITLE
Bump lastra to 0.2.0: add lastra_version() scalar function

### DIFF
--- a/extensions/lastra/description.yml
+++ b/extensions/lastra/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: lastra
   description: Reader for the Lastra columnar time-series format
-  version: 0.1.1
+  version: 0.2.0
   language: C++
   build: cmake
   license: Apache-2.0
@@ -10,16 +10,15 @@ extension:
 
 repo:
   github: QTSurfer/duckdb-lastra
-  ref: ddc821958e10fdef844fb2ac6549eb44a51a3ae7
+  ref: 984d6be30ecf91135a5377da904695ed66f55cf3
 
 docs:
   hello_world: |
     SELECT * FROM read_lastra('data.lastra') LIMIT 10;
   extended_description: |
     Reads Lastra (.lastra) columnar time-series files with per-column codec
-    selection. Designed for financial tick data (OHLCV), IoT sensor readings,
-    and strategy execution results.
-
+    selection. Designed for financial tick data (OHLCV), IoT sensor readings,etc.
+    
     Supported codecs: ALP (adaptive lossless floating-point), Gorilla (XOR),
     Pongo (decimal-aware), delta-varint (timestamps), ZSTD (binary).
 


### PR DESCRIPTION
## Summary

Bumps the **lastra** extension from `0.1.1` → `0.2.0`. Adds a new scalar SQL function `lastra_version()` so clients can validate the loaded extension build at runtime — useful as codec/format fixes roll out via the community CDN.

```sql
SELECT lastra_version();
-- '0.2.0'
```

## Changes
- New `LASTRA_EXTENSION_VERSION` macro (single source of truth) used by both `LastraExtension::Version()` and the new scalar.
- `extended_description` slightly tightened.

## Source
- Release: https://github.com/QTSurfer/duckdb-lastra/releases/tag/v0.2.0
- Ref: `984d6be30ecf91135a5377da904695ed66f55cf3`
- Changelog: https://github.com/QTSurfer/duckdb-lastra/blob/main/Changelog/2026-05-10T22-11_v0.2.0_lastra_version_scalar.md

## Test
- `make test_release` → 9 assertions / 1 test case / all passed.
- New regression check in `test/sql/lastra.test`: `SELECT lastra_version();` returns the compiled version literal.