### PR TITLE
Update DICOM extension to v0.3.0

### DIFF
--- a/extensions/dicom/description.yml
+++ b/extensions/dicom/description.yml
@@ -3,7 +3,7 @@ extension:
   description: |
     DuckDB integration with medical imaging data (DICOM - Digital Imaging and Communication in
     Medicine).
-  version: 0.2.0
+  version: 0.3.0
   language: C++
   build: cmake
   excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads"
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: nmontesg/duck-dicom
-  ref: v0.2.0
+  ref: v0.3.0
 
 docs:
   hello_world: |
@@ -66,3 +66,42 @@ docs:
 
     -- use glob pattern
     FROM read_dicom('s3://my-bucket/path/to/dicoms/**/*.dcm');
+
+    The extension also provides a custom `DICOM_TAG` type and scalar functions for working with DICOM tags. Tags can be
+    created in several ways:
+    
+    CREATE TABLE dicom_tags_test (id INTEGER, tag DICOM_TAG);
+    INSERT INTO dicom_tags_test VALUES (1, {'group': '0x0008', 'elem': '0x012D'});
+
+    INSERT INTO dicom_tags_test
+    VALUES
+      (1, '0008,0008'),
+      (2, '8,8'),
+      (3, '0008,012D'),
+      (4, '8,12D'),
+      (5, '0008,012d'),
+      (6, '8,12d');
+
+    INSERT INTO dicom_tags_test
+    VALUES
+      (1, '00080008'),
+      (2, '0008012D'),
+      (3, '0008012d');
+
+    Extract the group number, element number, and keyword name from DICOM tags:
+
+    SELECT tag_group('0010,0010') AS group_id;
+    SELECT tag_element('0010,0020') AS element_id;
+    SELECT tag_name('0010,0010') AS tag_keyword;
+
+    Comprehensive example:
+
+    SELECT 
+        tag AS raw_tag,
+        tag_name(tag) AS keyword,
+        tag_group(tag) AS group_hex,
+        tag_element(tag) AS element_hex
+    FROM (
+        SELECT unnest(json_keys(dicom_content))::DICOM_TAG AS tag 
+        FROM read_dicom('/path/to/dicom_file.dcm')
+    );


### PR DESCRIPTION
Update the DICOM extension includes:

* Build the extension for DuckDB 1.5.3
* Add custom `DICOM_TAG` type and scalar functions to work with DICOM tags