### PR TITLE
ggsql: v0.3.2

### DIFF
--- a/extensions/ggsql/description.yml
+++ b/extensions/ggsql/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: ggsql
   description: Bindings to ggsql — Grammar of Graphics based visualizations in SQL
-  version: 0.3.1
+  version: 0.3.2
   language: C++
   build: cmake
   license: MIT
@@ -13,7 +13,7 @@ extension:
   excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads"
 repo:
   github: posit-dev/ggsql-duckdb
-  ref: b58100459367e59c2933cbbb4aa8a2c7ac0e0283
+  ref: cf1289b992b7e12c5e0a9ef39b2d0cac74b2b1e1
 docs:
   hello_world: |
     SELECT 1 AS x, 2 AS y VISUALISE x, y DRAW point;


### PR DESCRIPTION
Small release bumping the included ggsql version

GH release: https://github.com/posit-dev/ggsql-duckdb/releases/tag/v0.3.2