### PR TITLE
Add quack_oauth

### DIFF
--- a/extensions/quack_oauth/description.yml
+++ b/extensions/quack_oauth/description.yml
@@ -1,0 +1,13 @@
+extension:
+  name: quack_oauth
+  description: Extensions providing OAuth and OpenID primitives for authentication and authorization for the DuckDB quack server.
+  language: C++
+  build: cmake
+  excluded_platforms: "windows_amd64_rtools;windows_amd64_mingw;"
+  license: MIT
+  requires_toolchains: "cmake, openssl"
+  maintainers:
+    - jrosskopf
+repo:
+  github: DataZooDE/quack-oauth
+  ref: 0b39e72efe1e85adce0dfe61bfb75ef4037692ff


### PR DESCRIPTION
Adds the `quack_oauth` extension providing OAuth and OpenID primitives for authentication and authorization for the DuckDB quack server.

Split from #1872 per the one-extension-per-PR policy.