### PR TITLE
Update dplyr extension to v0.4.0

### DIFF
--- a/extensions/dplyr/description.yml
+++ b/extensions/dplyr/description.yml
@@ -8,7 +8,7 @@
 extension:
   name: dplyr
   description: R dplyr pipeline syntax support for DuckDB - transpiles dplyr verbs to SQL
-  version: 0.3.3
+  version: 0.4.0
   language: Rust & C++
   build: cmake
   license: MIT
@@ -19,7 +19,7 @@ extension:
 
 repo:
   github: mrchypark/libdplyr
-  ref: a0ce561ced49c3da1187b02bc4d9be1b1e5913ae
+  ref: 405e38282970f5079f925549d2f574060c10313a
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary
- Update the dplyr community extension descriptor from 0.3.3 to 0.4.0.
- Point repo.ref at the commit behind the published v0.4.0 tag: 405e38282970f5079f925549d2f574060c10313a.
- Supersedes the older conflicting dplyr update PR #1199.

## Ref choice
Most community extension descriptors pin repo.ref to a 40-character commit SHA. Tags are valid Git refs and a small number of descriptors use version tags, but dplyr has historically used commit SHAs and the DuckDB update guide examples also use SHAs. This PR therefore pins the exact commit that v0.4.0 resolves to.

## Validation
- Checked descriptor patterns in duckdb/community-extensions: 228 of 242 repo.ref values are 40-character commit SHAs; 14 use tag-like refs.
- Verified mrchypark/libdplyr tag v0.4.0 resolves to commit 405e38282970f5079f925549d2f574060c10313a.
- Parsed extensions/dplyr/description.yml with Ruby YAML.
- Ran scripts/build.py for extensions/dplyr/description.yml in a temporary PyYAML venv and confirmed COMMUNITY_EXTENSION_REF=405e38282970f5079f925549d2f574060c10313a.
- Ran git diff --check.