### PR TITLE
Bump boilstream to v0.6.0

### DIFF
--- a/extensions/boilstream/description.yml
+++ b/extensions/boilstream/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: boilstream
   description: Secure remote secrets storage with OPAQUE PAKE authentication, email/password registration, MFA login, and automatic ducklake mounting
-  version: 0.5.0
+  version: 0.6.0
   language: C++, Rust
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: dforsber/boilstream-extension
-  ref: 45b114434ec04ffcfc2a3b0231dd9895d08336f0
+  ref: aa476340393b05713326ff0c1f7779efc70dba34
 
 docs:
   hello_world: |
@@ -61,6 +61,18 @@ docs:
     -- Query ducklake (automatically attached)
     USE my_analytics;
     SHOW TABLES;
+
+    -- Create persistent secret onto BoilStream server
+    CREATE PERSISTENT SECRET s3_minio IN boilstream (
+        TYPE S3,
+        KEY_ID 'minioadmin',
+        SECRET 'minioadmin',
+        REGION 'eu-west-1',
+        ENDPOINT 'localhost:9000',
+        USE_SSL false,
+        URL_STYLE 'path',
+        SCOPE 's3://ingestion-data/'
+    );
 
   extended_description: |
     Boilstream extension provides enterprise-grade remote secrets storage for multi-tenant DuckDB deployments.

--- a/extensions/boilstream/description.yml
+++ b/extensions/boilstream/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: dforsber/boilstream-extension
-  ref: aa476340393b05713326ff0c1f7779efc70dba34
+  ref: bd3c28def8d92921728729f499471cd165b90dc4
 
 docs:
   hello_world: |


### PR DESCRIPTION
## [0.6.0] - 2026-05-14

### Added

- **Quack remote-protocol bridge** (`src/quack_bridge.{cpp,hpp}`) — implements the scalar functions DuckDB Quack's `quack_authentication_function` / `quack_authorization_function` GLOBAL settings dispatch to:
  - `boilstream_quack_authn(token)` — HS256 JWT verifier registered via `boilstream_quack_set_jwt_verifier`; populates the bridge SessionMap on success.
  - `boilstream_quack_authz(session_id, kind, statement)` — read-only gate (allows `SELECT` / `EXPLAIN` / `PRAGMA`, rejects DDL/DML).
  - `boilstream_quack_bind_session(session_id, tenant_id, …)` — SessionMap upsert used by the auth path.
  - `boilstream_quack_session_init(session_id, void* client_context)` — `extern "C"` hook handler `dlsym`-registered with patched Quack via `quack_set_session_init_hook`. Stamps per-tenant context onto each new Quack `Connection` before its first query. On vanilla DuckDB / stock Quack the fork symbols aren't present and the bridge degrades silently — community-extension compatibility preserved.
- **`LookupQuackSecret` auto-vend** in `boilstream_secret_storage.cpp`: on first ATTACH against a `quack:` URI with no `TYPE quack` secret in cache, fetches one through the existing /secrets bootstrap path.
- **Tests**: `test/cpp/test_quack_attach_red.cpp` wired into CTest as `QuackAttachRedTests`; SQL tests `test/sql/quack_*.test`.
- **`BOILSTREAM_INSECURE_TLS=1`** local-dev knob: skips certificate verification when set (intended only for `localhost` self-signed cert setups).

### Fixed

- **`CREATE SECRET (TYPE quack)` without `bootstrap_session`**: `RestApiSecretStorage::StoreSecret` previously threw `"No active boilstream session"` when no `conn_state` was attached to the calling transaction, blocking the legitimate workflow of `CREATE SECRET (TYPE quack, TOKEN ..., SCOPE 'quack:host')` from a DuckDB CLI session that never called `PRAGMA boilstream_bootstrap_session`. The path now falls back to in-process storage only (skips REST persist) — mirrors DuckDB's `TEMPORARY` secret semantics.
- **Auto-vend no longer clobbers user-supplied quack secrets**: refactored the `__quack__<path>` cache-key short-circuit into a named helper `is_auto_vended_name(...)` that makes the convention explicit. A scope-matching `TYPE quack` secret whose name doesn't follow the auto-vend convention is treated as user-supplied and returned as-is, never replaced by the server-vended JWT.

### Diagnostics

- **`BOILSTREAM_WARN` for silent catches in AllSecrets memory cache**: surfaces production-critical failure paths inside `FetchAllSecretsFromServer` that were previously hidden behind `BOILSTREAM_LOG` (no-op without `-DBOILSTREAM_DEBUG`).

### Build

- Bumped distribution pipeline to DuckDB / extension-ci-tools v1.5.2 (matches the bundled submodule).