### PR TITLE
harbor: republish at v0.2.1 (fixes 404 on DuckDB v1.5.3)

### DIFF
--- a/extensions/harbor/description.yml
+++ b/extensions/harbor/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: harbor
   description: Multi-protocol HTTP service (Quack RPC, JSON SQL, DuckDB UI, admin) for DuckDB on a single port
-  version: 0.2.0
+  version: 0.2.1
   language: C++
   build: cmake
   license: MIT

--- a/extensions/harbor/description.yml
+++ b/extensions/harbor/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: shreeve/duckdb-harbor
-  ref: 2c56e2dcced08f74d18f2ab74c5f340492a643ca
+  ref: b189a546c0f3a87988c32e5fbaf3995bc01df0e7
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary

Republish of the existing `harbor` community extension at **v0.2.1** to fix `HTTP 404` on `INSTALL harbor FROM community` for DuckDB **v1.5.3**. No source changes from v0.2.0 — this is a republish only. Same fix pattern as [#2001](https://github.com/duckdb/community-extensions/pull/2001) (`finetype`).

Net diff is two lines in `extensions/harbor/description.yml`:

```diff
-  version: 0.2.0
+  version: 0.2.1
...
-  ref: 2c56e2dcced08f74d18f2ab74c5f340492a643ca
+  ref: b189a546c0f3a87988c32e5fbaf3995bc01df0e7
```

## Status: ready to merge

- ✅ All 9 platform **build** jobs green (`linux_amd64/arm64`, `osx_amd64/arm64`, `windows_amd64/_mingw`, `wasm_mvp/eh/threads`)
- ✅ All 9 **deploy** jobs green
- ✅ `mergeable: CLEAN`

## Background (the 404)

[#1954 "Bump harbor to 0.2.0"](https://github.com/duckdb/community-extensions/pull/1954) merged 2026-05-22 and reported green, but no harbor artifacts ever appeared at `/v1.5.3/<plat>/harbor.duckdb_extension.gz` — every platform 404s, and `/v1.5.2/<plat>/` still serves the older 0.1.2 build. This PR republishes to get v1.5.3 binaries onto the CDN.

## Note on the initial deploy failure (self-inflicted, now resolved)

The first push of this PR failed every `Deploy (...)` job because I had tagged `v0.2.1` on the **same commit** as `v0.2.0`. With two tags on one commit, `git tag --points-at HEAD` in `_extension_deploy.yml` returns two lines, and the deploy invocation then mis-parses the version argument. Resolved by retagging `v0.2.1` onto its own commit (`b189a54`) so a single tag points at HEAD; deploys are green now. Flagging only as an FYI — the one-tag-per-release-commit convention is reasonable and this was my own mistake, so there's nothing here that needs changing on your end.

## Post-merge verification

```bash
curl -sI http://community-extensions.duckdb.org/v1.5.3/osx_arm64/harbor.duckdb_extension.gz | head -1
# expect: HTTP/1.1 200 OK
```

```sql
INSTALL harbor FROM community;
LOAD harbor;
SELECT harbor_version();   -- expect: v0.2.1
```