### PR TITLE
Add ducknng: ducknng is a pure C DuckDB extension providing a binding to the NNG scalability protocols

### DIFF
--- a/extensions/ducknng/description.yml
+++ b/extensions/ducknng/description.yml
@@ -1,0 +1,90 @@
+extension:
+  name: ducknng
+  description: "Pure C DuckDB extension exposing a DuckDB-backed SQL and RPC server over NNG using Arrow IPC — with framed RPC, custom HTTP routes, TLS support, body codec layer, and admission controls"
+  version: 0.1.0
+  language: C
+  build: cmake
+  license: MIT
+  requires_toolchains: python3
+  excluded_platforms: wasm_mvp;wasm_eh;wasm_threads
+  maintainers: - sounkou-bioinfo
+repo:
+  github: sounkou-bioinfo/ducknng
+  ref: 3afc6d3539a32f75661bb049cb558903c2143827
+docs:
+  hello_world: |
+      -- Load the extension
+      LOAD ducknng;
+  
+      -- Start an inproc REP server and run remote SQL
+      SELECT ducknng_start_server('demo', 'inproc://ducknng_demo', 1, 134217728, 30000, 0::UBIGINT);
+  
+      ┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
+      │ ducknng_start_server('demo', 'inproc://ducknng_demo', 1, 134217728, 30000, CAST(0 AS "UBIGINT")) │
+      │                                             boolean                                              │
+      ├──────────────────────────────────────────────────────────────────────────────────────────────────┤
+      │ true                                                                                             │
+      └──────────────────────────────────────────────────────────────────────────────────────────────────┘
+  
+      -- ducknng_query_rpc returns the actual result rows
+      SELECT *
+      FROM ducknng_query_rpc('inproc://ducknng_demo', 'SELECT 42 AS answer', 0::UBIGINT);
+  
+      ┌────────┐
+      │ answer │
+      │ int32  │
+      ├────────┤
+      │     42 │
+      └────────┘
+  
+      SELECT ducknng_stop_server('demo');
+  
+      ┌─────────────────────────────┐
+      │ ducknng_stop_server('demo') │
+      │           boolean           │
+      ├─────────────────────────────┤
+      │ true                        │
+      └─────────────────────────────┘
+  extended_description: |
+      ducknng is a pure C DuckDB extension that exposes a DuckDB-backed SQL and
+      RPC server over NNG (Nanomsg Next Generation) using Arrow IPC with nanoarrow C
+      for payload encoding and decoding.
+  
+      **Transport layer (NNG)**
+      Supports inproc://, ipc://, tcp://, and tls+tcp:// URLs. TLS certificates
+      can be loaded from file paths or in-memory PEM content; self-signed dev
+      certificates are generated entirely inside the extension (no file I/O).
+  
+      **Framed RPC**
+      Versioned request/reply envelope with manifest, exec, query session
+      (open/fetch/close/cancel), and raw unary operations. All tabular data
+      is encoded as Arrow IPC streams.
+  
+      **HTTP carrier**
+      Start a server on an http:// or https:// URL for the framed RPC mount.
+      Register custom HTTP routes (exact, prefix, or template matching) backed
+      by SQL queries. Streaming chunked routes for Server-Sent Events are
+      supported via ducknng_add_stream_route. Static asset serving, route-local
+      auth policies, and background workers are also available.
+  
+      **Body codec layer**
+      Parse HTTP response bodies by content type: JSON, NDJSON, CSV, TSV,
+      Parquet, Arrow IPC, form-urlencoded, and ducknng frames. Standalone
+      ducknng_parse_csv(body), ducknng_parse_tsv(body), and
+      ducknng_parse_parquet(body) functions use DuckDB's standard readers
+      via a tempfile round-trip. User-registered codec hooks extend the set.
+  
+      **Admission & security**
+      mTLS peer-identity extraction, exact identity allowlists, IP/CIDR
+      allowlists, per-service and per-principal resource limits (max memory,
+      max sessions, max result bytes), and SQL authorizer callbacks.
+  
+      **Development & testing**
+      Built against the DuckDB C API (no C++). Uses DuckDB's stable and
+      unstable C extensions API for Arrow conversion. 20+ SQL integration
+      tests run via sqllogictest. Cross-platform (Linux, macOS, Windows)
+      via the extension-ci-tools CMake build system.
+  
+      Project details and examples: https://github.com/sounkou-bioinfo/ducknng
+  
+      Community package excludes WASM targets (NNG threading requirement).

--- a/extensions/ducknng/description.yml
+++ b/extensions/ducknng/description.yml
@@ -1,90 +1,82 @@
 extension:
-  name: ducknng
-  description: "Pure C DuckDB extension exposing a DuckDB-backed SQL and RPC server over NNG using Arrow IPC — with framed RPC, custom HTTP routes, TLS support, body codec layer, and admission controls"
-  version: 0.1.0
-  language: C
-  build: cmake
-  license: MIT
-  requires_toolchains: python3
-  excluded_platforms: wasm_mvp;wasm_eh;wasm_threads
-  maintainers: - sounkou-bioinfo
+  name:
+    ducknng
+  description:
+    "Pure C DuckDB extension exposing a DuckDB-backed SQL and RPC server over NNG using Arrow IPC — with framed RPC, custom HTTP routes, TLS support, body codec layer, and admission controls"
+  version:
+    0.1.0
+  language:
+    C
+  build:
+    cmake
+  license:
+    MIT
+  requires_toolchains:
+    python3
+  excluded_platforms:
+    wasm_mvp;wasm_eh;wasm_threads
+  maintainers:
+    - "sounkou-bioinfo"
 repo:
-  github: sounkou-bioinfo/ducknng
-  ref: 3afc6d3539a32f75661bb049cb558903c2143827
+  github:
+    sounkou-bioinfo/ducknng
+  ref:
+    3cab10cfcf5b76ebf3067c496c6d22a0d674429c
 docs:
-  hello_world: |
-      -- Load the extension
-      LOAD ducknng;
-  
-      -- Start an inproc REP server and run remote SQL
-      SELECT ducknng_start_server('demo', 'inproc://ducknng_demo', 1, 134217728, 30000, 0::UBIGINT);
-  
-      ┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
-      │ ducknng_start_server('demo', 'inproc://ducknng_demo', 1, 134217728, 30000, CAST(0 AS "UBIGINT")) │
-      │                                             boolean                                              │
-      ├──────────────────────────────────────────────────────────────────────────────────────────────────┤
-      │ true                                                                                             │
-      └──────────────────────────────────────────────────────────────────────────────────────────────────┘
-  
-      -- ducknng_query_rpc returns the actual result rows
-      SELECT *
-      FROM ducknng_query_rpc('inproc://ducknng_demo', 'SELECT 42 AS answer', 0::UBIGINT);
-  
-      ┌────────┐
-      │ answer │
-      │ int32  │
-      ├────────┤
-      │     42 │
-      └────────┘
-  
-      SELECT ducknng_stop_server('demo');
-  
-      ┌─────────────────────────────┐
-      │ ducknng_stop_server('demo') │
-      │           boolean           │
-      ├─────────────────────────────┤
-      │ true                        │
-      └─────────────────────────────┘
-  extended_description: |
-      ducknng is a pure C DuckDB extension that exposes a DuckDB-backed SQL and
-      RPC server over NNG (Nanomsg Next Generation) using Arrow IPC with nanoarrow C
-      for payload encoding and decoding.
-  
-      **Transport layer (NNG)**
-      Supports inproc://, ipc://, tcp://, and tls+tcp:// URLs. TLS certificates
-      can be loaded from file paths or in-memory PEM content; self-signed dev
-      certificates are generated entirely inside the extension (no file I/O).
-  
-      **Framed RPC**
-      Versioned request/reply envelope with manifest, exec, query session
-      (open/fetch/close/cancel), and raw unary operations. All tabular data
-      is encoded as Arrow IPC streams.
-  
-      **HTTP carrier**
-      Start a server on an http:// or https:// URL for the framed RPC mount.
-      Register custom HTTP routes (exact, prefix, or template matching) backed
-      by SQL queries. Streaming chunked routes for Server-Sent Events are
-      supported via ducknng_add_stream_route. Static asset serving, route-local
-      auth policies, and background workers are also available.
-  
-      **Body codec layer**
-      Parse HTTP response bodies by content type: JSON, NDJSON, CSV, TSV,
-      Parquet, Arrow IPC, form-urlencoded, and ducknng frames. Standalone
-      ducknng_parse_csv(body), ducknng_parse_tsv(body), and
-      ducknng_parse_parquet(body) functions use DuckDB's standard readers
-      via a tempfile round-trip. User-registered codec hooks extend the set.
-  
-      **Admission & security**
-      mTLS peer-identity extraction, exact identity allowlists, IP/CIDR
-      allowlists, per-service and per-principal resource limits (max memory,
-      max sessions, max result bytes), and SQL authorizer callbacks.
-  
-      **Development & testing**
-      Built against the DuckDB C API (no C++). Uses DuckDB's stable and
-      unstable C extensions API for Arrow conversion. 20+ SQL integration
-      tests run via sqllogictest. Cross-platform (Linux, macOS, Windows)
-      via the extension-ci-tools CMake build system.
-  
-      Project details and examples: https://github.com/sounkou-bioinfo/ducknng
-  
-      Community package excludes WASM targets (NNG threading requirement).
+  hello_world:
+    |
+        -- Load the extension
+        LOAD ducknng;
+    
+        -- Start an inproc REP server and run remote SQL
+        SELECT ducknng_start_server('demo', 'inproc://ducknng_demo', 1, 134217728, 30000, 0::UBIGINT);
+    
+        -- ducknng_query_rpc returns the actual result rows
+        SELECT *
+        FROM ducknng_query_rpc('inproc://ducknng_demo', 'SELECT 42 AS answer', 0::UBIGINT);
+    
+        SELECT ducknng_stop_server('demo');
+  extended_description:
+    |
+    ducknng is a pure C DuckDB extension that exposes a DuckDB-backed SQL and
+    RPC server over NNG (Nanomsg Next Generation) using Arrow IPC with nanoarrow C
+    for payload encoding and decoding.
+    
+    **Transport layer (NNG)**
+    Supports inproc://, ipc://, tcp://, and tls+tcp:// URLs. TLS certificates
+    can be loaded from file paths or in-memory PEM content; self-signed dev
+    certificates are generated entirely inside the extension (no file I/O).
+    
+    **Framed RPC**
+    Versioned request/reply envelope with manifest, exec, query session
+    (open/fetch/close/cancel), and raw unary operations. All tabular data
+    is encoded as Arrow IPC streams.
+    
+    **HTTP carrier**
+    Start a server on an http:// or https:// URL for the framed RPC mount.
+    Register custom HTTP routes (exact, prefix, or template matching) backed
+    by SQL queries. Streaming chunked routes for Server-Sent Events are
+    supported via ducknng_add_stream_route. Static asset serving, route-local
+    auth policies, and background workers are also available.
+    
+    **Body codec layer**
+    Parse HTTP response bodies by content type: JSON, NDJSON, CSV, TSV,
+    Parquet, Arrow IPC, form-urlencoded, and ducknng frames. Standalone
+    ducknng_parse_csv(body), ducknng_parse_tsv(body), and
+    ducknng_parse_parquet(body) functions use DuckDB's standard readers
+    via a tempfile round-trip. User-registered codec hooks extend the set.
+    
+    **Admission & security**
+    mTLS peer-identity extraction, exact identity allowlists, IP/CIDR
+    allowlists, per-service and per-principal resource limits (max memory,
+    max sessions, max result bytes), and SQL authorizer callbacks.
+    
+    **Development & testing**
+    Built against the DuckDB C API (no C++). Uses DuckDB's stable and
+    unstable C extensions API for Arrow conversion. 20+ SQL integration
+    tests run via sqllogictest. Cross-platform (Linux, macOS, Windows)
+    via the extension-ci-tools CMake build system.
+    
+    Project details and examples: https://github.com/sounkou-bioinfo/ducknng
+    
+    Community package excludes WASM targets (NNG threading requirement).

--- a/extensions/ducknng/description.yml
+++ b/extensions/ducknng/description.yml
@@ -1,82 +1,189 @@
 extension:
-  name:
-    ducknng
-  description:
-    "Pure C DuckDB extension exposing a DuckDB-backed SQL and RPC server over NNG using Arrow IPC — with framed RPC, custom HTTP routes, TLS support, body codec layer, and admission controls"
-  version:
-    0.1.1
-  language:
-    C
-  build:
-    cmake
-  license:
-    MIT
-  requires_toolchains:
-    python3
-  excluded_platforms:
-    wasm_mvp;wasm_eh;wasm_threads;windows_amd64;windows_arm64
+  name: "ducknng"
+  description: "\"Pure C DuckDB extension exposing a DuckDB-backed SQL and RPC server over NNG using Arrow IPC — with framed RPC, custom HTTP routes, TLS support, body codec layer, and admission controls\""
+  version: "0.1.1"
+  language: "C"
+  build: "cmake"
+  license: "MIT"
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64;windows_arm64"
   maintainers:
     - "sounkou-bioinfo"
+
 repo:
-  github:
-    sounkou-bioinfo/ducknng
-  ref:
-    26fc48ba8f42ad16681d73a887245c133d40d86b
+  github: "sounkou-bioinfo/ducknng"
+  ref: "8dbf0738b4c6f07208174b4245ceafb79638ccb7"
+
 docs:
-  hello_world:
-    |
-        -- Load the extension
-        LOAD ducknng;
+  hello_world: |
+    -- Load the extension
+    LOAD ducknng;
     
-        -- Start an inproc REP server and run remote SQL
-        SELECT ducknng_start_server('demo', 'inproc://ducknng_demo', 1, 134217728, 30000, 0::UBIGINT);
+    -- Start a local HTTP RPC service
+    SELECT ducknng_start_server(
+      'api',
+      'http://127.0.0.1:8080/_ducknng',
+      1,
+      134217728,
+      300000,
+      0::UBIGINT
+    );
     
-        -- ducknng_query_rpc returns the actual result rows
-        SELECT *
-        FROM ducknng_query_rpc('inproc://ducknng_demo', 'SELECT 42 AS answer', 0::UBIGINT);
+    -- Inspect the running service
+    SELECT name, listen, execution_model
+    FROM ducknng_list_servers();
     
-        SELECT ducknng_stop_server('demo');
-  extended_description:
-    |
-    ducknng is a pure C DuckDB extension that exposes a DuckDB-backed SQL and
-    RPC server over NNG (Nanomsg Next Generation) using Arrow IPC with nanoarrow C
-    for payload encoding and decoding.
+    -- Stop the service
+    SELECT ducknng_stop_server('api');
+  extended_description: |
+    Ducknng turns DuckDB into a transport-and-protocol server: DuckDB-backed SQL and manifest-declared RPC exposed over NNG transports and the built-in HTTP/HTTPS carrier, with Arrow IPC used for row-bearing payloads.
     
-    **Transport layer (NNG)**
-    Supports inproc://, ipc://, tcp://, and tls+tcp:// URLs. TLS certificates
-    can be loaded from file paths or in-memory PEM content; self-signed dev
-    certificates are generated entirely inside the extension (no file I/O).
+    The extension includes transport primitives, raw frame helpers, explicit query sessions, async aio handles, TLS helpers, and a low-level HTTP route layer that downstream users can extend into their own gateways, meshes, or application protocols.
     
-    **Framed RPC**
-    Versioned request/reply envelope with manifest, exec, query session
-    (open/fetch/close/cancel), and raw unary operations. All tabular data
-    is encoded as Arrow IPC streams.
+    Functions included in this extension:
     
-    **HTTP carrier**
-    Start a server on an http:// or https:// URL for the framed RPC mount.
-    Register custom HTTP routes (exact, prefix, or template matching) backed
-    by SQL queries. Streaming chunked routes for Server-Sent Events are
-    supported via ducknng_add_stream_route. Static asset serving, route-local
-    auth policies, and background workers are also available.
+    ### Service Control
+    - `ducknng_start_server(name, listen, contexts, recv_max_bytes, session_idle_ms, tls_config_id[, ip_allowlist_json])`: Start a named ducknng service and choose the carrier from the listen URL scheme.
+    - `ducknng_stop_server(name)`: Stop a named ducknng service.
+    - `ducknng_service_inflight(name)`: Return the current in-flight request count for a named service. Re-evaluated on every call, making it suitable for use inside recursive poll CTEs.
+    - `ducknng_set_service_execution_model(name, model)`: Set the DuckDB connection execution model used by service-side SQL.
     
-    **Body codec layer**
-    Parse HTTP response bodies by content type: JSON, NDJSON, CSV, TSV,
-    Parquet, Arrow IPC, form-urlencoded, and ducknng frames. Standalone
-    ducknng_parse_csv(body), ducknng_parse_tsv(body), and
-    ducknng_parse_parquet(body) functions use DuckDB's standard readers
-    via a tempfile round-trip. User-registered codec hooks extend the set.
+    ### Introspection
+    - `ducknng_list_servers()`: List registered ducknng services.
+    - `ducknng_read_monitor(name, after_seq, max_events)`: Read the bounded per-service NNG pipe monitor event stream.
+    - `ducknng_monitor_status(name)`: Return pipe monitor ring status and active-pipe counters for a running service.
+    - `ducknng_list_pipes(name)`: List currently active NNG pipes for a running service.
+    - `ducknng_log_entries()`: Return a snapshot of the most recent DuckDB log entries captured by the ducknng log ring.
+    - `ducknng_enable_log_capture()`: Wire the ducknng log ring into DuckDB's internal logger so that DuckDB log entries are captured and visible through ducknng_log_entries(). Returns TRUE if capture is active after the call, FALSE if registration failed. Safe to call multiple times.
     
-    **Admission & security**
-    mTLS peer-identity extraction, exact identity allowlists, IP/CIDR
-    allowlists, per-service and per-principal resource limits (max memory,
-    max sessions, max result bytes), and SQL authorizer callbacks.
+    ### Method Registry
+    - `ducknng_register_exec_method([requires_auth])`: Register the built-in exec RPC method explicitly.
+    - `ducknng_set_method_auth(name, requires_auth)`: Set descriptor-level verified-peer-identity authorization for a registered RPC method.
+    - `ducknng_unregister_method(name)`: Unregister a method from the runtime registry.
+    - `ducknng_unregister_family(family)`: Unregister all methods in a family and return the number removed.
+    - `ducknng_list_methods()`: List the currently registered RPC methods in the runtime registry.
     
-    **Development & testing**
-    Built against the DuckDB C API (no C++). Uses DuckDB's stable and
-    unstable C extensions API for Arrow conversion. 20+ SQL integration
-    tests run via sqllogictest. Cross-platform (Linux, macOS, Windows)
-    via the extension-ci-tools CMake build system.
+    ### Primitive Transport
+    - `ducknng_open_socket(protocol)`: Open a client socket handle for a supported NNG protocol.
+    - `ducknng_dial_socket(socket_id, url, timeout_ms, tls_config_id)`: Dial a URL using an opened socket handle.
+    - `ducknng_listen_socket(socket_id, url, recv_max_bytes, tls_config_id)`: Bind a socket handle to a listen URL and start its NNG listener.
+    - `ducknng_close_socket(socket_id)`: Close a client socket handle.
+    - `ducknng_send_socket_raw(socket_id, frame, timeout_ms)`: Send one raw frame through an active socket handle.
+    - `ducknng_recv_socket_raw(socket_id, timeout_ms)`: Receive one raw frame from an active socket handle.
+    - `ducknng_subscribe_socket(socket_id, topic)`: Register a raw topic prefix on a sub socket.
+    - `ducknng_unsubscribe_socket(socket_id, topic)`: Remove a raw topic prefix from a sub socket.
+    - `ducknng_list_sockets()`: List client socket handles in the runtime.
+    - `ducknng_request(url, payload, timeout_ms, tls_config_id)`: Perform a one-shot raw request and return a structured result row.
+    - `ducknng_request_socket(socket_id, payload, timeout_ms)`: Perform a raw request through a previously dialed socket handle and return a structured result row.
+    - `ducknng_request_raw(url, payload, timeout_ms, tls_config_id)`: Perform a one-shot raw request and return the raw reply frame bytes.
+    - `ducknng_request_socket_raw(socket_id, payload, timeout_ms)`: Perform a raw request through a dialed socket handle and return the raw reply frame bytes.
+    - `ducknng_decode_frame(frame)`: Decode a raw ducknng frame into envelope fields and extracted payload columns.
+    - `ducknng_frame_payload(frame)`: Extract the payload bytes from one raw ducknng frame.
+    - `ducknng_frame_payload_text(frame)`: Extract the payload as UTF-8 text when a raw ducknng frame carries a textual payload.
+    - `ducknng_frame_error_text(frame)`: Extract the protocol-level error text from a raw ducknng error frame.
+    - `ducknng_frame_version(frame)`: Extract the protocol version field from one raw ducknng frame.
+    - `ducknng_frame_type(frame)`: Extract the numeric reply type field from one raw ducknng frame.
+    - `ducknng_frame_flags(frame)`: Extract the reply flags bitset from one raw ducknng frame.
+    - `ducknng_frame_type_name(frame)`: Extract the symbolic reply type name from one raw ducknng frame.
+    - `ducknng_frame_name(frame)`: Extract the method or reply name field from one raw ducknng frame.
+    - `ducknng_frame_end_of_stream(frame)`: Report whether one raw ducknng frame carries the end-of-stream reply flag.
     
-    Project details and examples: https://github.com/sounkou-bioinfo/ducknng
+    ### Transport Security
+    - `ducknng_list_tls_configs()`: List registered TLS config handles and the kinds of material they contain.
+    - `ducknng_drop_tls_config(tls_config_id)`: Remove a registered TLS config handle from the runtime.
+    - `ducknng_set_tls_peer_allowlist(tls_config_id, identities_json)`: Set the default exact peer-identity allowlist on a TLS config handle.
+    - `ducknng_set_service_peer_allowlist(name, identities_json)`: Dynamically set the exact peer-identity allowlist for a running service.
+    - `ducknng_set_service_ip_allowlist(name, cidrs_json)`: Dynamically set the IP/CIDR remote-address allowlist for a running service.
+    - `ducknng_set_service_limits(name, max_open_sessions[, max_active_pipes[, max_inflight_requests[, max_sessions_per_peer_identity[, max_inflight_per_principal[, max_reply_bytes_per_principal[, max_session_open_rate_per_principal]]]]]])`: Set service resource limits.
+    - `ducknng_auth_context()`: Expose the current request context to a SQL authorization callback.
+    - `ducknng_set_service_authorizer(name, authorizer_sql)`: Install or clear a service-level SQL authorization callback evaluated uniformly for framed RPC requests before method dispatch.
+    - `ducknng_self_signed_tls_config(common_name, valid_days, auth_mode)`: Generate a self-signed development certificate and register it as a TLS config handle.
+    - `ducknng_tls_config_from_pem(cert_pem, key_pem, ca_pem, password, auth_mode)`: Register a TLS config handle from in-memory PEM material.
+    - `ducknng_tls_config_from_files(cert_key_file, ca_file, password, auth_mode)`: Register a TLS config handle from file-backed certificate material.
     
-    Community package excludes WASM targets (NNG threading requirement) and Windows MSVC (use MinGW/Rtools).
+    ### HTTP Transport
+    - `ducknng_ncurl(url, method, headers_json, body, timeout_ms, tls_config_id)`: Perform one HTTP or HTTPS request and return an in-band result row.
+    - `ducknng_ncurl_aio(url, method, headers_json, body, timeout_ms, tls_config_id)`: Launch one asynchronous HTTP or HTTPS request and return a future-like aio handle id.
+    - `ducknng_ncurl_aio_collect(aio_ids, wait_ms)`: Wait for asynchronous ncurl handles and return one raw HTTP result row per newly collected terminal operation.
+    - `ducknng_ncurl_table(url, method, headers_json, body, timeout_ms, tls_config_id)`: Perform one HTTP or HTTPS request and parse a successful response body into a DuckDB table using the built-in body codec providers.
+    
+    ### Body Codecs
+    - `ducknng_list_codecs()`: List built-in body serialization/deserialization providers and any registered user codec hooks.
+    - `ducknng_register_codec(content_type, function_name)`: Register a user body codec that decodes a BLOB body into a single VARCHAR value through an existing scalar SQL function.
+    - `ducknng_unregister_codec(content_type)`: Remove a previously registered user body codec for a content type.
+    - `ducknng_parse_body(body, content_type)`: Parse one response/request body BLOB according to its content type.
+    
+    ### HTTP Routes
+    - `ducknng_register_http_route(service_name, method, path, handler_sql[, request_max_bytes])`: Register one exact-path HTTP route beside the framed RPC mount of an existing http:// or https:// service.
+    - `ducknng_register_http_route_pattern(service_name, method, match_kind, path_pattern, handler_sql[, request_max_bytes])`: Register one low-level HTTP route pattern beside the framed RPC mount using exact, prefix, or template matching.
+    - `ducknng_unregister_http_route(service_name, method, path)`: Remove one previously registered exact-path HTTP route from a service.
+    - `ducknng_unregister_http_route_pattern(service_name, method, match_kind, path_pattern)`: Remove one previously registered prefix, template, or explicit exact route pattern from a service.
+    - `ducknng_list_http_routes()`: List the currently registered HTTP routes across running services, including their match kind and stored path pattern.
+    - `ducknng_set_http_route_auth(service_name, method, path[, require_identity[, allow_identities_json]])`: Set authentication requirements on a registered HTTP route.
+    - `ducknng_register_http_static(service_name, path_prefix, dir_path)`: Register a prefix route that serves static files from a directory on the server filesystem.
+    - `ducknng_register_http_worker(service_name, worker_name, sql, interval_ms)`: Register a background SQL worker that runs on a recurring interval while the HTTP service is active.
+    - `ducknng_unregister_http_worker(service_name, worker_name)`: Unregister a previously registered HTTP background worker.
+    - `ducknng_list_http_workers()`: List all currently registered HTTP background workers across running services.
+    - `ducknng_http_ndjson(status, body_text)`: Convenience table macro for returning an NDJSON HTTP response from a route handler.
+    - `ducknng_http_sse(status, body_text)`: Convenience table macro for returning a Server-Sent Events HTTP response from a route handler.
+    - `ducknng_http_request()`: Expose the current HTTP request context while SQL runs inside an active route handler.
+    - `ducknng_http_request_body()`: Expose the current HTTP request body while SQL runs inside an active route handler.
+    - `ducknng_http_headers_get(headers_json, name)`: Return one header value from ducknng's canonical HTTP header JSON.
+    - `ducknng_http_headers_build(names, values)`: Build ducknng's canonical HTTP header JSON from parallel name and value lists.
+    - `ducknng_http_query_param_get(query_string, name)`: Return one decoded query-string parameter value.
+    - `ducknng_http_cookie_get(cookie_header, name)`: Return one cookie value from a Cookie header string.
+    - `ducknng_http_path_params_get(path_params_json, name)`: Return one template-route path parameter from path_params_json.
+    - `ducknng_http_header(name)`: Route-local shortcut for reading one request header by name.
+    - `ducknng_http_query_param(name)`: Route-local shortcut for reading one decoded query parameter by name.
+    - `ducknng_http_cookie(name)`: Route-local shortcut for reading one request cookie by name.
+    - `ducknng_http_path_param(name)`: Route-local shortcut for reading one template path parameter by name.
+    - `ducknng_http_response(status, headers_json, content_type, body, body_text)`: Build the one-row response shape expected by a route handler.
+    - `ducknng_http_text(status, body_text)`: Build a one-row plain-text HTTP route response.
+    - `ducknng_http_json(status, body_text)`: Build a one-row JSON HTTP route response from a text body.
+    - `ducknng_http_binary(status, body)`: Build a one-row binary HTTP route response.
+    
+    ### Async I/O
+    - `ducknng_request_raw_aio(url, frame, timeout_ms, tls_config_id)`: Launch one raw req/rep roundtrip asynchronously and return a future-like aio handle id.
+    - `ducknng_get_rpc_manifest_raw_aio(url, timeout_ms, tls_config_id)`: Launch one asynchronous manifest RPC request and return an aio handle id for the raw reply frame.
+    - `ducknng_run_rpc_raw_aio(url, sql, timeout_ms, tls_config_id)`: Launch one asynchronous metadata-only exec RPC request and return an aio handle id for the raw reply frame.
+    - `ducknng_open_query_raw_aio(url, sql, batch_rows, batch_bytes, timeout_ms, tls_config_id)`: Launch one asynchronous query_open request and return an aio handle id for the raw reply frame.
+    - `ducknng_fetch_query_raw_aio(url, session_id, session_token, batch_rows, batch_bytes, timeout_ms, tls_config_id)`: Launch one asynchronous fetch request and return an aio handle id for the raw reply frame.
+    - `ducknng_close_query_raw_aio(url, session_id, session_token, timeout_ms, tls_config_id)`: Launch one asynchronous close request and return an aio handle id for the raw reply frame.
+    - `ducknng_cancel_query_raw_aio(url, session_id, session_token, timeout_ms, tls_config_id)`: Launch one asynchronous cancel request and return an aio handle id for the raw reply frame.
+    - `ducknng_request_socket_raw_aio(socket_id, frame, timeout_ms)`: Launch one raw req/rep roundtrip asynchronously on an existing req socket handle and return an aio handle id.
+    - `ducknng_send_socket_raw_aio(socket_id, frame, timeout_ms)`: Launch one raw socket send asynchronously and return an aio handle id.
+    - `ducknng_recv_socket_raw_aio(socket_id, timeout_ms)`: Launch one raw socket receive asynchronously and return an aio handle id.
+    - `ducknng_aio_ready(aio_id)`: Return whether an aio handle has reached a terminal state.
+    - `ducknng_aio_wait(aio_ids, wait_ms)`: Wait until any requested aio handle reaches a terminal state without collecting or dropping it.
+    - `ducknng_aio_status(aio_id)`: Inspect the current or terminal status of one aio handle, including send-phase and recv-phase completion.
+    - `ducknng_aio_collect(aio_ids, wait_ms)`: Wait for any requested aio handles to finish and return one row per newly collected terminal result.
+    - `ducknng_aio_collect_decoded(aio_ids, wait_ms)`: Wait for framed aio handles, collect their terminal frame rows, and project the decoded envelope columns directly.
+    - `ducknng_aio_cancel(aio_id)`: Request cancellation of a pending aio handle.
+    - `ducknng_aio_drop(aio_id)`: Release a terminal aio handle from the runtime registry.
+    
+    ### RPC Helper
+    - `ducknng_get_rpc_manifest(url, tls_config_id)`: Request the RPC manifest and return a structured result row.
+    - `ducknng_get_rpc_manifest_raw(url, tls_config_id)`: Request the RPC manifest and return the raw reply frame as BLOB.
+    - `ducknng_run_rpc(url, sql, tls_config_id)`: Execute a metadata-oriented RPC call and return a structured result row.
+    - `ducknng_run_rpc_raw(url, sql, tls_config_id)`: Execute the exec RPC and return the raw reply frame as BLOB.
+    - `ducknng_query_rpc(url, sql, tls_config_id)`: Execute a row-returning RPC query as a session convenience wrapper and expose the fetched Arrow IPC rows as a DuckDB table.
+    
+    ### RPC Session
+    - `ducknng_open_query(url, sql, batch_rows, batch_bytes, tls_config_id)`: Open a server-side query session and return the JSON control metadata as a structured row.
+    - `ducknng_fetch_query(url, session_id, session_token, batch_rows, batch_bytes, tls_config_id)`: Fetch the next session reply and return either JSON control metadata or an Arrow IPC batch payload.
+    - `ducknng_fetch_query_table(url, session_id, session_token, batch_rows, batch_bytes, tls_config_id)`: Fetch one session row batch and decode the returned Arrow IPC payload directly into a DuckDB table.
+    - `ducknng_close_query(url, session_id, session_token, tls_config_id)`: Close a server-side query session and return the JSON control metadata as a structured row.
+    - `ducknng_cancel_query(url, session_id, session_token, tls_config_id)`: Request cancellation for a server-side query session and return the JSON control metadata as a structured row.
+    - `ducknng_open_query_raw(url, sql, batch_rows, batch_bytes, tls_config_id)`: Open a server-side query session and return the raw reply frame as BLOB.
+    - `ducknng_fetch_query_raw(url, session_id, session_token, batch_rows, batch_bytes, tls_config_id)`: Fetch the next session reply and return the raw reply frame as BLOB.
+    - `ducknng_close_query_raw(url, session_id, session_token, tls_config_id)`: Close a server-side query session and return the raw reply frame as BLOB.
+    - `ducknng_cancel_query_raw(url, session_id, session_token, tls_config_id)`: Cancel a server-side query session and return the raw reply frame as BLOB.
+    
+    Operational notes:
+    - Transport family is chosen by URL scheme. Supported listeners and clients cover inproc://, ipc://, tcp://, tls+tcp://, ws://, wss://, http://, and https:// where applicable.
+    - Arrow IPC is the normal row payload format. JSON is used for manifest documents and lightweight control metadata.
+    - Query sessions are explicit (`query_open`, `fetch`, `close`, `cancel`) and raw/session aio helpers follow the same future-like async contract through `nng_aio` handles.
+    - Expected aio launch failures return immediate terminal error handles so callers inspect errors through aio status or collect helpers instead of catching DuckDB exceptions.
+    - The default server-side DuckDB execution model is `shared_serialized_connection`; services may switch to `service_serialized_connection` or `request_connection` with ducknng_set_service_execution_model().
+    - TLS configuration can come from filesystem paths, in-memory PEM content, or self-signed development helpers.
+    - The HTTP route layer is intentionally primitive and extensible; downstream users can build tenant routing, worker orchestration, and other control-plane logic without `ducknng` sealing those policies into the core extension.
+    - Current excluded platforms are wasm and Windows.

--- a/extensions/ducknng/description.yml
+++ b/extensions/ducknng/description.yml
@@ -14,14 +14,14 @@ extension:
   requires_toolchains:
     python3
   excluded_platforms:
-    wasm_mvp;wasm_eh;wasm_threads
+    wasm_mvp;wasm_eh;wasm_threads;windows_amd64;windows_arm64
   maintainers:
     - "sounkou-bioinfo"
 repo:
   github:
     sounkou-bioinfo/ducknng
   ref:
-    3cab10cfcf5b76ebf3067c496c6d22a0d674429c
+    edd904f35925203f0d289a6d3813d3ddbe5384b2
 docs:
   hello_world:
     |
@@ -79,4 +79,4 @@ docs:
     
     Project details and examples: https://github.com/sounkou-bioinfo/ducknng
     
-    Community package excludes WASM targets (NNG threading requirement).
+    Community package excludes WASM targets (NNG threading requirement) and Windows MSVC (use MinGW/Rtools).

--- a/extensions/ducknng/description.yml
+++ b/extensions/ducknng/description.yml
@@ -4,7 +4,7 @@ extension:
   description:
     "Pure C DuckDB extension exposing a DuckDB-backed SQL and RPC server over NNG using Arrow IPC — with framed RPC, custom HTTP routes, TLS support, body codec layer, and admission controls"
   version:
-    0.1.0
+    0.1.0.9000
   language:
     C
   build:
@@ -21,7 +21,7 @@ repo:
   github:
     sounkou-bioinfo/ducknng
   ref:
-    edd904f35925203f0d289a6d3813d3ddbe5384b2
+    da40831e8d5863a63b3ade9e3b98aab1cbdf9e79
 docs:
   hello_world:
     |

--- a/extensions/ducknng/description.yml
+++ b/extensions/ducknng/description.yml
@@ -4,7 +4,7 @@ extension:
   description:
     "Pure C DuckDB extension exposing a DuckDB-backed SQL and RPC server over NNG using Arrow IPC — with framed RPC, custom HTTP routes, TLS support, body codec layer, and admission controls"
   version:
-    0.1.0.9000
+    0.1.1
   language:
     C
   build:
@@ -21,7 +21,7 @@ repo:
   github:
     sounkou-bioinfo/ducknng
   ref:
-    da40831e8d5863a63b3ade9e3b98aab1cbdf9e79
+    5185cf58c8cc621579af6114900cc68aebab2676
 docs:
   hello_world:
     |

--- a/extensions/ducknng/description.yml
+++ b/extensions/ducknng/description.yml
@@ -21,7 +21,7 @@ repo:
   github:
     sounkou-bioinfo/ducknng
   ref:
-    5185cf58c8cc621579af6114900cc68aebab2676
+    26fc48ba8f42ad16681d73a887245c133d40d86b
 docs:
   hello_world:
     |


### PR DESCRIPTION
# ducknng

`ducknng` is a pure C DuckDB extension providing a binding to the [NNG](https://nng.nanomsg.org/) scalability protocols. It is inspired by [`nanonext`](https://github.com/r-lib/nanonext) and follows its ergonomic model: transport is chosen by URL scheme, aio handles wrap pending NNG operations as SQL-visible futures, and TLS material may come from filesystem paths or in-memory PEM. On top of the raw socket and transport layer, `ducknng` adds a framed RPC envelope, Arrow IPC tabular payloads, manifest-declared methods, and an HTTP/HTTPS carrier so DuckDB sessions can reach one another over `inproc://`, `ipc://`, `tcp://`, `tls+tcp://`, `ws://`, `wss://`, `http://`, or `https://`. Long-lived handles — servers, sockets, AIO futures, TLS configs, query sessions — are manually managed at the SQL surface.

It also draws on [`mangoro`](https://github.com/sounkou-bioinfo/mangoro) for the thin versioned RPC envelope design.

## Layer map

| Layer          | What it does                                                                                                                                                                                                             |
|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| **Transport**  | NNG sockets and listeners. Synchronous send/recv. One-shot AIO handles. Pipe-event telemetry.                                                                                                                            |
| **Framed RPC** | Versioned envelope carrying Arrow IPC payloads or JSON control text. `manifest` is always on; `exec` is opt-in. `http://`/`https://` mount the same methods at the URL path.                                             |
| **Policy**     | Fast C admission: mTLS, exact peer-identity allowlists, IP/CIDR allowlists, per-service and per-principal resource limits. Optional SQL authorizer at the request boundary.                                              |
| **Codecs**     | `ducknng_parse_body(...)` and `ducknng_ncurl_table(...)` parse content-type-tagged BLOBs. Built-in providers cover JSON, Arrow IPC, ducknng frames, and a text/raw fallback. User-registered codec hooks extend the set. |

## Quick tour

Build the extension first (see **Development** below), then load it:

Start a TLS server. Port 0 lets the OS assign a free port; a self-signed
certificate is generated in memory — no files needed.

``` sql
-- Self-signed dev cert: key and certificate live only in DuckDB memory.
SET VARIABLE tour_tls = ducknng_self_signed_tls_config('127.0.0.1', 365, 0);
SELECT ducknng_start_server(
  'tour',                              -- service name
  'tls+tcp://127.0.0.1:0',             -- TLS; port 0 = OS-assigned
  1,                                   -- REP contexts
  134217728,                           -- recv_max_bytes (128 MiB)
  300000,                              -- session_idle_ms
  getvariable('tour_tls')::UBIGINT     -- TLS config handle
);
SET VARIABLE tour_url = (
  SELECT listen FROM ducknng_list_servers() WHERE name = 'tour'
);
SELECT getvariable('tour_url') AS listen_url;
-- Open a REQ socket and dial immediately.
SET VARIABLE req_id = (ducknng_open_socket('req')).socket_id;
SELECT (ducknng_dial_socket(
  getvariable('req_id')::UBIGINT,
  getvariable('tour_url'),
  1000, getvariable('tour_tls')::UBIGINT
)).ok AS dialed;

+-------------------------------------------------------------------------------------------------------------------------+
| ducknng_start_server('tour', 'tls+tcp://127.0.0.1:0', 1, 134217728, 300000, CAST(getvariable('tour_tls') AS "UBIGINT")) |
+-------------------------------------------------------------------------------------------------------------------------+
| true                                                                                                                    |
+-------------------------------------------------------------------------------------------------------------------------+

+---------------------------+
|        listen_url         |
+---------------------------+
| tls+tcp://127.0.0.1:43747 |
+---------------------------+

+--------+
| dialed |
+--------+
| true   |
+--------+
```

**Raw socket send/receive.** Send the manifest request frame and decode
the reply envelope.

``` sql
-- Send the 22-byte manifest call frame and decode the reply.
SELECT ok, type_name, name,
       json_array_length(json_extract(payload_text::JSON, '$.methods')) AS method_count
FROM ducknng_decode_frame(
  ducknng_request_socket_raw(
    getvariable('req_id')::UBIGINT,
    from_hex('01000000000000000000000000000000000000000000'),
    1000
  )
);
+------+-----------+----------+--------------+
|  ok  | type_name |   name   | method_count |
+------+-----------+----------+--------------+
| true | result    | manifest | 6            |
+------+-----------+----------+--------------+
```

**One-shot URL form** — same call without holding a socket handle.

``` sql
SELECT ok, type_name, name
FROM ducknng_decode_frame(
  ducknng_request_raw(
    getvariable('tour_url'),
    from_hex('01000000000000000000000000000000000000000000'),
    1000, getvariable('tour_tls')::UBIGINT
  )
);
+------+-----------+----------+
|  ok  | type_name |   name   |
+------+-----------+----------+
| true | result    | manifest |
+------+-----------+----------+
```

**AIO: launch two requests in parallel, collect both later.**
`ducknng_request_raw_aio(...)` returns immediately with an integer AIO
handle. `ducknng_aio_collect(...)` blocks until all handles are ready.

``` sql
CREATE TEMP TABLE tour_aios AS
SELECT
  ducknng_request_raw_aio(
    getvariable('tour_url'),
    from_hex('01000000000000000000000000000000000000000000'),
    1000, getvariable('tour_tls')::UBIGINT
  ) AS aio1,
  ducknng_request_raw_aio(
    getvariable('tour_url'),
    from_hex('01000000000000000000000000000000000000000000'),
    1000, getvariable('tour_tls')::UBIGINT
  ) AS aio2;
-- aio_collect blocks until both frames are ready then returns one row per handle.
SELECT aio_id, ok, octet_length(frame) > 0 AS has_frame
FROM ducknng_aio_collect((SELECT list_value(aio1, aio2) FROM tour_aios), 1000)
ORDER BY aio_id;

+--------+------+-----------+
| aio_id |  ok  | has_frame |
+--------+------+-----------+
| 1      | true | true      |
+--------+------+-----------+
```

**`ducknng_ncurl` — HTTP client primitive.** The framed RPC mount
accepts POST only. Mount a server on an `http://` URL and POST the
manifest call frame to demonstrate that the framed RPC surface is
identical over HTTP.

``` sql
SELECT ducknng_start_server(
  'tour_http', 'http://127.0.0.1:18440/_ducknng', 1, 134217728, 300000, 0::UBIGINT
);
-- The RPC mount accepts POST. POST the 22-byte manifest frame and decode the reply.
SET VARIABLE tour_http_reply = (
  SELECT body FROM ducknng_ncurl(
    'http://127.0.0.1:18440/_ducknng',
    'POST', '[{"name":"Content-Type","value":"application/vnd.ducknng.frame"}]',
    from_hex('01000000000000000000000000000000000000000000'),
    2000, 0::UBIGINT
  )
);
SELECT ok, type_name, name,
       json_array_length(json_extract(payload_text::JSON, '$.methods')) AS method_count
FROM ducknng_decode_frame(getvariable('tour_http_reply')::BLOB);
+------------------------------------------------------------------------------------------------------------------+
| ducknng_start_server('tour_http', 'http://127.0.0.1:18440/_ducknng', 1, 134217728, 300000, CAST(0 AS "UBIGINT")) |
+------------------------------------------------------------------------------------------------------------------+
| true                                                                                                             |
+------------------------------------------------------------------------------------------------------------------+

+------+-----------+----------+--------------+
|  ok  | type_name |   name   | method_count |
+------+-----------+----------+--------------+
| true | result    | manifest | 6            |
+------+-----------+----------+--------------+
```

**Query session: open, fetch Arrow IPC, parse the batch.**
`ducknng_open_query` returns a `session_id` + `session_token`.
`ducknng_fetch_query_table` decodes the first Arrow batch directly as
rows. The raw fetch frame carries the same Arrow bytes as a BLOB for
callers that need to forward or inspect the payload.

``` sql
CREATE TEMP TABLE tour_session AS
SELECT *
FROM ducknng_open_query(
  getvariable('tour_url'),
  'SELECT i, i * i AS sq FROM range(1, 6) AS t(i)',
  0::UBIGINT, 0::UBIGINT, getvariable('tour_tls')::UBIGINT
);
SET VARIABLE tour_sid   = (SELECT session_id    FROM tour_session);
SET VARIABLE tour_token = (SELECT session_token FROM tour_session);
-- Decoded rows directly:
SELECT *
FROM ducknng_fetch_query_table(
  getvariable('tour_url'),
  getvariable('tour_sid')::UBIGINT,
  getvariable('tour_token')::VARCHAR,
  0::UBIGINT, 0::UBIGINT, getvariable('tour_tls')::UBIGINT
);



+---+----+
| i | sq |
+---+----+
| 1 | 1  |
| 2 | 4  |
| 3 | 9  |
| 4 | 16 |
| 5 | 25 |
+---+----+
```

Raw fetch gives the Arrow IPC BLOB. `ducknng_parse_body` decodes it as a
table function.

``` sql
-- Re-open a fresh session to show the raw path.
CREATE TEMP TABLE tour_session2 AS
SELECT *
FROM ducknng_open_query(
  getvariable('tour_url'),
  'SELECT i, i * i AS sq FROM range(1, 6) AS t(i)',
  0::UBIGINT, 0::UBIGINT, getvariable('tour_tls')::UBIGINT
);
SET VARIABLE tour_raw_frame = ducknng_fetch_query_raw(
  getvariable('tour_url'),
  (SELECT session_id    FROM tour_session2)::UBIGINT,
  (SELECT session_token FROM tour_session2)::VARCHAR,
  0::UBIGINT, 0::UBIGINT, getvariable('tour_tls')::UBIGINT
);
-- Inspect envelope fields, then decode the Arrow payload.
SELECT ducknng_frame_type_name(getvariable('tour_raw_frame')::BLOB) AS type_name,
       ducknng_frame_end_of_stream(getvariable('tour_raw_frame')::BLOB) AS end_of_stream;
SELECT *
FROM ducknng_parse_body(
  ducknng_frame_payload(getvariable('tour_raw_frame')::BLOB),
  'application/vnd.apache.arrow.stream'
);


+-----------+---------------+
| type_name | end_of_stream |
+-----------+---------------+
| result    | false         |
+-----------+---------------+
+---+----+
| i | sq |
+---+----+
| 1 | 1  |
| 2 | 4  |
| 3 | 9  |
| 4 | 16 |
| 5 | 25 |
+---+----+
```

**SSE streaming route.** `ducknng_add_stream_route` registers a
chunked-streaming route. The SQL must return a `chunk` column; each
non-null row is written to the client as a separate HTTP chunk.
`ducknng_format_sse` formats a Server-Sent Events event string.

``` sql
SELECT ducknng_add_stream_route(
  'tour_http', 'GET', '/events',
  'SELECT ducknng_format_sse(''tick '' || i::VARCHAR) AS chunk
   FROM generate_series(1, 3) t(i)'
);
-- ncurl transparently reassembles the chunked body.
SELECT ok, status, body_text
FROM ducknng_ncurl('http://127.0.0.1:18440/events', 'GET', NULL, NULL, 2000, 0::UBIGINT);
+--------------------------------------+
| ducknng_add_stream_route('tour_http', 'GET', '/events', 'SELECT ducknng_format_sse(''tick '' || i::VARCHAR) AS chunk
   FROM generate_series(1, 3) t(i)') |
+--------------------------------------+
| true                                 |
+--------------------------------------+
+------+--------+-----------+
|  ok  | status | body_text |
+------+--------+-----------+
| true | 200    | data: tick 1

data: tick 2

data: tick 3

          |
+------+--------+-----------+
```

Explicit cleanup — everything that was opened must be explicitly
stopped, closed, or dropped.

``` sql
SELECT ducknng_aio_drop(aio1) AND ducknng_aio_drop(aio2) AS aios_dropped FROM tour_aios;
DROP TABLE tour_aios;
DROP TABLE tour_session;
DROP TABLE tour_session2;
SELECT (ducknng_close_socket(getvariable('req_id')::UBIGINT)).ok AS socket_closed;
SELECT ducknng_stop_server('tour_http');
SELECT ducknng_stop_server('tour');
SELECT ducknng_drop_tls_config(getvariable('tour_tls')::UBIGINT);
+--------------+
| aios_dropped |
+--------------+
| true         |
+--------------+



+---------------+
| socket_closed |
+---------------+
| true          |
+---------------+
+----------------------------------+
| ducknng_stop_server('tour_http') |
+----------------------------------+
| true                             |
+----------------------------------+
+-----------------------------+
| ducknng_stop_server('tour') |
+-----------------------------+
| true                        |
+-----------------------------+
+---------------------------------------------------------------------+
| ducknng_drop_tls_config(CAST(getvariable('tour_tls') AS "UBIGINT")) |
+---------------------------------------------------------------------+
| true                                                                |
+---------------------------------------------------------------------+
```
