### PR TITLE
webbed: bump to v2.1.0 (STRUCT widening + SAX rich-typing + DuckDB v1.5.3)

### DIFF
--- a/extensions/webbed/description.yml
+++ b/extensions/webbed/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: webbed
   description: Comprehensive processing extension for web markup languages (XML and HTML) with SAX streaming for large files, intelligent schema inference, XPath-based data extraction, and HTML table parsing.
-  version: 2.0.1
+  version: 2.1.0
   language: C++
   build: cmake
   license: MIT
@@ -11,8 +11,8 @@ extension:
   vcpkg_commit: 68a1c387f660632f2f65cdb7e8cd093a08840e5d
 repo:
   github: teaguesterling/duckdb_webbed
-  andium: 1c5dbe889d0b6efaf1cda2e26ee370de2d1612c6
-  ref: 1c5dbe889d0b6efaf1cda2e26ee370de2d1612c6
+  andium: 3ccf005124491090a6e291a6cde2e848044e6992
+  ref: 3ccf005124491090a6e291a6cde2e848044e6992
 docs:
   docs_url: https://duckdb-webbed.readthedocs.io
   hello_world: |


### PR DESCRIPTION
Bumps the `webbed` extension to [v2.1.0](https://github.com/teaguesterling/duckdb_webbed/releases/tag/v2.1.0).

Most of this release is @bendrucker's work — thanks Ben!

- **STRUCT widening + SAX rich-typing for `read_xml(union_by_name)`** ([#75](https://github.com/teaguesterling/duckdb_webbed/pull/75), [#80](https://github.com/teaguesterling/duckdb_webbed/pull/80)): cross-file `STRUCT` shape disagreement now recursively unions instead of collapsing to `VARCHAR`. SAX path participates in widening for files over `maximum_file_size`.
- **DuckDB main (v1.6) build compatibility** ([#76](https://github.com/teaguesterling/duckdb_webbed/pull/76)): `duckdb_compat.hpp` adopts the new per-vector size tracking ([duckdb/duckdb#22377](https://github.com/duckdb/duckdb/pull/22377)) while staying compatible with stable.
- **DuckDB v1.5.3 stable** ([#79](https://github.com/teaguesterling/duckdb_webbed/pull/79)): submodule + workflow bump from v1.4-andium → v1.5.3. `windows_amd64_mingw` excluded on both jobs due to upstream cp1252 reporter crash on the mingw runner (same workaround as several other v1.5.3-migrated extensions).

Full release notes: https://github.com/teaguesterling/duckdb_webbed/blob/v2.1.0/RELEASE_NOTES_v2.1.0.md