### PR TITLE
Add tpch_rust community extension

### DIFF
--- a/extensions/tpch_rust/description.yml
+++ b/extensions/tpch_rust/description.yml
@@ -6,13 +6,13 @@ extension:
   build: cmake
   license: MIT
   requires_toolchains: "rust;python3"
-  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;linux_amd64_musl"
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;linux_amd64_musl;windows_amd64;windows_amd64_mingw;windows_amd64_rtools"
   maintainers:
     - guillesd
 
 repo:
   github: guillesd/duckdb-tpch-rust
-  ref: 4f0d6bfc13145ea01dbae051854e0a1518c2e4ce
+  ref: 997db7e13cd4342359ac3f215d20c63b434606da
 
 docs:
   hello_world: |

--- a/extensions/tpch_rust/description.yml
+++ b/extensions/tpch_rust/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: guillesd/duckdb-tpch-rust
-  ref: 23c5d63f09e320ed2b100dd9e2bbb30f27d4ce4e
+  ref: 4f0d6bfc13145ea01dbae051854e0a1518c2e4ce
 
 docs:
   hello_world: |

--- a/extensions/tpch_rust/description.yml
+++ b/extensions/tpch_rust/description.yml
@@ -1,0 +1,48 @@
+extension:
+  name: tpch_rust
+  description: Generate TPC-H data as DuckDB tables or Parquet files, powered by the pure-Rust tpchgen-rs generators
+  version: 0.1.0
+  language: Rust
+  build: cmake
+  license: MIT
+  requires_toolchains: "rust;python3"
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;linux_amd64_musl"
+  maintainers:
+    - guillesd
+
+repo:
+  github: guillesd/duckdb-tpch-rust
+  ref: 23c5d63f09e320ed2b100dd9e2bbb30f27d4ce4e
+
+docs:
+  hello_world: |
+    -- Stream a single TPC-H table as a DuckDB table function and materialize it:
+    CREATE TABLE lineitem AS FROM tpch(1, 'lineitem');
+
+    -- Or query generated rows directly without materializing:
+    SELECT count(*) FROM tpch(0.1, 'orders');
+
+    -- Get a ready-to-run load script for the full 8-table schema:
+    SELECT statement FROM tpch_load(1);
+
+    -- Write Parquet files to disk instead (optionally a subset of tables):
+    CALL tpch_gen(1, 'data', tables := ['lineitem', 'orders']);
+  extended_description: |
+    ## tpch_rust
+
+    A Rust DuckDB extension (built on the C-extension template) that generates
+    [TPC-H](https://www.tpc.org/tpch/) data using the pure-Rust
+    [`tpchgen-rs`](https://github.com/clflushopt/tpchgen-rs) generators. It offers two modes:
+
+    - **DuckDB tables** — `tpch(sf, 'table')` is a table function that streams the rows of a
+      single TPC-H table, so you can materialize it with `CREATE TABLE ... AS FROM tpch(...)`.
+      `tpch_load(sf)` returns a ready-to-run load script for the full 8-table schema.
+    - **Parquet files** — `tpch_gen(sf, output_dir, [tables])` writes Parquet files directly to
+      disk, with knobs for `compression`, `row_group_bytes`, and `parts` (output-file count).
+
+    Supported tables: `nation`, `region`, `part`, `supplier`, `partsupp`, `customer`, `orders`,
+    `lineitem`. Generation is parallelized across CPU cores and streamed in bounded batches, so
+    memory stays flat regardless of scale factor.
+
+    See the [project README](https://github.com/guillesd/duckdb-tpch-rust) for benchmarks and the
+    full set of parameters.


### PR DESCRIPTION
This PR adds **tpch_rust**, a Rust DuckDB extension (built on the C-extension template) that generates [TPC-H](https://www.tpc.org/tpch/) data using the pure-Rust [tpchgen-rs](https://github.com/clflushopt/tpchgen-rs) generators.

It offers two modes:

- **DuckDB tables** — `tpch(sf, 'table')` streams the rows of a single TPC-H table, so you can materialize it with `CREATE TABLE ... AS FROM tpch(...)`. `tpch_load(sf)` returns a ready-to-run load script for the full 8-table schema.
- **Parquet files** — `tpch_gen(sf, output_dir, [tables])` writes Parquet files directly to disk, with knobs for `compression`, `row_group_bytes`, and `parts` (output-file count).

Supported tables: `nation`, `region`, `part`, `supplier`, `partsupp`, `customer`, `orders`, `lineitem`. Generation is parallelized across CPU cores and streamed in bounded batches, so memory stays flat regardless of scale factor.

- Repo: https://github.com/guillesd/duckdb-tpch-rust
- Targets DuckDB v1.5.3 (`v1.5-variegata` ci-tools); local `duckdb-stable-build` and the sqllogic test suite pass.
- License: MIT

## Why another tpch generator?

Well, if you go to the tpchgen-rs repo, you will see the benchmarks. If you want to generate sf=1000 or larger, this is the way to get it done in a reasonable time. This extension just exposes that functionality to a DuckDB extension, which gives the possibility of writing the data directly to DuckDB or DuckLake.