### PR TITLE
Bump PRQL again

### DIFF
--- a/extensions/prql/description.yml
+++ b/extensions/prql/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: ywelsch/duckdb-prql
-  ref: 1f491bb79de4ccbc6287f952ab8bad7daa17e196
+  ref: 17368b6881efcd7a045dcbc26fc617edfaf2fd09
 
 docs:
   hello_world: |


### PR DESCRIPTION
Something broke between 1.5.2 and 1.5.3 (unclear what), and both build fine in my local CI. Trying to resolve with a SHA bump here: https://github.com/ywelsch/duckdb-prql/commit/17368b6881efcd7a045dcbc26fc617edfaf2fd09