### PR TITLE
yaml: bump to v1.6.5 (fixes empty-list nesting #37)

### DIFF
--- a/extensions/yaml/description.yml
+++ b/extensions/yaml/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: yaml
   description: Read YAML files into DuckDB with native YAML type support, comprehensive extraction functions, and seamless JSON interoperability
-  version: 1.6.3
+  version: 1.6.5
   language: C++
   build: cmake
   license: MIT
@@ -13,8 +13,8 @@ extension:
   
 repo:
   github: teaguesterling/duckdb_yaml
-  andium: de60de55fb238c44661cef27373e82ab21920f43
-  ref: de60de55fb238c44661cef27373e82ab21920f43
+  andium: 9d57e9557742ede442be4095951dfa56227282b2
+  ref: 9d57e9557742ede442be4095951dfa56227282b2
 
 docs:
   hello_world: |


### PR DESCRIPTION

Empty lists in struct-array fields used to be inferred as `LIST<LIST<child>>` instead of `LIST<child>`. This caused materialisation of YAML files where the **first** row had an empty list and a **later** row had a populated list to fail with a misleading cast error:

- Bug report: [teaguesterling/duckdb_yaml#37](https://github.com/teaguesterling/duckdb_yaml/issues/37)
- Fix PR: [teaguesterling/duckdb_yaml#38](https://github.com/teaguesterling/duckdb_yaml/pull/38)
