### PR TITLE
cozip v1.1.0: bump ref to lazy ParquetReader reader

### DIFF
--- a/extensions/cozip/description.yml
+++ b/extensions/cozip/description.yml
@@ -1,24 +1,31 @@
 extension:
   name: cozip
   description: Cloud-Optimized ZIP reader for DuckDB
-  version: 1.0.0
+  version: 1.1.0
   language: C++
   build: cmake
   license: MIT
   maintainers:
     - csaybar
+    - ryali93
 repo:
   github: asterisk-labs/cozip_reader
-  ref: afd930e59f33ba43ef23db8e8fec5a30ece451e9
+  ref: 3c7021429f6460e2feebced7c61982a863cce1d0
 docs:
   hello_world: |
+    INSTALL cozip FROM community;
     LOAD cozip;
 
     SELECT *
     FROM read_cozip('https://huggingface.co/datasets/Major-TOM/Core-VIIRS-Nighttime-Light/resolve/main/2024/MAJORTOM-VIIRS-NTL_2024_median_000.zip')
     LIMIT 10;
   extended_description: |
-    cozip replaces the Central Directory scan with a Parquet metadata file,
-    locatable through a compact binary index at byte 0 of the archive.
-    read_cozip(path) reads that Parquet directly. Works on local files and
-    remote URLs (HTTPS, S3, HuggingFace), on native and WebAssembly.
+    cozip replaces the ZIP Central Directory scan with a Parquet metadata
+    file located through a fixed 51-byte header at byte 0 of the archive.
+    read_cozip(path) reads that Parquet directly through a virtual
+    cozip-subfile filesystem, so range requests flow lazily through the
+    underlying transport. Works on local files and remote URLs (HTTPS, S3,
+    GCS, Azure, HuggingFace), on native and WebAssembly. Every row gets
+    an extra cozip:gdal_vsi column with a /vsisubfile/ path that opens
+    the referenced inner file in GDAL or rasterio without re-downloading
+    the archive.


### PR DESCRIPTION
Summary of changes in 1.1.0:

- `read_cozip(path)` parses the cozip index at byte 0 of the archive,
  locates the `__metadata__` Parquet payload, and constructs a virtual
  path `cozip-subfile://<offset>_<size>!<underlying>`.
- A new `CozipSubFileSystem` is registered on extension Load. When
  `ParquetReader` opens the virtual path, range reads against the subfile
  are translated by adding `base_offset` and delegated to the underlying
  transport. Works over local files, https, s3, gcs, abfss, hf://.
- No temp files are written. Reads remain lazy: only the Parquet footer
  and the projected row groups are fetched.
