### PR TITLE
Bump harbor to 0.1.2

### DIFF
--- a/extensions/harbor/description.yml
+++ b/extensions/harbor/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: harbor
   description: Multi-protocol HTTP service (Quack RPC, JSON SQL, DuckDB UI, admin) for DuckDB on a single port
-  version: 0.1.0
+  version: 0.1.2
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: shreeve/duckdb-harbor
-  ref: 181ad520b37cdb9ccd8a8ed855beaa5624a83df4
+  ref: adc4410e3b4122a18ff8b91af76c6b3be17e47ad
 
 docs:
   hello_world: |


### PR DESCRIPTION
> **Updated 2026-05-19**: bumps harbor directly from v0.1.0 → v0.1.2 (instead of the original v0.1.0 → v0.1.1) since v0.1.2 has shipped in the meantime. Combines both bumps into a single descriptor change to avoid a redundant intermediate publish cycle.

Bumps `extensions/harbor/description.yml` from harbor v0.1.0 to v0.1.2.

## What's changed since v0.1.0

### v0.1.1 — UI proxy bug fixes ([release notes](https://github.com/shreeve/duckdb-harbor/releases/tag/v0.1.1))

Three UX-changing fixes for the DuckDB UI surface:

1. **UI proxy 500s on compressed asset bodies** — browser-sent `Accept-Encoding: gzip, deflate, br` triggered cpp-httplib's `Error::Read` on the upstream `HandleProxyGet`. harbor now forces `Accept-Encoding: identity` upstream.
2. **`/localEvents` 401 on same-origin EventSource** — browsers don't send `Origin` on same-origin "no-cors" requests. The pre-auth Origin allow-list check rejected empty Origin. Empty Origin now accepted (auth-gated below); cross-origin disallowed Origin still rejects.
3. **`/localToken` 401 on `Referer: http://127.0.0.1:<port>/`** — the Referer-prefix check hardcoded `localhost`. Now matches all loopback variants.

Plus retry-once on transport errors in `HandleProxyGet`.

### v0.1.2 — operator footgun cleanup ([release notes](https://github.com/shreeve/duckdb-harbor/releases/tag/v0.1.2))

1. **`harbor_stop()` no-arg overload** ([#28](https://github.com/shreeve/duckdb-harbor/issues/28)). Single-server-per-process semantics make the no-arg form unambiguous.
2. **Auto-load `httpfs` on harbor extension load** ([#29](https://github.com/shreeve/duckdb-harbor/issues/29)). Side-loaded local builds don't require an explicit `LOAD httpfs;` anymore.
3. **Log type doc/code drift** ([#30](https://github.com/shreeve/duckdb-harbor/issues/30)). Docs corrected to `'Quack'` (the actual registered name).

## Compat

- **Wire format unchanged** on `/quack`, `/sql`, `/ddb/*`, admin since v0.1.0
- **Auth model unchanged**
- **Targets DuckDB v1.5.2** (same as v0.1.0 / v0.1.1)

## Verification

- All 6 test suites green: 203 assertions
- 9-platform CI matrix green at both v0.1.1 (`467a7945`) and v0.1.2 (`adc4410e`) merge commits
- Browser-validated end-to-end on macOS arm64 (DuckDB UI loads, queries execute)
- All 9 platform binaries attached to both releases:
  - https://github.com/shreeve/duckdb-harbor/releases/tag/v0.1.1
  - https://github.com/shreeve/duckdb-harbor/releases/tag/v0.1.2

## Descriptor diff

```diff
- version: 0.1.0
+ version: 0.1.2

- ref: 181ad520b37cdb9ccd8a8ed855beaa5624a83df4
+ ref: adc4410e3b4122a18ff8b91af76c6b3be17e47ad
```