### PR TITLE
Bump us_address_standardizer to v0.2.1

### DIFF
--- a/extensions/us_address_standardizer/description.yml
+++ b/extensions/us_address_standardizer/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: us_address_standardizer
   description: US address parsing and standardization (PAGC + Rust addrust)
-  version: 0.2.0
+  version: 0.2.1
   language: C/Rust
   build: cmake
   license: MIT
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: ericmanning/duckdb-address-standardizer
-  ref: 8da70a76d3ade131a094a0e746aa5d06605e3f80
+  ref: 3421cf7326ce60e16feb932a801a62a483909c4b
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary

Bump [us_address_standardizer](https://github.com/ericmanning/duckdb-address-standardizer) from v0.2.0 to v0.2.1.

## What's new

- DuckDB target bumped to v1.5.3 (bugfix release)

All platforms verified green in [the v0.2.1 CI run](https://github.com/ericmanning/duckdb-address-standardizer/actions/runs/26169416982).

## Release

- Pin SHA: `3421cf7326ce60e16feb932a801a62a483909c4b`
- GitHub release: https://github.com/ericmanning/duckdb-address-standardizer/releases/tag/v0.2.1