### PR TITLE
bvh2sql: update source ref

### DIFF
--- a/extensions/bvh2sql/description.yml
+++ b/extensions/bvh2sql/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: nkwork9999/bvh2sql
-  ref: 62e96ba71a1bc57175a18827a2ad807bff9bfe5f
+  ref: b72eec2566c7d8f361f471d81feede4caf8e39e4
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary
- update bvh2sql source ref to nkwork9999/bvh2sql@b72eec2566c7d8f361f471d81feede4caf8e39e4
- picks up the BVH nested JOINT parser fix, CHANNELS-order rotation handling, and regression sqllogictest

## Local verification
- make release
- make test
- direct SQL confirmed 31 distinct joints across 2,752 frames from the fixture