### PR TITLE
Update duckorch extension ref

### DIFF
--- a/extensions/duckorch/description.yml
+++ b/extensions/duckorch/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: nkwork9999/duck-orch
-  ref: dbde74853768e47d753534c35d9853f99e28b769
+  ref: 46ed9a5ee299034763aecb87fd511affbcc5577f
 
 docs:
   hello_world: |

--- a/extensions/duckorch/description.yml
+++ b/extensions/duckorch/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: nkwork9999/duck-orch
-  ref: 23251ff62e25b04ea04fdb1916a764c285e75e7a
+  ref: d5fd7e076d237a0d912ac0f6cedafe244f1c7ac7
 
 docs:
   hello_world: |

--- a/extensions/duckorch/description.yml
+++ b/extensions/duckorch/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: nkwork9999/duck-orch
-  ref: 46ed9a5ee299034763aecb87fd511affbcc5577f
+  ref: 23251ff62e25b04ea04fdb1916a764c285e75e7a
 
 docs:
   hello_world: |

--- a/extensions/duckorch/description.yml
+++ b/extensions/duckorch/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: nkwork9999/duck-orch
-  ref: ede922bb469032483ac4a14410ef09d600a7cf6a
+  ref: dbde74853768e47d753534c35d9853f99e28b769
 
 docs:
   hello_world: |


### PR DESCRIPTION
Updates duckorch to nkwork9999/duck-orch@dbde74853768e47d753534c35d9853f99e28b769, which includes the merged SQLMesh-style on_interval interval tracking implementation.\n\nValidated locally in duck-orch with:\n- cargo test --workspace\n- make release -j1\n- load/register/sensor smoke for on_interval and orch_restate