### PR TITLE
midi: update source ref

### DIFF
--- a/extensions/midi/description.yml
+++ b/extensions/midi/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: nkwork9999/duckdb-midi
-  ref: b50ec402b5c522c3cd43c5d42a982a71e5a81998
+  ref: 164c1e4ab63c06cae67054301157a23bbd216579
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary
- move the MIDI descriptor from extensions/duckdb_midi to extensions/midi so it matches extension.name and the current build.py validation
- update midi source ref to nkwork9999/duckdb-midi@5acd2d037b10847247eb951c3b7562d70f2d982f
- picks up MIDI fixture parsing, meta event, generation, and write/read roundtrip coverage

## Local verification
- descriptor YAML parsed locally with matching directory/name and 40-char ref
- make release
- make test
- direct SQL confirmed fixture notes/meta tempo and midi_write roundtrip