### PR TITLE
harbor: bump to v0.3.2

### DIFF
--- a/extensions/harbor/description.yml
+++ b/extensions/harbor/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: harbor
-  description: Multi-protocol HTTP service (Quack RPC, JSON SQL, DuckDB UI, admin) for DuckDB on a single port
-  version: 0.2.1
+  description: Client/server DuckDB over one HTTP port — web UI, JSON /sql, and native ATTACH (TYPE harbor)
+  version: 0.3.2
   language: C++
   build: cmake
   license: MIT
@@ -10,13 +10,14 @@ extension:
 
 repo:
   github: shreeve/duckdb-harbor
-  ref: b189a546c0f3a87988c32e5fbaf3995bc01df0e7
+  ref: eebb64406bb2a1f77c8262eabc36285ef976e676
 
 docs:
   hello_world: |
     -- Load the extension and start the server in the background.
-    -- harbor_serve returns immediately; harbor_wait keeps the process
-    -- alive in daemon mode (containers, systemd).
+    -- harbor_serve returns once the server is accepting connections;
+    -- harbor_wait keeps the process alive in daemon mode (containers,
+    -- systemd).
     LOAD harbor;
     CALL harbor_serve(bind := '127.0.0.1', port := 9494);
     --                                                  ┌─────────────────────────────────┐
@@ -39,42 +40,45 @@ docs:
     -- page asks for the token once, sets a HttpOnly SameSite=Strict
     -- cookie, then proxies the official DuckDB UI through.
 
-    -- A second DuckDB process can attach via the Quack RPC protocol:
-    --   ATTACH 'quack:127.0.0.1:9494' AS h (SECRET <bearer-secret>);
-    --   SELECT * FROM h.main.t;
+    -- A second DuckDB attaches the server's catalog natively — catalog
+    -- discovery and table scans both ride /sql, so multi-table JOINs,
+    -- projection pushdown, and CLI autocomplete all work:
+    --   LOAD harbor;
+    --   ATTACH 'harbor:127.0.0.1:9494' AS h (TYPE harbor, TOKEN '<token>');
+    --   SELECT * FROM h.main.orders o JOIN h.main.customers c USING (customer_id);
 
     -- Stop the server:
     CALL harbor_stop();
 
   extended_description: |
     `harbor` is a single DuckDB extension. When loaded, your DuckDB
-    instance turns into a multi-protocol HTTP service on one port:
+    instance turns into a client/server database on one HTTP port:
 
-    | Surface     | Endpoints                              | What it gives you                                                         |
-    |-------------|----------------------------------------|---------------------------------------------------------------------------|
-    | Quack RPC   | `POST /quack`                          | Wire-compat with stock `duckdb-quack` clients (`ATTACH 'quack:host'`)     |
-    | JSON SQL    | `POST /sql`, `/sql/sessions/*`         | NDJSON streaming + one-shot JSON, prepared params (incl. `LIST`/`STRUCT`/`MAP`), principal-owned sessions, `harbor_query_timeout_s` enforcement |
-    | DuckDB UI   | `GET /`, `/ddb/*`, `/localEvents`      | Cookie-gated proxy to the official DuckDB UI; CSP+nonce on the login page |
-    | Admin       | `/health`, `/whoami`, `/tables`, `/schema/:db/:t`, `/checkpoint`, `/sessions`, `/interrupt` | Centralized `__HARBOR_ADMIN__:resource:action` default-deny + `harbor_allow_admin_without_authz` operator opt-in |
-    | Auth        | `/auth/login`, `/auth/logout`          | Bearer / X-Harbor-Token / HMAC-signed `harbor_session` cookie             |
+    | Surface       | Endpoints                              | What it gives you                                                         |
+    |---------------|----------------------------------------|---------------------------------------------------------------------------|
+    | JSON SQL      | `POST /sql`, `/sql/sessions/*`         | NDJSON streaming + one-shot JSON, prepared params (incl. `LIST`/`STRUCT`/`MAP`), principal-owned sessions, `harbor_query_timeout_s` enforcement |
+    | Native attach | client-side `ATTACH 'harbor:host' (TYPE harbor)` | Browse and query the server's catalog from any DuckDB — multi-table JOINs, projection pushdown, and CLI autocomplete; catalog + scans both ride `/sql` (read-only) |
+    | DuckDB UI     | `GET /`, `/ddb/*`, `/localEvents`      | Cookie-gated proxy to the official DuckDB UI; CSP+nonce on the login page |
+    | Admin         | `/health`, `/whoami`, `/tables`, `/schema/:db/:t`, `/checkpoint`, `/sessions`, `/interrupt` | Centralized `__HARBOR_ADMIN__:resource:action` default-deny + `harbor_allow_admin_without_authz` operator opt-in |
+    | Auth          | `/auth/login`, `/auth/logout`          | Bearer / X-Harbor-Token / HMAC-signed `harbor_session` cookie             |
 
     All on the same port, against the same in-process DuckDB, with the
     same session pool and auth model.
 
     **Use cases:**
-    - Operate one DuckDB process and let users hit it via whatever interface
-      fits their tool: notebook (UI), REPL (Quack), backend code (`/sql`).
+    - Operate one DuckDB process and let users hit it via whatever
+      interface fits their tool: browser (UI), DuckDB CLI/clients
+      (`ATTACH ... TYPE harbor`), backend code (`/sql`).
     - Bridge between SQL clients and apps without standing up a separate
       database server.
     - Container-native deployments — `harbor_wait()` blocks until SIGTERM
       so harbor runs cleanly under systemd / Docker / Kubernetes.
 
-    **Status:** v0.2 release, tested across the DuckDB community-extension
+    **Status:** v0.3 release, tested across the DuckDB community-extension
     matrix (linux_amd64/arm64, osx_amd64/arm64, windows_amd64/_mingw,
     wasm_mvp/eh/threads).
 
     Source, design spec, contributor guide, full release notes:
     [github.com/shreeve/duckdb-harbor](https://github.com/shreeve/duckdb-harbor).
 
-    Tracks upstream `duckdb-quack` `v1.5-variegata` and `duckdb-ui`;
-    targets DuckDB v1.5.3.
+    Vendors the official `duckdb-ui`; targets DuckDB v1.5.3.


### PR DESCRIPTION
## Summary

Updates the `harbor` extension from v0.2.1 to **v0.3.2** ([release notes](https://github.com/shreeve/duckdb-harbor/releases/tag/v0.3.2)).

- `version: 0.2.1 → 0.3.2`, `ref → eebb64406bb2a1f77c8262eabc36285ef976e676` (the `v0.3.2` tag commit; the tag sits **alone** on its commit, avoiding the multi-tag `EXT_VERSION` resolution issue previously hit in the deploy workflow).
- Description and docs refreshed: as of v0.3.0, harbor's Quack RPC endpoint and `TYPE quack` client were **removed** in favor of a native `ATTACH 'harbor:host' (TYPE harbor)` — catalog discovery and table scans both ride the JSON `/sql` endpoint, so multi-table JOINs, projection pushdown, and DuckDB CLI autocomplete all work against a plain token-authenticated server.
- `hello_world` updated accordingly.

Since v0.2.1, notable hardening relevant to this repo's CI: an intermittent `harbor_serve`→`harbor_stop` shutdown race (cpp-httplib `stop()` no-ops before the accept loop is running) was root-caused and fixed in v0.3.2 — the extension's sqllogictest suite has since passed 3 consecutive full 9-target matrix runs (including macOS arm64, where the race used to bite).

All 9 community-extension platforms (linux_amd64/arm64, osx_amd64/arm64, windows_amd64/_mingw, wasm_mvp/eh/threads) build and test green on the pinned ref in the [upstream repo's CI](https://github.com/shreeve/duckdb-harbor/actions).

## Test plan

- [x] Upstream CI green on `eebb644` across all 9 targets (build + sqllogictest, 90 assertions incl. a live `TYPE harbor` attach roundtrip)
- [ ] This repo's CI builds `harbor` from the pinned ref