### PR TITLE
Update bvh2sql source ref

### DIFF
--- a/extensions/bvh2sql/description.yml
+++ b/extensions/bvh2sql/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: nkwork9999/bvh2sql
-  ref: 774970fb7897a1ae0251a62771d8a96bba26ba7f
+  ref: 774970f749ccab7a6e37271363882549e6d0e2f3
 
 docs:
   hello_world: |

--- a/extensions/bvh2sql/description.yml
+++ b/extensions/bvh2sql/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: nkwork9999/bvh2sql
-  ref: 1253d336b3fd7597e40d1fbed3721862ce2895b2
+  ref: 857e1042a180de4ad38ddc35d6fe912ef6f9a31e
 
 docs:
   hello_world: |

--- a/extensions/bvh2sql/description.yml
+++ b/extensions/bvh2sql/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: nkwork9999/bvh2sql
-  ref: b72eec2566c7d8f361f471d81feede4caf8e39e4
+  ref: 1253d336b3fd7597e40d1fbed3721862ce2895b2
 
 docs:
   hello_world: |

--- a/extensions/bvh2sql/description.yml
+++ b/extensions/bvh2sql/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: nkwork9999/bvh2sql
-  ref: 3165db705c974ccdc85430d3f6f901bd34b72e71
+  ref: 774970fb7897a1ae0251a62771d8a96bba26ba7f
 
 docs:
   hello_world: |

--- a/extensions/bvh2sql/description.yml
+++ b/extensions/bvh2sql/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: nkwork9999/bvh2sql
-  ref: 857e1042a180de4ad38ddc35d6fe912ef6f9a31e
+  ref: 3165db705c974ccdc85430d3f6f901bd34b72e71
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary

Update `bvh2sql` source ref:

- `bvh2sql`: `b72eec2` -> `1253d33`

`pic2vec` is split into a separate PR because the community-extensions build script only accepts one changed descriptor per PR. `duckorch` is intentionally handled separately in #2049.
