### PR TITLE
Update DICOM extension to v0.2.0

### DIFF
--- a/extensions/dicom/description.yml
+++ b/extensions/dicom/description.yml
@@ -3,7 +3,7 @@ extension:
   description: |
     DuckDB integration with medical imaging data (DICOM - Digital Imaging and Communication in
     Medicine).
-  version: 0.1.0
+  version: 0.2.0
   language: C++
   build: cmake
   excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads"
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: nmontesg/duck-dicom
-  ref: 91524cf0a885e7f5f236490b0eea02e5d46fa978
+  ref: v0.2.0
 
 docs:
   hello_world: |
@@ -48,3 +48,21 @@ docs:
         any_value(dicom_content->'00081030'->'Value') AS study_description
     FROM read_dicom('/Users/nmontes/Downloads/slicer_export/**/*.dcm')
     GROUP BY 1;
+
+    This extension also supports reading from remote object storage using the httpfs extension:
+
+    LOAD httpfs;
+
+    CREATE OR REPLACE SECRET my_secret (
+        TYPE s3,
+        PROVIDER config,
+        KEY_ID 'my_key',
+        SECRET 'my_secret_key',
+        URL_STYLE 'path'
+    );
+
+    -- read one file from an AWS S3 bucket
+    FROM read_dicom('s3://my-bucket/path/to/dicom_file.dcm');
+
+    -- use glob pattern
+    FROM read_dicom('s3://my-bucket/path/to/dicoms/**/*.dcm');


### PR DESCRIPTION
This update brings the following changes to the DICOM extension:

- The extension is now built for DuckDB 1.5.2
- Add support for reading DICOM files from remote storage through the `httpfs` extension