### PR TITLE
Update nkwork extension refs

### DIFF
--- a/extensions/bvh2sql/description.yml
+++ b/extensions/bvh2sql/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: nkwork9999/bvh2sql
-  ref: 62e96ba71a1bc57175a18827a2ad807bff9bfe5f
+  ref: b72eec2566c7d8f361f471d81feede4caf8e39e4
 
 docs:
   hello_world: |

--- a/extensions/duckdb_midi/description.yml
+++ b/extensions/duckdb_midi/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: nkwork9999/duckdb-midi
-  ref: b50ec402b5c522c3cd43c5d42a982a71e5a81998
+  ref: 5acd2d037b10847247eb951c3b7562d70f2d982f
 
 docs:
   hello_world: |

--- a/extensions/duckorch/description.yml
+++ b/extensions/duckorch/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: nkwork9999/duck-orch
-  ref: 89645807397b8f33c10ab0d0c347cb989c1598bd
+  ref: ede922bb469032483ac4a14410ef09d600a7cf6a
 
 docs:
   hello_world: |

--- a/extensions/pic2vec/description.yml
+++ b/extensions/pic2vec/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: nkwork9999/pic2vec
-  ref: d39ef33b1389e670e1b19861ec1b6a51c3717273
+  ref: 97059943d85becdaf1076e0a7364b14efda0af17
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary
- update bvh2sql, pic2vec, duckdb_midi, and duckorch source refs to recently verified commits
- pick up regression/e2e fixture coverage for BVH parsing, image IO/VSS utilities, MIDI roundtrip, and duckorch task orchestration

## Local verification
- bvh2sql: make release; make test; direct SQL confirmed 31 joints across 2,752 frames, not root-only
- pic2vec: make release; make test; direct SQL confirmed image info, pHash/hamming, dedupe, and match helpers
- duckdb-midi: make release; make test; direct SQL confirmed fixture notes/meta tempo plus midi_write roundtrip
- duckorch: make release; make test; direct SQL confirmed orch_register/orch_run/orch_check_run, dependency edge, and passing asset check