### PR TITLE
Bump anofox_statistics ref to 24403ae

### DIFF
--- a/extensions/anofox_statistics/description.yml
+++ b/extensions/anofox_statistics/description.yml
@@ -9,4 +9,4 @@ extension:
   requires_toolchains: rust
 repo:
   github: DataZooDE/anofox-statistics
-  ref: fa6ef3217159b0cbeb829afe190fafb1a560e978
+  ref: 24403aeb0eb511273a9d885147aa38c67c2c2ea7


### PR DESCRIPTION
Bumps the pinned ref for [\`anofox_statistics\`](https://github.com/DataZooDE/anofox-statistics) from \`fa6ef32\` to [\`24403ae\`](https://github.com/DataZooDE/anofox-statistics/commit/24403aeb0eb511273a9d885147aa38c67c2c2ea7).

## What's new in this ref

- Upgrade to DuckDB **1.5.3** (also includes the intermediate 1.5.1 / 1.5.2 upgrades).
- \`FunctionDescription\` metadata added to all scalar, aggregate, table, and window functions (visible via \`duckdb_functions()\`).
- README cleanup.

Tested CI on \`main\` is green for the v1.5.3 matrix across Linux amd64/arm64, macOS amd64/arm64, Windows amd64+mingw, and the wasm trio (mvp/eh/threads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)