### PR TITLE
release: DuckDB Delta Sharing v1.5.2.8

### DIFF
--- a/extensions/duckdb_delta_sharing/description.yml
+++ b/extensions/duckdb_delta_sharing/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: prequel-co/DuckDB-Delta-Sharing
-  ref: cc55ade76b1580b4565e8f85d722a1e41c21345b
+  ref: deb18484d2a04d213dc01f3bc8f74e167fb5c797
 
 docs:
   hello_world: |
@@ -21,6 +21,7 @@ docs:
     LOAD httpfs;
 
     -- Basic Configuration
+    -- Set your sharing endpoint and bearer token using DuckDB Secrets:
     CREATE SECRET (
         TYPE delta_sharing,
         PROVIDER config,
@@ -28,9 +29,8 @@ docs:
         BEARER_TOKEN 'your_private_token'
     );
 
-    -- Alternatively, using environment variables:
-    -- DELTA_SHARING_ENDPOINT and DELTA_SHARING_BEARER_TOKEN
-    -- CREATE SECRET (TYPE delta_sharing, PROVIDER env);
+    -- Alternatively, if you have DELTA_SHARING_ENDPOINT and DELTA_SHARING_BEARER_TOKEN set in your environment:
+    CREATE SECRET (TYPE delta_sharing, PROVIDER env);
 
     -- Discovering Content
     SELECT * FROM delta_share_list();


### PR DESCRIPTION
## Summary of Changes

- [x] ensure doc in the yaml reflects previous secrets change
- [x] target correct hash which has a fix to make the credential chain deterministic  