### PR TITLE
Bump boilstream to v0.6.1

### DIFF
--- a/extensions/boilstream/description.yml
+++ b/extensions/boilstream/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: boilstream
   description: Secure remote secrets storage with OPAQUE PAKE authentication, email/password registration, MFA login, and automatic ducklake mounting
-  version: 0.6.0
+  version: 0.6.1
   language: C++, Rust
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: dforsber/boilstream-extension
-  ref: bd3c28def8d92921728729f499471cd165b90dc4
+  ref: 8bb35073af2420e1d78e2c8448f4879ba61e861a
 
 docs:
   hello_world: |


### PR DESCRIPTION
## [0.6.1] - 2026-05-14

### Added

- **Quack pre-execute SQL-rewriter hook** — new bridge surface for host-registered query-time rewriting:
  - `boilstream_quack_set_sql_rewriter(fn)` — setter (atomic slot, release-store at boot, acquire-load on the hot path; same lifecycle as the JWT verifier slot).
  - `boilstream_quack_pre_execute(session_id, sql_in, sql_out_buf, ...)` — `extern "C"` hook handler. Patched Quack calls this between authz and SendQuery; the handler routes through to the host-registered Rust rewriter. Caller owns the output buffer — no allocation crosses the C/Rust boundary.
  - Registered with patched Quack via `boilstream_lookup_runtime_symbol("quack_set_pre_execute_hook")`, re-using the portable POSIX / Windows shim introduced in v0.6.0. On vanilla DuckDB / stock Quack the symbol isn't present and the bridge degrades silently — community-extension compatibility preserved.

### Style

- `make format-fix` pass across 12 files — fixes the `Code Quality / Format Check` that was the only red mark on the v0.6.0 distribution pipeline. Clang-format / cmake-format / sqllogic-test trailing-whitespace normalisation; no semantic changes.