### PR TITLE
Update anofox_forecast to 057f1fa (DuckDB v1.5.3, libssl fixes)

### DIFF
--- a/extensions/anofox_forecast/description.yml
+++ b/extensions/anofox_forecast/description.yml
@@ -10,4 +10,4 @@ extension:
     - sipemu
 repo:
   github: DataZooDE/anofox-forecast
-  ref: 057f1fa8dcadcd12edb92b91dac3fd8719ab4861
+  ref: 1e1d4f2df15a08ec6bc5d4aa53fd10f709e147d1

--- a/extensions/anofox_forecast/description.yml
+++ b/extensions/anofox_forecast/description.yml
@@ -10,4 +10,4 @@ extension:
     - sipemu
 repo:
   github: DataZooDE/anofox-forecast
-  ref: 6035b1024d76efd00f1b104d9ebf0b3d340b7ee4
+  ref: 057f1fa8dcadcd12edb92b91dac3fd8719ab4861


### PR DESCRIPTION
## Summary

Bumps `extensions/anofox_forecast/description.yml` `ref` from `6035b10` to [`057f1fa`](https://github.com/DataZooDE/anofox-forecast/commit/057f1fa8dcadcd12edb92b91dac3fd8719ab4861), the current `main` HEAD.

## What changed since the previous ref

- **DuckDB v1.5.1 → v1.5.2 → v1.5.3** (DataZooDE/anofox-forecast#213, #219). extension-ci-tools submodule now tracks the `v1.5.3` branch.
- **Linux: static OpenSSL** — fixes [`libssl.so.1.1` not found on Ubuntu 22.04+ / Fedora 36+ / Arch](https://github.com/DataZooDE/anofox-forecast/issues/211) (PR #214).
- **Windows: static OpenSSL via vcpkg** — fixes [`libssl-3-x64.dll` / `libcrypto-3-x64.dll` not found on clean Windows 11](https://github.com/DataZooDE/anofox-forecast/issues/215) (PR #217). The Windows artifact previously linked these DLLs dynamically; the GHA `windows-latest` runner happened to have them preinstalled which masked the bug in CI.
- **Doc + test fixes** ([anofox-forecast #216](https://github.com/DataZooDE/anofox-forecast/issues/216), PR #218) — README quick-start example and `ts_forecast_by.test` updated to match the column schema after the GROUP BY rewrite from #209 (`ds`/`yhat` instead of `date`/`point_forecast`; `insample_fitted` is now only on `ts_forecast_agg`, not the table form).

## Verification

Verified locally on Linux:
- Clean `GEN=ninja make` against DuckDB v1.5.3.
- `ts_forecast()` smoke test produces correct output.
- `ldd` on the resulting `.duckdb_extension` reports zero `libssl*` / `libcrypto*` dependencies.

All upstream CI (linux_amd64, linux_arm64, macOS amd64/arm64, DuckDB-Wasm × 3, Windows amd64) passed on `057f1fa` and on the precursor PRs (#214, #217, #218, #219) at the source repo.