### PR TITLE
webbed: bump to v2.2.0

### DIFF
--- a/extensions/webbed/description.yml
+++ b/extensions/webbed/description.yml
@@ -11,8 +11,8 @@ extension:
   vcpkg_commit: 68a1c387f660632f2f65cdb7e8cd093a08840e5d
 repo:
   github: teaguesterling/duckdb_webbed
-  andium: 1b44015bc7d0567e27d2cd4ef4a23c57607099be
-  ref: 1b44015bc7d0567e27d2cd4ef4a23c57607099be
+  andium: 465b37b04ee974d958e5a0b7559814b84f9f373b
+  ref: 465b37b04ee974d958e5a0b7559814b84f9f373b
 docs:
   docs_url: https://duckdb-webbed.readthedocs.io
   hello_world: |

--- a/extensions/webbed/description.yml
+++ b/extensions/webbed/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: webbed
   description: Comprehensive processing extension for web markup languages (XML and HTML) with SAX streaming for large files, intelligent schema inference, XPath-based data extraction, and HTML table parsing.
-  version: 2.1.1
+  version: 2.2.0
   language: C++
   build: cmake
   license: MIT
@@ -11,8 +11,8 @@ extension:
   vcpkg_commit: 68a1c387f660632f2f65cdb7e8cd093a08840e5d
 repo:
   github: teaguesterling/duckdb_webbed
-  andium: 98f27251d77a41723d40f539761a3f8ee462d0c0
-  ref: 98f27251d77a41723d40f539761a3f8ee462d0c0
+  andium: 1b44015bc7d0567e27d2cd4ef4a23c57607099be
+  ref: 1b44015bc7d0567e27d2cd4ef4a23c57607099be
 docs:
   docs_url: https://duckdb-webbed.readthedocs.io
   hello_world: |

--- a/extensions/webbed/description.yml
+++ b/extensions/webbed/description.yml
@@ -6,6 +6,9 @@ extension:
   build: cmake
   license: MIT
   requires_toolchains: vcpkg
+  # Windows excluded: DuckDB's vendored fmt fails to compile against the community runner's
+  # current MSVC STL (stdext::checked_array_iterator removed); not fixable from the extension.
+  excluded_platforms: windows_amd64;windows_amd64_mingw
   maintainers:
     - teaguesterling
   vcpkg_commit: 68a1c387f660632f2f65cdb7e8cd093a08840e5d


### PR DESCRIPTION
Bumps `webbed` to v2.2.0, primarily the work of @bendrucker.

Security & robustness release: vector memory-safety, markup-injection guards (`xml_wrap_fragment`, `to_xml`), a `read_xml` memory-disclosure fix, `duck_blocks_to_html` DoS hardening, a concurrency validity fix, libxml2 OOM-vs-invalid-XML handling, `parse_html` whitespace/CDATA correctness, five `read_xml` schema-inference fixes, and DuckDB `main` compatibility.

Release: https://github.com/teaguesterling/duckdb_webbed/releases/tag/v2.2.0