### PR TITLE
Add firebird extension

### DIFF
--- a/extensions/firebird/description.yml
+++ b/extensions/firebird/description.yml
@@ -1,0 +1,124 @@
+extension:
+  name: firebird
+  description: Federated read-only access to Firebird (3.0/4.0/5.0) databases from DuckDB, with projection + filter pushdown, INT128 / DECIMAL(38) / TIMESTAMP_TZ support, and native ATTACH.
+  version: 0.4.0
+  language: C++
+  build: cmake
+  license: MIT
+  maintainers:
+    - flozer
+  # Platforms where libfbclient is reachable via the build's vcpkg
+  # manifest / FB_SDK_ROOT. WASM is excluded — libfbclient depends on
+  # native sockets / threads / file IO.
+  excluded_platforms: "wasm_mvp;wasm_threads;wasm_eh"
+
+repo:
+  github: flozer/duckdb-firebird
+  ref: v0.4.0
+
+docs:
+  hello_world: |
+    LOAD firebird;
+
+    -- 1. Live scan against a Firebird server.
+    SELECT * FROM firebird_scan(
+        'firebird://SYSDBA:masterkey@db.host:3050/srv:/data/prod.fdb?charset=UTF8',
+        'EMPLOYEE') LIMIT 10;
+
+    -- 2. Projection + filter pushdown — only EMP_NO, FIRST_NAME and the
+    --    WHERE predicate are sent to Firebird.
+    SELECT EMP_NO, FIRST_NAME
+      FROM firebird_scan('firebird://…', 'EMPLOYEE')
+     WHERE DEPT_NO = '600'
+       AND HIRE_DATE > DATE '2020-01-01';
+
+    -- 3. Discover the schema.
+    SELECT * FROM firebird_tables('firebird://…');
+
+    -- 4. Native ATTACH — every Firebird table reachable through DuckDB's catalog.
+    ATTACH 'firebird://SYSDBA:masterkey@host/path/db.fdb' AS fb (TYPE firebird);
+    SELECT * FROM fb.main.EMPLOYEE WHERE DEPT_NO = '600';
+
+    -- 5. Federated JOIN — Firebird ⋈ Parquet.
+    SELECT e.dept_no, COUNT(*), AVG(e.salary)
+      FROM firebird_scan('firebird://…', 'EMPLOYEE') e
+      JOIN read_parquet('s3://lake/departments/*.parquet') d
+       ON e.dept_no = d.dept_no
+     GROUP BY e.dept_no;
+
+  extended_description: |
+    duckdb-firebird exposes Firebird tables as DuckDB tables, with the
+    DuckDB optimiser pushing projection and filter predicates down to
+    the Firebird server. Big aggregations still happen inside DuckDB's
+    vectorised executor; you just stop maintaining a parallel ETL
+    pipeline to export Firebird data to Parquet first.
+
+    ## Surface area
+
+    - `firebird_scan(conn, table [, named params])` — single-table scan
+      with projection + filter pushdown and optional PK-range parallel
+      scan.
+    - `firebird_tables(conn)` — list user tables (and views, external
+      tables, GTTs) with PK info.
+    - `firebird_attach_sql(conn[, schema])` — emits the DDL for a
+      lightweight view-based attach when you don't want the full
+      `StorageExtension` lifetime.
+    - `ATTACH 'firebird://…' AS fb (TYPE firebird)` — native read-only
+      catalog with `SELECT * FROM fb.main.TABLE`, federated joins,
+      `DESCRIBE`, case-insensitive lookup, and connection pooling.
+
+    ## Pushdown
+
+    - **Projection**: only requested columns travel the wire.
+    - **Filters**: `=, <>, <, >, <=, >=, IS [NOT] NULL, BETWEEN, IN,
+      AND/OR, LIKE 'prefix%'` translate to Firebird SQL. Anything else
+      stays in DuckDB above the scan.
+    - **PK-range parallel scan**: opt-in via the `partitions=N` named
+      parameter — recommended for remote / Classic Firebird servers
+      where parallelism is cheap.
+    - **Manual `row_limit=N`**: emits Firebird's `ROWS N` directly.
+
+    ## Type mapping
+
+    Firebird 3 + 4 + 5 server compatibility:
+
+    - `INTEGER`, `BIGINT`, `SMALLINT`, `CHAR(N)`, `VARCHAR(N)`,
+      `NUMERIC/DECIMAL(p, s)` (up to 38 digits), `FLOAT`, `DOUBLE`,
+      `DATE`, `TIME`, `TIMESTAMP`, `BOOLEAN` — exact mapping.
+    - `INT128` → `HUGEINT`; `DECIMAL(p > 18, s)` → `DECIMAL(38, s)`.
+    - `TIMESTAMP WITH TIME ZONE` (including the FB4 extended-TZ form) →
+      DuckDB `TIMESTAMP WITH TIME ZONE` (UTC instant preserved).
+    - `TIME WITH TIME ZONE` → DuckDB `TIME WITH TIME ZONE`.
+    - `BLOB SUB_TYPE 1` (text) → `VARCHAR`; other BLOBs → `BLOB`.
+    - `DECFLOAT(16)` / `DECFLOAT(34)` currently surface NULL on fetch
+      (no native IEEE decimal-floating-point type in DuckDB). Workaround:
+      cast to VARCHAR or DECIMAL(38, s) at the source.
+
+    ## Connection-string forms
+
+        firebird://USER:PASS@HOST:PORT/DB_PATH?charset=UTF8&dialect=3&role=…
+        user=SYSDBA;password=masterkey;database=server:/data/db.fdb;charset=UTF8
+
+    A bare path (`/var/lib/firebird/test.fdb`, `C:/data/prod.fdb`) is
+    also accepted for local databases.
+
+    Override the user / password / charset / role / dialect / partitions
+    / row_limit at call time via named parameters.
+
+    ## Charset handling
+
+    DuckDB stores strings as UTF-8 internally. The extension only
+    accepts `UTF8`, `UTF-8`, `NONE`, or `OCTETS` for the client
+    charset; anything else is rejected at bind time with a hint.
+
+    Legacy WIN1252 / ISO-8859-1 / Latin-1 databases are queryable with
+    the default `charset=UTF8` — Firebird transliterates server-side,
+    so Brazilian-Portuguese-encoded strings round-trip correctly
+    without any extra configuration.
+
+    ## Verified against
+
+    - Firebird 3.0 (apt `firebird3.0-server`, CI fixture)
+    - Firebird 4.0.x (`firebirdsql/firebird:4-noble`)
+    - Firebird 5.0.4 (Windows local + `firebirdsql/firebird:5-noble`)
+    - DuckDB v1.5.3 (`StorageExtension::Register` API)

--- a/extensions/firebird/description.yml
+++ b/extensions/firebird/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: firebird
   description: Federated read-only access to Firebird (3.0/4.0/5.0) databases from DuckDB, with projection + filter pushdown, INT128 / DECIMAL(38) / TIMESTAMP_TZ support, native ATTACH, and CHARACTER SET NONE handling (default win1252; strict / iso8859_1 / blob also available) with filter-pushdown correctness on transcoded columns.
-  version: 0.6.0
+  version: 0.6.1
   language: C++
   build: cmake
   license: MIT
@@ -21,7 +21,7 @@ extension:
 
 repo:
   github: flozer/duckdb-firebird
-  ref: v0.6.0
+  ref: v0.6.1
 
 docs:
   hello_world: |
@@ -29,7 +29,7 @@ docs:
 
     -- 1. Live scan against a Firebird server.
     SELECT * FROM firebird_scan(
-        'firebird://SYSDBA:masterkey@db.host:3050/srv:/data/prod.fdb?charset=UTF8',
+        'firebird://APP_READONLY:secret@db.host:3050/srv:/data/prod.fdb?charset=UTF8',
         'EMPLOYEE') LIMIT 10;
 
     -- 2. Projection + filter pushdown — only EMP_NO, FIRST_NAME and the
@@ -43,7 +43,7 @@ docs:
     SELECT * FROM firebird_tables('firebird://…');
 
     -- 4. Native ATTACH — every Firebird table reachable through DuckDB's catalog.
-    ATTACH 'firebird://SYSDBA:masterkey@host/path/db.fdb' AS fb (TYPE firebird);
+    ATTACH 'firebird://APP_READONLY:secret@host/path/db.fdb' AS fb (TYPE firebird);
     SELECT * FROM fb.main.EMPLOYEE WHERE DEPT_NO = '600';
 
     -- 5. Firebird-native diagnostics (v0.6).
@@ -61,7 +61,7 @@ docs:
     --    NOT transliterate NONE columns to UTF-8 on the wire; pick
     --    the encoding the writing application used.
     SELECT * FROM firebird_scan(
-        'C:/legacy/athenas.fdb',
+        'C:/legacy/company.fdb',
         'TABENTRADASAIDA',
         none_encoding='win1252');
 
@@ -120,7 +120,7 @@ docs:
     ## Connection-string forms
 
         firebird://USER:PASS@HOST:PORT/DB_PATH?charset=UTF8&dialect=3&role=…
-        user=SYSDBA;password=masterkey;database=server:/data/db.fdb;charset=UTF8
+        user=APP_READONLY;password=secret;database=server:/data/db.fdb;charset=UTF8
 
     A bare path (`/var/lib/firebird/test.fdb`, `C:/data/prod.fdb`) is
     also accepted for local databases.

--- a/extensions/firebird/description.yml
+++ b/extensions/firebird/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: firebird
   description: Federated read-only access to Firebird (3.0/4.0/5.0) databases from DuckDB, with projection + filter pushdown, INT128 / DECIMAL(38) / TIMESTAMP_TZ support, native ATTACH, and CHARACTER SET NONE handling (default win1252; strict / iso8859_1 / blob also available) with filter-pushdown correctness on transcoded columns.
-  version: 0.5.6
+  version: 0.6.0
   language: C++
   build: cmake
   license: MIT
@@ -21,7 +21,7 @@ extension:
 
 repo:
   github: flozer/duckdb-firebird
-  ref: v0.5.6
+  ref: v0.6.0
 
 docs:
   hello_world: |
@@ -46,14 +46,18 @@ docs:
     ATTACH 'firebird://SYSDBA:masterkey@host/path/db.fdb' AS fb (TYPE firebird);
     SELECT * FROM fb.main.EMPLOYEE WHERE DEPT_NO = '600';
 
-    -- 5. Federated JOIN — Firebird ⋈ Parquet.
+    -- 5. Firebird-native diagnostics (v0.6).
+    SELECT * FROM firebird_profile_table('fb.main.EMPLOYEE');
+    SELECT * FROM firebird_pool_stats('fb');
+
+    -- 6. Federated JOIN — Firebird ⋈ Parquet.
     SELECT e.dept_no, COUNT(*), AVG(e.salary)
       FROM firebird_scan('firebird://…', 'EMPLOYEE') e
       JOIN read_parquet('s3://lake/departments/*.parquet') d
        ON e.dept_no = d.dept_no
      GROUP BY e.dept_no;
 
-    -- 6. Legacy database declared CHARACTER SET NONE. Firebird does
+    -- 7. Legacy database declared CHARACTER SET NONE. Firebird does
     --    NOT transliterate NONE columns to UTF-8 on the wire; pick
     --    the encoding the writing application used.
     SELECT * FROM firebird_scan(
@@ -81,6 +85,11 @@ docs:
     - `ATTACH 'firebird://…' AS fb (TYPE firebird)` — native read-only
       catalog with `SELECT * FROM fb.main.TABLE`, federated joins,
       `DESCRIBE`, case-insensitive lookup, and connection pooling.
+    - `firebird_profile_table('fb.main.TABLE')` — v0.6 factual diagnostics
+      for PKs, indexes, filter/watermark candidates, view risk, and
+      recommended partitions.
+    - `firebird_pool_stats('fb')` — v0.6 connection-pool counters for one
+      attached Firebird catalog.
 
     ## Pushdown
 
@@ -105,9 +114,8 @@ docs:
       DuckDB `TIMESTAMP WITH TIME ZONE` (UTC instant preserved).
     - `TIME WITH TIME ZONE` → DuckDB `TIME WITH TIME ZONE`.
     - `BLOB SUB_TYPE 1` (text) → `VARCHAR`; other BLOBs → `BLOB`.
-    - `DECFLOAT(16)` / `DECFLOAT(34)` currently surface NULL on fetch
-      (no native IEEE decimal-floating-point type in DuckDB). Workaround:
-      cast to VARCHAR or DECIMAL(38, s) at the source.
+    - `DECFLOAT(16)` / `DECFLOAT(34)` → lossless `VARCHAR` via server-side
+      `CAST(... AS VARCHAR(64))` (v0.6).
 
     ## Connection-string forms
 
@@ -134,13 +142,13 @@ docs:
     Databases (or individual columns) declared `CHARACTER SET NONE`
     are different: Firebird returns the raw bytes the writing
     application stored, with no transliteration. The extension's
-    default `strict` mode raises an informative error the first time
-    it sees non-UTF-8 bytes; the caller must then pick the encoding
-    the source application used:
+    default `win1252` mode decodes the bytes used by many legacy Brazilian
+    and Western-European ERPs. The caller can still pick the encoding the
+    source application used:
 
-    - `none_encoding='strict'` (default) — accept only valid UTF-8.
-    - `none_encoding='win1252'`         — decode bytes as
+    - `none_encoding='win1252'` (default) — decode bytes as
       Windows-1252 → UTF-8.
+    - `none_encoding='strict'`          — accept only valid UTF-8.
     - `none_encoding='iso8859_1'` (alias `'latin1'`) — decode bytes
       as ISO-8859-1 → UTF-8.
     - `none_encoding='blob'`            — surface NONE text columns

--- a/extensions/firebird/description.yml
+++ b/extensions/firebird/description.yml
@@ -1,10 +1,14 @@
 extension:
   name: firebird
-  description: Federated read-only access to Firebird (3.0/4.0/5.0) databases from DuckDB, with projection + filter pushdown, INT128 / DECIMAL(38) / TIMESTAMP_TZ support, and native ATTACH.
-  version: 0.4.0
+  description: Federated read-only access to Firebird (3.0/4.0/5.0) databases from DuckDB, with projection + filter pushdown, INT128 / DECIMAL(38) / TIMESTAMP_TZ support, native ATTACH, and CHARACTER SET NONE handling (default win1252; strict / iso8859_1 / blob also available) with filter-pushdown correctness on transcoded columns.
+  version: 0.4.4
   language: C++
   build: cmake
   license: MIT
+  # libfbclient is consumed via the in-repo vcpkg.json manifest, so the
+  # community CI must spin up the vcpkg toolchain to satisfy the
+  # ibase.h / fbclient_ms dependency before configuring CMake.
+  requires_toolchains: vcpkg
   maintainers:
     - flozer
   # Platforms where libfbclient is reachable via the build's vcpkg
@@ -14,7 +18,7 @@ extension:
 
 repo:
   github: flozer/duckdb-firebird
-  ref: v0.4.0
+  ref: v0.4.4
 
 docs:
   hello_world: |
@@ -45,6 +49,14 @@ docs:
       JOIN read_parquet('s3://lake/departments/*.parquet') d
        ON e.dept_no = d.dept_no
      GROUP BY e.dept_no;
+
+    -- 6. Legacy database declared CHARACTER SET NONE. Firebird does
+    --    NOT transliterate NONE columns to UTF-8 on the wire; pick
+    --    the encoding the writing application used.
+    SELECT * FROM firebird_scan(
+        'C:/legacy/athenas.fdb',
+        'TABENTRADASAIDA',
+        none_encoding='win1252');
 
   extended_description: |
     duckdb-firebird exposes Firebird tables as DuckDB tables, with the
@@ -109,12 +121,34 @@ docs:
 
     DuckDB stores strings as UTF-8 internally. The extension only
     accepts `UTF8`, `UTF-8`, `NONE`, or `OCTETS` for the client
-    charset; anything else is rejected at bind time with a hint.
+    charset; anything else is rejected at bind time.
 
-    Legacy WIN1252 / ISO-8859-1 / Latin-1 databases are queryable with
-    the default `charset=UTF8` — Firebird transliterates server-side,
-    so Brazilian-Portuguese-encoded strings round-trip correctly
-    without any extra configuration.
+    Databases declared with a real character set (WIN1252, ISO8859_1,
+    UTF8, …) round-trip cleanly under the default `charset=UTF8`:
+    Firebird transliterates server-side, so `São Paulo`, `Açúcar`,
+    `Coração` arrive as valid UTF-8 without extra configuration.
+
+    Databases (or individual columns) declared `CHARACTER SET NONE`
+    are different: Firebird returns the raw bytes the writing
+    application stored, with no transliteration. The extension's
+    default `strict` mode raises an informative error the first time
+    it sees non-UTF-8 bytes; the caller must then pick the encoding
+    the source application used:
+
+    - `none_encoding='strict'` (default) — accept only valid UTF-8.
+    - `none_encoding='win1252'`         — decode bytes as
+      Windows-1252 → UTF-8.
+    - `none_encoding='iso8859_1'` (alias `'latin1'`) — decode bytes
+      as ISO-8859-1 → UTF-8.
+    - `none_encoding='blob'`            — surface NONE text columns
+      as DuckDB `BLOB` (raw bytes).
+
+    The option is accepted both by `firebird_scan(…)` and by the
+    `ATTACH ... (TYPE firebird, none_encoding 'win1252')` form. While
+    `none_encoding != 'strict'`, filter pushdown on NONE text columns
+    is deliberately disabled — the SQL literal we'd send is UTF-8
+    and would not match the raw bytes server-side. DuckDB applies
+    the post-transcode text filter above the scan.
 
     ## Verified against
 

--- a/extensions/firebird/description.yml
+++ b/extensions/firebird/description.yml
@@ -1,24 +1,27 @@
 extension:
   name: firebird
   description: Federated read-only access to Firebird (3.0/4.0/5.0) databases from DuckDB, with projection + filter pushdown, INT128 / DECIMAL(38) / TIMESTAMP_TZ support, native ATTACH, and CHARACTER SET NONE handling (default win1252; strict / iso8859_1 / blob also available) with filter-pushdown correctness on transcoded columns.
-  version: 0.5.4
+  version: 0.5.5
   language: C++
   build: cmake
   license: MIT
-  # libfbclient is consumed via the in-repo vcpkg.json manifest, so the
-  # community CI must spin up the vcpkg toolchain to satisfy the
-  # ibase.h / fbclient_ms dependency before configuring CMake.
-  requires_toolchains: vcpkg
+  # libfbclient is loaded at RUNTIME via dlopen / LoadLibrary; the
+  # community CI no longer needs vcpkg to satisfy it at build time.
+  # End users must have a Firebird client library reachable on their
+  # platform's default dynamic-loader search path (or via
+  # DUCKDB_FIREBIRD_CLIENT_LIBRARY) when they first call a firebird_*
+  # function. Vendored Firebird headers under
+  # third_party/firebird/include/ (Interbase Public License) cover the
+  # compile-time requirement.
   maintainers:
     - flozer
-  # Platforms where libfbclient is reachable via the build's vcpkg
-  # manifest / FB_SDK_ROOT. WASM is excluded — libfbclient depends on
-  # native sockets / threads / file IO.
+  # WASM is still excluded because libfbclient depends on native
+  # sockets / threads / file IO, regardless of how it is loaded.
   excluded_platforms: "wasm_mvp;wasm_threads;wasm_eh"
 
 repo:
   github: flozer/duckdb-firebird
-  ref: v0.5.4
+  ref: v0.5.5
 
 docs:
   hello_world: |

--- a/extensions/firebird/description.yml
+++ b/extensions/firebird/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: firebird
   description: Federated read-only access to Firebird (3.0/4.0/5.0) databases from DuckDB, with projection + filter pushdown, INT128 / DECIMAL(38) / TIMESTAMP_TZ support, native ATTACH, and CHARACTER SET NONE handling (default win1252; strict / iso8859_1 / blob also available) with filter-pushdown correctness on transcoded columns.
-  version: 0.5.5
+  version: 0.5.6
   language: C++
   build: cmake
   license: MIT
@@ -21,7 +21,7 @@ extension:
 
 repo:
   github: flozer/duckdb-firebird
-  ref: v0.5.5
+  ref: v0.5.6
 
 docs:
   hello_world: |

--- a/extensions/firebird/description.yml
+++ b/extensions/firebird/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: firebird
   description: Federated read-only access to Firebird (3.0/4.0/5.0) databases from DuckDB, with projection + filter pushdown, INT128 / DECIMAL(38) / TIMESTAMP_TZ support, native ATTACH, and CHARACTER SET NONE handling (default win1252; strict / iso8859_1 / blob also available) with filter-pushdown correctness on transcoded columns.
-  version: 0.5.0
+  version: 0.5.1
   language: C++
   build: cmake
   license: MIT
@@ -18,7 +18,7 @@ extension:
 
 repo:
   github: flozer/duckdb-firebird
-  ref: v0.5.0
+  ref: v0.5.1
 
 docs:
   hello_world: |

--- a/extensions/firebird/description.yml
+++ b/extensions/firebird/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: firebird
   description: Federated read-only access to Firebird (3.0/4.0/5.0) databases from DuckDB, with projection + filter pushdown, INT128 / DECIMAL(38) / TIMESTAMP_TZ support, native ATTACH, and CHARACTER SET NONE handling (default win1252; strict / iso8859_1 / blob also available) with filter-pushdown correctness on transcoded columns.
-  version: 0.4.4
+  version: 0.5.0
   language: C++
   build: cmake
   license: MIT
@@ -18,7 +18,7 @@ extension:
 
 repo:
   github: flozer/duckdb-firebird
-  ref: v0.4.4
+  ref: v0.5.0
 
 docs:
   hello_world: |

--- a/extensions/firebird/description.yml
+++ b/extensions/firebird/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: firebird
   description: Federated read-only access to Firebird (3.0/4.0/5.0) databases from DuckDB, with projection + filter pushdown, INT128 / DECIMAL(38) / TIMESTAMP_TZ support, native ATTACH, and CHARACTER SET NONE handling (default win1252; strict / iso8859_1 / blob also available) with filter-pushdown correctness on transcoded columns.
-  version: 0.5.1
+  version: 0.5.4
   language: C++
   build: cmake
   license: MIT
@@ -18,7 +18,7 @@ extension:
 
 repo:
   github: flozer/duckdb-firebird
-  ref: v0.5.1
+  ref: v0.5.4
 
 docs:
   hello_world: |


### PR DESCRIPTION
Submission for the **firebird** extension — federated read-only access to Firebird (3.0 / 4.0 / 5.0) databases from DuckDB.

## What's in this PR

A single new file: `extensions/firebird/description.yml`. No other paths touched.

## Extension at a glance

- `firebird_scan(conn, table [, named params])` — single-table scan with projection + filter pushdown.
- `firebird_tables(conn)` — table-name + PK + kind discovery.
- `firebird_attach_sql(conn[, schema])` — emits DDL for a view-based attach.
- `ATTACH 'firebird://…' AS fb (TYPE firebird)` — native read-only catalog backed by a connection pool + metadata cache.

Filter pushdown covers `=, <>, <, >, <=, >=, IS [NOT] NULL, BETWEEN, IN, AND/OR, LIKE 'prefix%'`. PK-range parallel scan is opt-in via `partitions=N`. Type mapping covers every FB3 type plus the FB4 additions (INT128 → HUGEINT, DECIMAL(38, s), TIMESTAMP_TZ, TIME_TZ); DECFLOAT(16/34) currently surfaces NULL on fetch and is documented as such.

## Distribution metadata

- Repo: https://github.com/flozer/duckdb-firebird
- Pinned ref: `v0.4.0` ([release notes](https://github.com/flozer/duckdb-firebird/releases/tag/v0.4.0))
- License: MIT
- Maintainer: @flozer
- Excluded platforms: WASM (libfbclient depends on native sockets/threads/file IO).
- Build: cmake. `vcpkg.json` ships a `libfbclient` manifest; on Windows / macOS the CI alternative is `FB_SDK_ROOT` pointed at an unpacked Firebird install.

## Verified against

- Firebird 3.0 — apt `firebird3.0-server` (existing CI fixture).
- Firebird 4.0.x — `firebirdsql/firebird:4-noble` Docker image.
- Firebird 5.0.4 — Windows local + `firebirdsql/firebird:5-noble`.
- DuckDB v1.5.3 (`StorageExtension::Register` API).

Live INT128 round-trip (max/min values), DECIMAL(38, 5) extremes, TIMESTAMP_TZ + TIME_TZ, CTAS materialisation, COPY to Parquet, federated joins, ATTACH catalog — all green. See [`docs/test_report.md`](https://github.com/flozer/duckdb-firebird/blob/v0.4.0/docs/test_report.md) "Firebird 5 live coverage" for the full matrix.

## Submission checklist

- [x] description.yml pinned to immutable tag (`v0.4.0`), not `main`.
- [x] Extension slug: `firebird`.
- [x] Single-file PR; no changes outside `extensions/firebird/`.
- [x] Release tag exists with build artefacts referenceable.