### PR TITLE
pic2vec: update source ref

### DIFF
--- a/extensions/pic2vec/description.yml
+++ b/extensions/pic2vec/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: nkwork9999/pic2vec
-  ref: d39ef33b1389e670e1b19861ec1b6a51c3717273
+  ref: 97059943d85becdaf1076e0a7364b14efda0af17
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary
- update pic2vec source ref to nkwork9999/pic2vec@97059943d85becdaf1076e0a7364b14efda0af17
- picks up image IO/perceptual hash/dedupe/match SQL coverage and the VSS image search example

## Local verification
- make release
- make test
- direct SQL confirmed pic_image_info, pic_phash/pic_hamming, pic_dedupe, and pic_match