### PR TITLE
H5db, minor wording change to rerun deploy workflow

### DIFF
--- a/extensions/h5db/description.yml
+++ b/extensions/h5db/description.yml
@@ -34,4 +34,4 @@ docs:
     - Remote reads over SFTP via a built-in SFTP client.
     - Globbing: Combine datasets from multiple files vertically (UNION ALL).
 
-    For full documentation, see: [https://github.com/jokasimr/h5db](https://github.com/jokasimr/h5db).
+    For full documentation, see the [h5db repository](https://github.com/jokasimr/h5db).


### PR DESCRIPTION
As title says, this PR is only to let the deploy workflow rerun.
 
In the last run the workflow failed in the `build docker image` step: https://github.com/duckdb/community-extensions/actions/runs/27193945750/job/80285265282 with error `Failed to download metadata for repo 'epel'`.

I don't know what caused the previous failure, but because it occurred so early in the pipeline I assume it did not have to do with the extension itself.