### PR TITLE
Bump harbor to 0.2.0

### DIFF
--- a/extensions/harbor/description.yml
+++ b/extensions/harbor/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: harbor
   description: Multi-protocol HTTP service (Quack RPC, JSON SQL, DuckDB UI, admin) for DuckDB on a single port
-  version: 0.1.2
+  version: 0.2.0
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: shreeve/duckdb-harbor
-  ref: adc4410e3b4122a18ff8b91af76c6b3be17e47ad
+  ref: 2c56e2dcced08f74d18f2ab74c5f340492a643ca
 
 docs:
   hello_world: |
@@ -18,7 +18,7 @@ docs:
     -- harbor_serve returns immediately; harbor_wait keeps the process
     -- alive in daemon mode (containers, systemd).
     LOAD harbor;
-    CALL harbor_serve('harbor:127.0.0.1:9494');
+    CALL harbor_serve(bind := '127.0.0.1', port := 9494);
     --                                                  ┌─────────────────────────────────┐
     --                                                  │             token               │
     --                                                  ├─────────────────────────────────┤
@@ -69,12 +69,12 @@ docs:
     - Container-native deployments — `harbor_wait()` blocks until SIGTERM
       so harbor runs cleanly under systemd / Docker / Kubernetes.
 
-    **Status:** v0.1 release, tested across all 9 DuckDB CI platforms
-    (linux_amd64/arm64, osx_amd64/arm64, windows_amd64/_mingw,
-    wasm_mvp/eh/threads). 198 test assertions across 6 suites.
+    **Status:** v0.2 release, tested across the DuckDB community-extension
+    matrix (linux_amd64/arm64, osx_amd64/arm64, windows_amd64/_mingw,
+    wasm_mvp/eh/threads).
 
     Source, design spec, contributor guide, full release notes:
     [github.com/shreeve/duckdb-harbor](https://github.com/shreeve/duckdb-harbor).
 
     Tracks upstream `duckdb-quack` `v1.5-variegata` and `duckdb-ui`;
-    targets DuckDB v1.5.2.
+    targets DuckDB v1.5.3.


### PR DESCRIPTION
## Summary

Bump `harbor` from `0.1.2` to `0.2.0`.

Upstream release: https://github.com/shreeve/duckdb-harbor/releases/tag/v0.2.0

## Notable changes

- Targets DuckDB `v1.5.3`.
- Simplifies `harbor_serve` to named `bind` / `port` arguments.
- Adds explicit three-mode auth model:
  - omitted `token` → auto-generated token
  - `token := '...'` → static token
  - `token := NULL` → unauthenticated mode
- Custom `harbor_authentication_function` now requires omitting `token`.
- `/sql` improvements:
  - `INSERT/UPDATE/DELETE ... RETURNING` now returns select-shaped responses with `columns` + `data`.
  - BIGINT/UBIGINT/HUGEINT/UHUGEINT use JSON numbers inside JavaScript's safe-integer range and strings outside it.
- Registers `harbor_stop_drain_timeout_s` to match existing shutdown behavior.
- Rebuilt README/docs and removed stale docs from the upstream repo.

## Validation

The v0.2.0 tag workflow passed and attached 9 platform artifacts on `shreeve/duckdb-harbor`.

Local validation before tagging included:

- `make release`
- `make test_release` (75 assertions)
- `scripts/golden-cookie-auth.sh`
- `scripts/golden-sql-roundtrip.sh`
- `scripts/golden-sql-types.sh` (78 assertions)
- `scripts/golden-admin-roundtrip.sh`
- `scripts/golden-query-timeout.sh`