### PR TITLE
Add harbor: multi-protocol HTTP service for DuckDB

### DIFF
--- a/extensions/harbor/description.yml
+++ b/extensions/harbor/description.yml
@@ -1,0 +1,80 @@
+extension:
+  name: harbor
+  description: Multi-protocol HTTP service (Quack RPC, JSON SQL, DuckDB UI, admin) for DuckDB on a single port
+  version: 0.1.0
+  language: C++
+  build: cmake
+  license: MIT
+  maintainers:
+    - shreeve
+
+repo:
+  github: shreeve/duckdb-harbor
+  ref: 181ad520b37cdb9ccd8a8ed855beaa5624a83df4
+
+docs:
+  hello_world: |
+    -- Load the extension and start the server in the background.
+    -- harbor_serve returns immediately; harbor_wait keeps the process
+    -- alive in daemon mode (containers, systemd).
+    LOAD harbor;
+    CALL harbor_serve('harbor:127.0.0.1:9494');
+    --                                                  ┌─────────────────────────────────┐
+    --                                                  │             token               │
+    --                                                  ├─────────────────────────────────┤
+    --                                                  │ a1b2c3d4e5f6...                 │
+    --                                                  └─────────────────────────────────┘
+
+    -- Hit it from another shell:
+    --   curl http://127.0.0.1:9494/health
+    --   curl -H "Authorization: Bearer <token>" \
+    --        -X POST http://127.0.0.1:9494/sql \
+    --        -H 'Content-Type: application/json' \
+    --        -d '{"sql":"SELECT 42 AS the_answer"}'
+    --
+    --   {"ok":true,"kind":"select","columns":[{"name":"the_answer","duckdbType":"INTEGER","lossless":true}],
+    --    "data":[[42]],"rowCount":1,"timeMs":0}
+
+    -- Browser users open http://127.0.0.1:9494/ — the harbor login
+    -- page asks for the token once, sets a HttpOnly SameSite=Strict
+    -- cookie, then proxies the official DuckDB UI through.
+
+    -- A second DuckDB process can attach via the Quack RPC protocol:
+    --   ATTACH 'quack:127.0.0.1:9494' AS h (SECRET <bearer-secret>);
+    --   SELECT * FROM h.main.t;
+
+    -- Stop the server:
+    CALL harbor_stop();
+
+  extended_description: |
+    `harbor` is a single DuckDB extension. When loaded, your DuckDB
+    instance turns into a multi-protocol HTTP service on one port:
+
+    | Surface     | Endpoints                              | What it gives you                                                         |
+    |-------------|----------------------------------------|---------------------------------------------------------------------------|
+    | Quack RPC   | `POST /quack`                          | Wire-compat with stock `duckdb-quack` clients (`ATTACH 'quack:host'`)     |
+    | JSON SQL    | `POST /sql`, `/sql/sessions/*`         | NDJSON streaming + one-shot JSON, prepared params (incl. `LIST`/`STRUCT`/`MAP`), principal-owned sessions, `harbor_query_timeout_s` enforcement |
+    | DuckDB UI   | `GET /`, `/ddb/*`, `/localEvents`      | Cookie-gated proxy to the official DuckDB UI; CSP+nonce on the login page |
+    | Admin       | `/health`, `/whoami`, `/tables`, `/schema/:db/:t`, `/checkpoint`, `/sessions`, `/interrupt` | Centralized `__HARBOR_ADMIN__:resource:action` default-deny + `harbor_allow_admin_without_authz` operator opt-in |
+    | Auth        | `/auth/login`, `/auth/logout`          | Bearer / X-Harbor-Token / HMAC-signed `harbor_session` cookie             |
+
+    All on the same port, against the same in-process DuckDB, with the
+    same session pool and auth model.
+
+    **Use cases:**
+    - Operate one DuckDB process and let users hit it via whatever interface
+      fits their tool: notebook (UI), REPL (Quack), backend code (`/sql`).
+    - Bridge between SQL clients and apps without standing up a separate
+      database server.
+    - Container-native deployments — `harbor_wait()` blocks until SIGTERM
+      so harbor runs cleanly under systemd / Docker / Kubernetes.
+
+    **Status:** v0.1 release, tested across all 9 DuckDB CI platforms
+    (linux_amd64/arm64, osx_amd64/arm64, windows_amd64/_mingw,
+    wasm_mvp/eh/threads). 198 test assertions across 6 suites.
+
+    Source, design spec, contributor guide, full release notes:
+    [github.com/shreeve/duckdb-harbor](https://github.com/shreeve/duckdb-harbor).
+
+    Tracks upstream `duckdb-quack` `v1.5-variegata` and `duckdb-ui`;
+    targets DuckDB v1.5.2.


### PR DESCRIPTION
## Summary

Adds [`harbor`](https://github.com/shreeve/duckdb-harbor) — a DuckDB extension that turns one DuckDB process into a multi-protocol HTTP service on one port.

| Surface | Endpoints | What it gives users |
|---|---|---|
| **Quack RPC** | `POST /quack` | Wire-compat with stock `duckdb-quack` clients (`ATTACH 'quack:host'` works against harbor) |
| **JSON SQL** | `POST /sql`, `/sql/sessions/*`, `/sql/cancel` | NDJSON streaming + one-shot JSON, prepared params (incl. `LIST<T>`/`ARRAY<T,N>`/`MAP<K,V>`/`STRUCT(...)`), principal-owned sessions, `harbor_query_timeout_s` enforcement |
| **DuckDB UI** | `GET /`, `/ddb/*`, `/localEvents`, `/localToken` | Cookie-gated proxy to the official DuckDB UI; CSP+nonce on the login page; UI proxy strips harbor credentials before forwarding upstream |
| **Admin** | `/health`, `/ready`, `/whoami`, `/info`, `/tables`, `/schema/:db/:t`, `/checkpoint`, `/sessions`, `/interrupt`, `/sql/cancel` | Centralized `__HARBOR_ADMIN__:resource:action` default-deny + `harbor_allow_admin_without_authz` operator opt-in |
| **Auth** | `/auth/login`, `/auth/logout` | Bearer / X-Harbor-Token / HMAC-signed `harbor_session` cookie. Non-Bearer `Authorization` returns `UNSUPPORTED_AUTH_SCHEME` (no fallback to ambient cookie) |

All four surfaces share the same in-process DuckDB instance, the same session pool, and the same auth model.

## Use cases

- Operate one DuckDB process and let users hit it via whichever interface fits their tool — notebook (UI), REPL (Quack), backend code (`/sql`).
- Bridge between SQL clients and apps without standing up a separate database server.
- Container-native deployments — `harbor_wait()` blocks until SIGTERM so harbor runs cleanly under systemd / Docker / Kubernetes.

## Verification

Tested across **all 9 DuckDB CI platforms** (`linux_amd64`, `linux_arm64`, `osx_amd64`, `osx_arm64`, `windows_amd64`, `windows_amd64_mingw`, `wasm_mvp`, `wasm_eh`, `wasm_threads`) at the [`v0.1.0` tag](https://github.com/shreeve/duckdb-harbor/releases/tag/v0.1.0). The repo's [own `MainDistributionPipeline.yml`](https://github.com/shreeve/duckdb-harbor/blob/main/.github/workflows/MainDistributionPipeline.yml) uses the same `_extension_distribution.yml@v1.5-variegata` reusable workflow this repo runs.

**198 test assertions across 6 test suites** at v0.1.0:

| Suite | Assertions |
|---|---|
| `test/sql/harbor.test` (sqllogictest) | 45 |
| `golden-cookie-auth.sh` (HTTP cookie + CORS + UI proxy) | 18 |
| `golden-sql-roundtrip.sh` (`/sql` NDJSON + sessions + nested-type params) | 32 |
| `golden-admin-roundtrip.sh` (admin endpoints + default-deny matrix) | 31 |
| `golden-query-timeout.sh` (`harbor_query_timeout_s` enforcement) | 10 |
| `golden-sql-types.sh` (per-DuckDB-type `/sql` encoding) | 62 |

## Upstream provenance

Vendors source from `duckdb/duckdb-quack` (`v1.5-variegata`) and `duckdb/duckdb-ui`. Every modification harbor makes to vendored upstream code is documented in the repo's [`docs/upstream-quack-patches.md`](https://github.com/shreeve/duckdb-harbor/blob/main/docs/upstream-quack-patches.md) and [`docs/upstream-ui-patches.md`](https://github.com/shreeve/duckdb-harbor/blob/main/docs/upstream-ui-patches.md). Targets DuckDB **v1.5.2**.

## Documentation

- [`README.md`](https://github.com/shreeve/duckdb-harbor/blob/main/README.md) — user introduction
- [`SPEC.md`](https://github.com/shreeve/duckdb-harbor/blob/main/SPEC.md) — authoritative design
- [`AGENTS.md`](https://github.com/shreeve/duckdb-harbor/blob/main/AGENTS.md) — contributor map
- [`CHANGELOG.md`](https://github.com/shreeve/duckdb-harbor/blob/main/CHANGELOG.md) — release notes (v0.1.0)

## License

MIT, dual copyright (DuckDB Foundation + harbor authors). Vendored `duckdb-quack` and `duckdb-ui` source under their respective MIT licenses.

## Descriptor

```yaml
extension:
  name: harbor
  description: Multi-protocol HTTP service (Quack RPC, JSON SQL, DuckDB UI, admin) for DuckDB on a single port
  version: 0.1.0
  language: C++
  build: cmake
  license: MIT
  maintainers:
    - shreeve

repo:
  github: shreeve/duckdb-harbor
  ref: 181ad520b37cdb9ccd8a8ed855beaa5624a83df4
```

Pinned to v0.1.0 commit `181ad520`.