### PR TITLE
duck_tails: bump to v1.4.2

### DIFF
--- a/extensions/duck_tails/description.yml
+++ b/extensions/duck_tails/description.yml
@@ -6,7 +6,7 @@ extension:
   build: cmake
   license: MIT
   requires_toolchains: vcpkg
-  excluded_platforms: wasm_mvp;wasm_eh;wasm_threads
+  excluded_platforms: wasm_mvp;wasm_eh;wasm_threads;windows_amd64;windows_amd64_mingw
   maintainers:
     - teaguesterling
 repo:

--- a/extensions/duck_tails/description.yml
+++ b/extensions/duck_tails/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duck_tails
   description: Smart Development Intelligence for DuckDB - Git-aware data analysis capabilities that allow querying git history, accessing files at any revision, and performing version-aware data analysis with SQL.
-  version: 1.4.1
+  version: 1.4.2
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
     - teaguesterling
 repo:
   github: teaguesterling/duck_tails
-  ref: dca8ff3b3f5d423beb474c11349b547c88e99e70
+  ref: db69b5579ccf46cab8208587e6a59f54cb5f224f
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps `duck_tails` to v1.4.2.

- DuckDB v1.5.3 / main build compatibility (adopts the fleet compat pattern). Restores availability for the v1.5.3 build, which the previous ref (v1.4.1) couldn't compile against.

Repo: https://github.com/teaguesterling/duck_tails (ref `db69b55`)