### PR TITLE
raquet: 0.2.6

### DIFF
--- a/extensions/raquet/description.yml
+++ b/extensions/raquet/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: raquet
   description: "Raster analytics on Raquet files with QUADBIN spatial indexing, raster ingestion, and PostGIS-style functions"
-  version: 0.2.5
+  version: 0.2.6
   language: C++
   build: cmake
   license: Apache-2.0
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: jatorre/duckdb-raquet
-  ref: 4d2f66c08b295402aab566b016aa502c6e869bae
+  ref: e077a7c36f4527949cd5e36719cf4c81289d9d4b
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps **raquet** to **0.2.6**.

- `version`: 0.2.5 → 0.2.6
- `ref`: `4d2f66c` → `e077a7c` (jatorre/duckdb-raquet@main)

### Changes since 0.2.5 (single commit, jatorre/duckdb-raquet#15)
Fixes a crash and a no-op overview path in `read_raster()`:

1. **`GDALAllRegister()` data race (crash fix).** Each parallel worker opened a per-thread GDAL handle and called `GDALAllRegister()`, which mutates the global driver manager and is not thread-safe — concurrent workers corrupted the heap (SIGTRAP in malloc) on larger rasters such as multi-overview YCbCr-JPEG COGs. Now guarded by `std::call_once`.

2. **COG overview fast path.** Phase 2 passed a non-existent `SRC_OVERVIEW_LEVEL` transformer option (silently ignored, re-warping every overview tile from base). Now selects the source overview via the `OVERVIEW_LEVEL` open option, reading the small overview directly.

Verified on a 58112×38400 YCbCr-JPEG COG: no crash at any zoom, correct RGB decode, full test suite green (352 assertions). Upstream CI (Linux + macOS) passed on the merged commit.