### PR TITLE
ducksmiles: update source ref

### DIFF
--- a/extensions/ducksmiles/description.yml
+++ b/extensions/ducksmiles/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: nkwork9999/duckSMILES
-  ref: f6e4c76169193e7f521578720e75aa2b952df7ac
+  ref: 4c10e7c9be2175707933af80045bbee0c479ed3e
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary
- update ducksmiles extension source ref to the merged duckSMILES main commit
- keeps community-extensions pinned to nkwork9999/duckSMILES@4c10e7c9be2175707933af80045bbee0c479ed3e

## Notes
- duckSMILES PR: https://github.com/nkwork9999/duckSMILES/pull/4