### PR TITLE
Bump duckorch to 0.2.0 (Asset + Sensor + Dynamic + MCP)

### DIFF
--- a/extensions/duckorch/description.yml
+++ b/extensions/duckorch/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: nkwork9999/duck-orch
-  ref: 8964580866a3a06ddca7f5c20cc6ef1c45f87a8d
+  ref: 89645807397b8f33c10ab0d0c347cb989c1598bd
 
 docs:
   hello_world: |

--- a/extensions/duckorch/description.yml
+++ b/extensions/duckorch/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duckorch
-  description: DAG orchestration with side-product lineage for DuckDB - SQL-file tasks, parallel execution, Mermaid graphs, OpenLineage emission
-  version: 0.1.0
+  description: Asset-centric data orchestration with partitions, declarative automation sensor, Snowflake-compatible CREATE DYNAMIC ASSET, MCP server, lineage and OpenLineage emission — all on DuckDB
+  version: 0.2.0
   language: C++
   build: cmake
   license: MIT
@@ -10,75 +10,105 @@ extension:
 
 repo:
   github: nkwork9999/duck-orch
-  ref: 00b8fc4ab5d8cbbd9c683359102907fff92af325
+  ref: 8964580866a3a06ddca7f5c20cc6ef1c45f87a8d
 
 docs:
   hello_world: |
     LOAD duckorch;
 
-    -- Set up state schema
+    -- 1. Set up state schema and register a directory of *.sql task files.
     PRAGMA orch_init;
+    PRAGMA orch_register('./tasks/');
 
-    -- Register a task directly (in real use, prefer .sql files via PRAGMA orch_register('./tasks/'))
-    INSERT INTO __orch__.tasks (name, sql, inputs, outputs, retries) VALUES
-      ('clean_users',
-       'CREATE OR REPLACE TABLE clean_users AS SELECT id FROM raw_users WHERE deleted_at IS NULL',
-       ['raw_users']::VARCHAR[],
-       ['clean_users']::VARCHAR[],
-       0);
-
-    -- Run the DAG (topological order, parallel within each layer)
+    -- 2. Run the DAG (topological order, per-layer parallelism).
     SET orch_max_parallel = 4;
     PRAGMA orch_run;
 
-    -- Inspect run history
-    SELECT task_name, status, retry_count FROM __orch__.runs ORDER BY started_at;
+    -- 3. Asset-aware features (Phase 13+):
+    PRAGMA orch_asset_list;                            -- all registered Assets
+    PRAGMA orch_asset_partitions('analytics.daily');   -- per-partition status
+    PRAGMA orch_backfill('analytics.daily', '2026-01-01', '2026-12-31');
 
-    -- Get a Mermaid lineage graph
+    -- 4. Snowflake-compatible declaration (Phase 17):
+    PRAGMA orch_create_dynamic_asset(
+      'analytics.region_total',
+      '5 minutes',
+      'SELECT region, SUM(total) AS rt FROM analytics.daily GROUP BY region');
+
+    -- 5. Sensor — auto-materializes when upstream updates (Phase 15):
+    PRAGMA orch_sensor_set_interval(30);
+    PRAGMA orch_sensor_start;
+
+    -- 6. Mermaid lineage:
     PRAGMA orch_visualize('lineage');
 
-    -- Pure helpers (auto-extract I/O from a SQL string)
-    SELECT orch_extract_io('INSERT INTO out SELECT * FROM a JOIN b ON a.id = b.id');
-    -- {"inputs":["a","b"],"outputs":["out"]}
-
   extended_description: |
-    duckorch is a DuckDB extension for **DAG-based task orchestration**, with
-    table-level lineage emerging as a side product of each task's declared
-    inputs and outputs.
+    duckorch is a **DuckDB-native, single-file Asset orchestrator** that
+    brings Dagster's declarative automation and Snowflake's
+    `CREATE DYNAMIC TABLE` semantics into a `LOAD duckorch;`. Designed to
+    run on a laptop or in a plane without a cloud control plane.
 
     **Task definition (SQLMesh-style headers in plain .sql files):**
 
-        -- @task name=user_stats
-        -- @outputs analytics.user_stats
-        -- @retries 2
-        -- @incremental_by updated_at
-        -- @test "SELECT COUNT(*) FROM analytics.user_stats WHERE users < 0" expect 0
+        -- @asset name=analytics.user_stats
+        -- @asset_group sales
+        -- @partitions_by daily(start=2026-01-01)
+        -- @param partition_key:DATE
+        -- @automation eager AND NOT in_progress()
+        -- @freshness max_lag=60min
+        -- @check name=positive "SELECT MIN(rev) FROM ${asset}" expect gt 0
 
         CREATE OR REPLACE TABLE analytics.user_stats AS
-        SELECT country, COUNT(*) AS users
+        SELECT country, SUM(rev) AS rev
         FROM analytics.clean_users
+        WHERE event_date = $partition_key
         GROUP BY country;
 
-    Inputs are auto-extracted from the SQL via `sqlparser-rs`, so writing
-    `@inputs` is optional in most cases.
+    Inputs auto-extracted via `sqlparser-rs`. `$partition_key` bound via
+    DuckDB `PREPARE` (multi-statement aware).
 
     **Capabilities:**
-    - Directory-loaded task files (`PRAGMA orch_register('./tasks/')`)
-    - Topological execution with per-layer parallelism (`SET orch_max_parallel`)
-    - Exponential backoff retry, downstream skip on failure
-    - Incremental processing with `{{ last_processed_at }}` / `{{ now }}` / `{{ run_id }}` placeholders
-    - Per-task assertions via `@test "<sql>" expect|expect_gt|expect_lt|expect_empty|expect_non_empty <n>`
-    - Mermaid output (lineage / dag / combined modes) — `PRAGMA orch_visualize`
-    - OpenLineage event emission to Marquez / DataHub / etc.
-      (`SET orch_openlineage_url`)
-    - State tables: `__orch__.tasks` / `runs` / `lineage_edges` / `task_edges`
-      `tests` / `schedules`
+    - **Tasks + DAG** (Phase 0-9): directory-loaded SQL files, topological
+      execution, per-layer parallelism, exponential backoff retry, downstream
+      skip, `@test`, Mermaid (`lineage` / `dag` / `combined`), OpenLineage
+      events, table- and column-level lineage with subtype taxonomy, opt-in
+      ad-hoc query capture, DuckLake-aware OL namespace.
+    - **MCP server** (Phase 11): `duck-orch-mcp` stdio server (rmcp 0.3)
+      with 9 tools for Claude Code integration (`list_assets`, `run_pipeline`
+      with `dry_run` default, etc.).
+    - **Asset** (Phase 13): `@asset` headers promote outputs to first-class
+      Assets in `__orch__.assets` with materialization history, code_version
+      hash, declared edges. Backward compatible with `@outputs`.
+    - **Partition** (Phase 14): `@partitions_by daily/static/multi`,
+      `$partition_key` bind, `orch_backfill`, calendar-style ✅⚪ ASCII view.
+    - **AutomationCondition + Sensor** (Phase 15): DSL
+      (`eager / on_cron / on_missing / freshness_violated / in_progress`
+      + `&` / `|` / `!`), `@target_lag` throttle, background `std::thread`
+      sensor that polls and auto-fires `RunSingleTask` when conditions met.
+    - **Freshness + Asset Check** (Phase 16): `@freshness max_lag=...`,
+      `@check name=N "<SQL>" expect <op> <value>` with auto-run on success
+      and `severity=error` blocking downstream.
+    - **Snowflake `CREATE DYNAMIC ASSET`** (Phase 17): `PRAGMA
+      orch_create_dynamic_asset(name, target_lag, sql)` synthesizes Asset +
+      `automation_condition='eager()'` so the sensor picks it up. The
+      `duck-orch dynamic migrate-from-snowflake <dump>` CLI parses Snowflake
+      dumps and registers each block (skipping `WAREHOUSE`/`REFRESH_MODE`).
 
-    **Companion CLI:** `duck-orch` provides `register / run / status / graph /
-    test / validate / impact / lineage / schedule` subcommands, all with
-    `--json` for agent integration.
+    **3-route surface**: every feature reachable from CLI (`duck-orch ...`),
+    SQL (`PRAGMA orch_*`), and MCP (Claude Code).
 
-    **Architecture:** thin C++ shim plus a Rust workspace
+    **Companion CLI:** `duck-orch` with `register / run / status / graph /
+    test / validate / impact / lineage / schedule / asset / backfill /
+    automation / sensor / check / dynamic` subcommands, all `--json`-capable.
+
+    **State tables:** `__orch__.{tasks, runs, lineage_edges, column_lineage,
+    task_edges, tests, schedules, assets, asset_materializations,
+    asset_edges, asset_partitions, automation_evaluations, asset_checks,
+    asset_check_results}`.
+
+    **Architecture:** thin C++ shim (~3000 lines, registers PRAGMAs, runs
+    SQL via per-thread Connection, hosts the sensor thread, exposes
+    OptimizerExtension for ad-hoc capture) plus a Rust workspace
     (orch_common / orch_dag / orch_lineage / orch_runtime / orch_ol /
-    orch_core), keeping all logic in Rust while the C++ layer handles
-    DuckDB-internal calls (PRAGMAs, scalar functions, parallel dispatch).
+    orch_core / orch_cli / orch_mcp), keeping all logic in Rust while the
+    C++ layer handles DuckDB-internal calls.


### PR DESCRIPTION
## Summary

Bumps `duckorch` from **0.1.0 → 0.2.0**. This release adds the Phase 11-17 surface laid out in `ROADMAP.md`:

- **Phase 11 — MCP server**: `duck-orch-mcp` stdio server (rmcp 0.3) with 9 tools for Claude Code integration. Read-only tools are always safe; write tools (`run_pipeline`, `register_task`, `unregister_task`, `schedule_add`) default to safe modes (`dry_run=true`, `confirm=true`, path-required).
- **Phase 12 — `$param` binding**: DuckDB-native named parameter binding (`PREPARE` + multi-statement aware) replaces Jinja-style `{{ }}` for new variable plumbing.
- **Phase 13 — Asset as first-class entity**: `@asset` headers promote outputs to first-class Assets. New tables `__orch__.{assets, asset_materializations, asset_edges}` + `code_version` (FNV-1a) + auto-population from `@asset` or `@outputs`.
- **Phase 14 — Partition**: `@partitions_by daily/static/multi`, `$partition_key` bind, `PRAGMA orch_backfill`, calendar-style ✅⚪ ASCII view, `duck-orch asset partitions/backfill`.
- **Phase 15 — AutomationCondition + sensor**: DSL (`eager / on_cron / on_missing / freshness_violated / in_progress` + `&` / `|` / `!`), `@target_lag` throttle, background `std::thread` sensor that polls and auto-fires `RunSingleTask` when conditions met.
- **Phase 16 — Freshness + Asset Check**: `@freshness max_lag=...`, `@check name=N \"<SQL>\" expect <op> <value>` with auto-run on success and `severity=error` blocking downstream.
- **Phase 17 — Snowflake `CREATE DYNAMIC ASSET`**: `PRAGMA orch_create_dynamic_asset(name, target_lag, sql)` + `duck-orch dynamic migrate-from-snowflake <dump>` parses Snowflake dumps and registers each block (skipping Snowflake-only options like `WAREHOUSE`/`REFRESH_MODE`).

Every feature is reachable from CLI (`duck-orch ...`), SQL (`PRAGMA orch_*`), and MCP (Claude Code).

ref: nkwork9999/duck-orch@8964580866a3a06ddca7f5c20cc6ef1c45f87a8d (community-extension branch).

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` all green (orch_common 54, orch_runtime 21+, orch_dag, orch_cli incl. 8 snowflake dump parser tests + asset check helpers + automation evaluator)
- [x] `make release -j8` produces `duckorch.duckdb_extension`
- [x] End-to-end smoke test from a fresh DuckDB file: register partitioned task → backfill 5 days → 5 ✅ partitions in calendar + 5 success materializations
- [x] Live sensor smoke: register downstream Asset with `@automation eager AND NOT in_progress()`, start sensor with 1s interval, backfill upstream → downstream auto-materializes within one tick
- [x] `duck-orch dynamic migrate-from-snowflake` parses a multi-block Snowflake dump and registers each as `automation_condition='eager()'` + `target_lag_seconds=<parsed>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)