### PR TITLE
Bump ducksmiles to 0.3.0 (morgan_fp_bits)

### DIFF
--- a/extensions/ducksmiles/description.yml
+++ b/extensions/ducksmiles/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: ducksmiles
-  description: Cheminformatics toolkit for DuckDB - SMILES, InChI, MOL/SDF, PDB, SELFIES, and Wildman-Crippen LogP from SQL
-  version: 0.2.0
+  description: Cheminformatics toolkit for DuckDB - SMILES, InChI, MOL/SDF, PDB, SELFIES, Wildman-Crippen LogP, and Morgan/ECFP fingerprints from SQL
+  version: 0.3.0
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: nkwork9999/duckSMILES
-  ref: b34ffe7a20aeac2cc0c46debb3ab7179fdc726fc
+  ref: 85dfe3cae4ba15e9e59887a0c8d0ba16201d919e
 
 docs:
   hello_world: |
@@ -32,6 +32,16 @@ docs:
 
     -- Expand implicit hydrogens to explicit [H] atoms in SMILES
     SELECT add_hydrogens('CCO');         -- [C]([C]([O][H])([H])[H])([H])([H])[H]
+
+    -- Morgan/ECFP fingerprint as a 2048-bit BLOB (ECFP4 default)
+    SELECT bit_count(CAST(morgan_fp_bits('CC(=O)Oc1ccccc1C(=O)O') AS BIT));  -- 26 (aspirin)
+
+    -- Tanimoto similarity between two SMILES (CAST BLOB to BIT to use bitwise ops)
+    WITH x AS (
+      SELECT CAST(morgan_fp_bits('CCO') AS BIT) AS a,
+             CAST(morgan_fp_bits('CCN') AS BIT) AS b
+    )
+    SELECT bit_count(a & b)::DOUBLE / bit_count(a | b) AS tanimoto FROM x;  -- 0.3333
 
     -- InChI layer extraction
     SELECT inchi_formula('InChI=1S/C2H4O2/c1-2(3)4/h1H3,(H,3,4)');  -- C2H4O2
@@ -55,7 +65,7 @@ docs:
     - PDB/CIF/XYZ: Protein structure analysis (atom, chain, residue, model counts)
     - SELFIES: Bidirectional SMILES-SELFIES conversion for ML pipelines
 
-    **37 scalar SQL functions** for molecular property extraction, format conversion,
+    **38 scalar SQL functions** for molecular property extraction, format conversion,
     structural comparison, and physicochemical property prediction. Ideal for
     cheminformatics datasets, drug discovery pipelines, and molecular ML feature
     engineering.
@@ -69,5 +79,12 @@ docs:
     through the parser). Useful as a preprocessing primitive for any descriptor
     that needs explicit hydrogens, and composes safely with `logp_crippen` (the
     internal H expansion is idempotent).
+
+    **Morgan / ECFP fingerprint:** `morgan_fp_bits()` ports RDKit's MorganGenerator
+    (layered BFS + hash_combine + dead-atom dedup) to Rust and returns a fixed-width
+    bit vector as `BLOB`. Defaults to ECFP4 (radius=2, 2048 bit); 3-arg overload
+    `morgan_fp_bits(smi, radius, n_bits)` exposes full control. Combine with
+    `CAST(... AS BIT)` for SQL-level Tanimoto similarity:
+    `bit_count(a & b)::DOUBLE / bit_count(a | b)`.
 
     **Architecture:** Rust (core logic, 5 crates) + C++ (DuckDB integration via FFI)


### PR DESCRIPTION
Adds [`morgan_fp_bits()`](https://github.com/nkwork9999/duckSMILES/blob/main/crates/smiles/src/morgan.rs) — Morgan / ECFP fingerprint as a fixed-width `BLOB`.

## Changes

- Bump version `0.2.0` → `0.3.0`
- Update ref to [`85dfe3c`](https://github.com/nkwork9999/duckSMILES/commit/85dfe3cae4ba15e9e59887a0c8d0ba16201d919e)
- Function count `37` → `38`
- Add `hello_world` examples (popcount + Tanimoto via `CAST AS BIT`)
- Document Morgan/ECFP in `extended_description`

## API

```sql
-- ECFP4 default (radius=2, 2048 bit) → 256-byte BLOB
SELECT morgan_fp_bits('CCO');

-- Custom radius / width
SELECT morgan_fp_bits('CC(=O)Oc1ccccc1C(=O)O', 3, 4096);  -- ECFP6 / 4096 bit

-- popcount (BLOB has no native bit_count, cast to BIT)
SELECT bit_count(CAST(morgan_fp_bits('CCO') AS BIT));  -- 6

-- Tanimoto similarity via BIT operators
WITH x AS (
  SELECT CAST(morgan_fp_bits('CCO') AS BIT) AS a,
         CAST(morgan_fp_bits('CCN') AS BIT) AS b
)
SELECT bit_count(a & b)::DOUBLE / bit_count(a | b) FROM x;  -- 0.3333
```

## Implementation notes

Port of RDKit's `MorganGenerator.cpp` (layered BFS + `hash_combine` + dead-atom dedup). Uses an independent hash function so bits are **not** bit-exact with RDKit, but the algorithm structure is preserved; downstream Tanimoto rankings should be comparable. Verified end-to-end via DuckDB shell against the Rust unit test popcounts.