### PR TITLE
Bump Behavioral Extension

### DIFF
--- a/extensions/behavioral/description.yml
+++ b/extensions/behavioral/description.yml
@@ -4,7 +4,7 @@
 extension:
   name: behavioral
   description: Behavioral analytics functions inspired by ClickHouse (sessionize, retention, window_funnel, sequence_match, sequence_count, sequence_match_events, sequence_next_node)
-  version: 0.4.0
+  version: 0.6.0
   language: Rust
   build: cargo
   license: MIT
@@ -15,7 +15,7 @@ extension:
 
 repo:
   github: tomtom215/duckdb-behavioral
-  ref: a0d6f5e9dd6bd15e297188e7bdcd6edc5f8e05e2
+  ref: 7f80a96d8a26f896ca96c5ffb0c756a6d0ff7ead
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps behavioral to v0.6.0: DuckDB 1.5.3 / quack-rs 0.13.0. Ref pinned to the v0.6.0 release commit.