### PR TITLE
cozip v1.2.0: fix wasm memory corruption in read_cozip

### DIFF
--- a/extensions/cozip/description.yml
+++ b/extensions/cozip/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: cozip
   description: Cloud-Optimized ZIP reader for DuckDB
-  version: 1.1.0
+  version: 1.2.0
   language: C++
   build: cmake
   license: MIT

--- a/extensions/cozip/description.yml
+++ b/extensions/cozip/description.yml
@@ -10,7 +10,7 @@ extension:
     - ryali93
 repo:
   github: asterisk-labs/cozip_reader
-  ref: 3c7021429f6460e2feebced7c61982a863cce1d0
+  ref: 593d2853a294c33dc1c505c5d7c504159b332489
 docs:
   hello_world: |
     INSTALL cozip FROM community;


### PR DESCRIPTION
### Bumps `cozip` to `v1.2.0`.

Hi @carlopi! another follow-up PR here. Sorry for the churn 🫠.

It turns out the previous WASM build had a target-specific memory corruption bug that did not show up in the native test suite.

The root cause was that `read_cozip` called DuckDB’s `ParquetReader` directly from C++. That works in native builds, but in `wasm_eh` it pulled in Parquet-related template instantiations and constructors that are not exported by `duckdb-eh.wasm` to side modules. At runtime, some missing imports were resolved to zero-returning stubs, which led to null-pointer dereferences and leaked low linear-memory contents into query results.

My fix was to refactor `read_cozip` into a SQL table macro that wraps `read_parquet` over the existing `cozip-subfile://` VFS. This keeps all Parquet access on DuckDB’s standard SQL path, which is the path `duckdb-wasm` expects and supports.

I verified the new build against production `@duckdb/duckdb-wasm` in the browser. The macro registers correctly, the result schema matches native output, and the corrupted memory output is gone 🤞 

Thank you for all the great work!