### PR TITLE
Bump h5db

### DIFF
--- a/extensions/h5db/description.yml
+++ b/extensions/h5db/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: h5db
   description: Read HDF5 datasets and attributes
-  version: 1.1.5
+  version: 1.1.6
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
     - jokasimr
 repo:
   github: jokasimr/h5db
-  ref: v1.1.5
+  ref: v1.1.6
   andium: v0.3.0
 
 docs:


### PR DESCRIPTION
[Previous deploy workflow](https://github.com/duckdb/community-extensions/actions/runs/26820209045/job/79072571022) failed because of a network/availability issue of one of the dependencies. 
The purpose of this bump is mainly so that the deploy workflow can re-run.
The bump also adds function descriptions in `duckdb_functions()`.