### PR TITLE
Add pcap_duckdb extension

### DIFF
--- a/extensions/pcap_duckdb/description.yml
+++ b/extensions/pcap_duckdb/description.yml
@@ -7,7 +7,7 @@ extension:
   language: C++
   build: cmake
   license: MIT
-  excluded_platforms: wasm_mvp;wasm_eh;wasm_threads;windows_amd64
+  excluded_platforms: wasm_mvp;wasm_eh;wasm_threads;windows_amd64;windows_amd64_mingw
   maintainers:
     - siara-in
   requires_toolchains: "vcpkg"

--- a/extensions/pcap_duckdb/description.yml
+++ b/extensions/pcap_duckdb/description.yml
@@ -20,7 +20,7 @@ extension:
 
 repo:
   github: siara-in/pcap_duckdb
-  ref: 14e5b03c9b87497f74e73015c769fe32911e51e8
+  ref: 73f9bb2a42693d9e2fb5343911742bd567244259
 
 docs:
   hello_world: |

--- a/extensions/pcap_duckdb/description.yml
+++ b/extensions/pcap_duckdb/description.yml
@@ -7,7 +7,7 @@ extension:
   language: C++
   build: cmake
   license: MIT
-  excluded_platforms: wasm_mvp;wasm_eh;wasm_threads
+  excluded_platforms: wasm_mvp;wasm_eh;wasm_threads;windows_amd64
   maintainers:
     - siara-in
   requires_toolchains: "vcpkg"

--- a/extensions/pcap_duckdb/description.yml
+++ b/extensions/pcap_duckdb/description.yml
@@ -14,7 +14,7 @@ extension:
   vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
 repo:
   github: siara-in/pcap_duckdb
-  ref: 73f9bb2a42693d9e2fb5343911742bd567244259
+  ref: main
 docs:
   hello_world: |
     INSTALL pcap_duckdb FROM community;

--- a/extensions/pcap_duckdb/description.yml
+++ b/extensions/pcap_duckdb/description.yml
@@ -1,0 +1,47 @@
+extension:
+  name: pcap_duckdb
+  description: >
+    Read and analyze PCAP network capture files directly in DuckDB using a
+    native C++ implementation based on libpcap. Works on duckdb v1.5.3.
+
+  version: "1.0.0"
+
+  language: C++
+
+  build: cmake
+
+  licence: MIT
+
+  maintainers:
+    - siara-in
+
+  requires_toolchains:
+    - vcpkg
+
+repo:
+  github: siara-in/pcap_duckdb
+  ref: 14e5b03c9b87497f74e73015c769fe32911e51e8
+
+docs:
+  hello_world: |
+    INSTALL pcap FROM community;
+    LOAD pcap;
+
+    SELECT *
+    FROM read_pcap('capture.pcap')
+    LIMIT 10;
+
+  extended_description: |
+    The pcap extension enables direct querying of PCAP packet capture files
+    from DuckDB using SQL.
+
+    Unlike several existing PCAP processing approaches that rely on Rust
+    runtimes or external shell commands such as tcpdump/tshark, this extension
+    is implemented entirely in modern C++ using libpcap via vcpkg.
+
+    This provides:
+      * Native DuckDB integration
+      * No external shell command execution
+      * No Rust dependency chain
+      * Cross-platform builds through the DuckDB extension toolchain
+      * Efficient packet-level analytics directly in SQL

--- a/extensions/pcap_duckdb/description.yml
+++ b/extensions/pcap_duckdb/description.yml
@@ -14,7 +14,7 @@ extension:
   vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
 repo:
   github: siara-in/pcap_duckdb
-  ref: main
+  ref: b2eae6e6bafc49fa48b5f0abd68bef95ecf97c8c
 docs:
   hello_world: |
     INSTALL pcap_duckdb FROM community;

--- a/extensions/pcap_duckdb/description.yml
+++ b/extensions/pcap_duckdb/description.yml
@@ -2,43 +2,32 @@ extension:
   name: pcap_duckdb
   description: >
     Read and analyze PCAP network capture files directly in DuckDB using a
-    native C++ implementation based on libpcap. Works on duckdb v1.5.3.
-
+    native C++ implementation based on libpcap.
   version: "1.0.0"
-
   language: C++
-
   build: cmake
-
-  licence: MIT
-
+  license: MIT
+  excluded_platforms: wasm_mvp;wasm_eh;wasm_threads
   maintainers:
     - siara-in
-
-  requires_toolchains:
-    - vcpkg
-
+  requires_toolchains: "vcpkg"
+  vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
 repo:
   github: siara-in/pcap_duckdb
   ref: 73f9bb2a42693d9e2fb5343911742bd567244259
-
 docs:
   hello_world: |
-    INSTALL pcap FROM community;
-    LOAD pcap;
-
+    INSTALL pcap_duckdb FROM community;
+    LOAD pcap_duckdb;
     SELECT *
     FROM read_pcap('capture.pcap')
     LIMIT 10;
-
   extended_description: |
-    The pcap extension enables direct querying of PCAP packet capture files
-    from DuckDB using SQL.
-
+    The pcap_duckdb extension enables direct querying of PCAP packet capture
+    files from DuckDB using SQL.
     Unlike several existing PCAP processing approaches that rely on Rust
     runtimes or external shell commands such as tcpdump/tshark, this extension
     is implemented entirely in modern C++ using libpcap via vcpkg.
-
     This provides:
       * Native DuckDB integration
       * No external shell command execution


### PR DESCRIPTION
This pcap extension enables direct querying of PCAP packet capture files
from DuckDB using SQL.

Unlike several existing PCAP processing approaches that rely on Rust
runtimes or external shell commands such as tcpdump/tshark, this extension
is implemented entirely in C++ using libpcap via vcpkg.

It was tested on duckdb 1.5.3