### PR TITLE
Update semantic_views to v0.10.1

### DIFF
--- a/extensions/semantic_views/description.yml
+++ b/extensions/semantic_views/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: semantic_views
   description: "Semantic views -- a declarative layer for dimensions, metrics, and relationships"
-  version: 0.10.0
+  version: 0.10.1
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: anentropic/duckdb-semantic-views
-  ref: 1da5ab6b83a835769d578ecc83f453c09f1e66c9
+  ref: 7792c592bf71f1a64cd93d2a768cc59c7180ca80
 
 docs:
   hello_world: |


### PR DESCRIPTION
Unfortunately v0.10.0 was broken (built against 1.5.2, published against 1.5.3)

this release fixes that (built and published for 1.5.3)