### PR TITLE
[mongo] Bump to v0.2.3 (DuckDB v1.5.3)

### DIFF
--- a/extensions/mongo/description.yml
+++ b/extensions/mongo/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: mongo
   description: Integrates DuckDB with MongoDB, enabling direct SQL queries over MongoDB collections without exporting data or ETL
-  version: 0.2.2
+  version: 0.2.3
   language: C++
   build: cmake
   license: MIT
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: stephaniewang526/duckdb-mongo
-  ref: ea700533da25ff9430e9e91ead5967f125de1082
+  ref: e61b26addf94279f771ae2abb76fd998e5717e21
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps the mongo extension to v0.2.3, built against DuckDB v1.5.3.

- Updates `ref` to `e61b26addf94279f771ae2abb76fd998e5717e21`
- Bumps extension version from 0.2.2 → 0.2.3