### PR TITLE
agent_data: update source ref for DuckDB v1.5.3

### DIFF
--- a/extensions/agent_data/description.yml
+++ b/extensions/agent_data/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: axsaucedo/agent_data_duckdb
-  ref: 41993629dfdd259055327213f119b9b83a4a5826
+  ref: 537172a74104f520e642c20421520dcd88b865cc
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary
- bumps `extensions/agent_data/description.yml` `repo.ref` to `537172a74104f520e642c20421520dcd88b865cc`
- the new source ref targets DuckDB `v1.5.3`, `duckdb`/`libduckdb-sys` crate `1.10503.1`, and `extension-ci-tools` `v1.5-variegata`
- this rebuild is required because the current public DuckDB `1.5.3` install path serves an `agent_data` binary stamped for DuckDB `v1.5.2`

## Validation in source repo
Source PR: https://github.com/axsaucedo/agent_data_duckdb/pull/5

Local validation performed there:
- `python3 scripts/update_duckdb_release.py --check`
- forced drift check against `v1.5.2` returned exit code `10`
- Python compile checks for release scripts
- workflow YAML parsed successfully
- `cargo check --locked`
- `scripts/validate_duckdb_release.sh`
- exact DuckDB `1.5.3` smoke test loading the local extension

Source CI:
- `DuckDB Release Monitor`
- `Main Extension Distribution Pipeline`

## Current public baseline
- `https://duckdb.org/community_extensions/extensions/agent_data.html` returns 200
- public `v1.5.3` binary URLs currently return 200
- aggregate list membership includes `agent_data`
- `INSTALL agent_data FROM community` on DuckDB `1.5.3` currently fails because the published binary metadata says it was built for DuckDB `v1.5.2`
