### PR TITLE
Update raquet extension to v0.2.5

### DIFF
--- a/extensions/raquet/description.yml
+++ b/extensions/raquet/description.yml
@@ -8,6 +8,7 @@ extension:
   excluded_platforms: "windows_amd64;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads"
   maintainers:
     - jatorre
+    - cayetanobv
 
 repo:
   github: jatorre/duckdb-raquet

--- a/extensions/raquet/description.yml
+++ b/extensions/raquet/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: raquet
   description: "Raster analytics on Raquet files with QUADBIN spatial indexing, raster ingestion, and PostGIS-style functions"
-  version: 0.2.4
+  version: 0.2.5
   language: C++
   build: cmake
   license: Apache-2.0
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: jatorre/duckdb-raquet
-  ref: a699560ad74e86f8168aa0b80af120c36e671662
+  ref: 4d2f66c08b295402aab566b016aa502c6e869bae
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps `raquet` from 0.2.4 → 0.2.5 and updates the ref to the tip of [jatorre/duckdb-raquet:main](https://github.com/jatorre/duckdb-raquet/commits/main) (`4d2f66c0`).

## Highlights since 0.2.4

- **Sparsity-aware pre-warp tile filtering in `read_raster()`** — skip empty source tiles before warping. New `sparsity_probe_size` parameter controls the probe.
- **`bands=` filter parameter for `read_raster()`** — ingest a subset of bands from a multi-band source.
- **`read_raster()` correctness fixes** — `IsTileEmpty` now considers all bands (not just band 1); the sparsity probe runs on the *selected* bands, not all source bands.
- **`band_stats`** — honour `approx` in both `format='v0'` and `format='v0.5.0'`; emit extension columns in v0.5.0. Renamed `band_stats_v01` → `band_stats` (drop misleading suffix).
- **New `raquet_merge_bands(LIST<VARCHAR>)`** — combine single-band raquet files into a multi-band raquet. Format-aware, with `parse_metadata` round-trip. Fixes: recompute `num_blocks` for the merged metadata, emit top-level `nodata` as numbers (not quoted strings), renumber `source_band` to output position.
- **CI**: inline sample-data smoke test into `build-linux`; enable `ccache` for Linux and macOS builds (mirrors upstream DuckDB extension strategy); install/load `json` extension before `json_extract_string` queries; set `OVERRIDE_GIT_DESCRIBE` so the binary embeds `v1.5.2` not `v0.0.1`; replace dead GCS download with in-repo 4 KB raquet fixture.
- **Test coverage**: 10 previously-untested public functions and 11 previously-untested `read_raster()` named parameters.
- **Docs**: README refresh of the `read_raster` section and `raquet_merge_bands` usage.

## Compatibility

The Parquet column schema (`block / metadata / band_*`) is **unchanged** — additions are additive, no consumer breakage. The `band_stats_v01` → `band_stats` rename is the only user-visible rename; the old name no longer exists.

## Validation

Upstream CI is green on the new ref (`4d2f66c0`), including the inlined sample-data smoke test and the expanded SQL test suite (read_raster named-parameter coverage and previously-untested public functions).