### PR TITLE
webbed: bump to v2.1.1

### DIFF
--- a/extensions/webbed/description.yml
+++ b/extensions/webbed/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: webbed
   description: Comprehensive processing extension for web markup languages (XML and HTML) with SAX streaming for large files, intelligent schema inference, XPath-based data extraction, and HTML table parsing.
-  version: 2.1.0
+  version: 2.1.1
   language: C++
   build: cmake
   license: MIT
@@ -11,8 +11,8 @@ extension:
   vcpkg_commit: 68a1c387f660632f2f65cdb7e8cd093a08840e5d
 repo:
   github: teaguesterling/duckdb_webbed
-  andium: 3ccf005124491090a6e291a6cde2e848044e6992
-  ref: 3ccf005124491090a6e291a6cde2e848044e6992
+  andium: 98f27251d77a41723d40f539761a3f8ee462d0c0
+  ref: 98f27251d77a41723d40f539761a3f8ee462d0c0
 docs:
   docs_url: https://duckdb-webbed.readthedocs.io
   hello_world: |


### PR DESCRIPTION
Bumps `webbed` to v2.1.1.

- Fix `xml_to_json` emitting unescaped `"` and C0 control characters, producing malformed JSON (#78)
- Restore DuckDB `main` build compatibility (API drift)

Release: https://github.com/teaguesterling/duckdb_webbed/releases/tag/v2.1.1