### PR TITLE
bump mongo extension to 0.2.2

### DIFF
--- a/extensions/mongo/description.yml
+++ b/extensions/mongo/description.yml
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: stephaniewang526/duckdb-mongo
-  ref: 0273da8d8daf6b6e42050914ec01b389c5725a61
+  ref: ea700533da25ff9430e9e91ead5967f125de1082
 
 docs:
   hello_world: |

--- a/extensions/mongo/description.yml
+++ b/extensions/mongo/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: mongo
   description: Integrates DuckDB with MongoDB, enabling direct SQL queries over MongoDB collections without exporting data or ETL
-  version: 0.2.1
+  version: 0.2.2
   language: C++
   build: cmake
   license: MIT
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: stephaniewang526/duckdb-mongo
-  ref: 3bcdfeb85a3922c0b00dd54bf26f388c8d12669d
+  ref: 0273da8d8daf6b6e42050914ec01b389c5725a61
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps the `mongo` extension from `0.2.1` to `0.2.2`.
- Fix case-insensitive duplicate column name deduplication during schema inference ([#35](https://github.com/stephaniewang526/duckdb-mongo/issues/35))
- Fix DuckDB main compat: renamed filter types and removed `TableFilter::Copy()` ([PR #36](https://github.com/stephaniewang526/duckdb-mongo/pull/36))
- Allow `mongo_scan` to accept a secret name as the connection argument, enabling SRV and Atlas connections without embedding credentials ([#37](https://github.com/stephaniewang526/duckdb-mongo/issues/37))