### PR TITLE
Add duck_diff extension (v0.3.0)

### DIFF
--- a/extensions/duck_diff/description.yml
+++ b/extensions/duck_diff/description.yml
@@ -1,0 +1,75 @@
+extension:
+  name: duck_diff
+  description: Diff two relations (tables, queries) off a primary key, reporting per-key status (identical/different/left_only/right_only), a JSON summary of changed columns, and per-column left/right values.
+  version: 0.3.0
+  language: C++
+  build: cmake
+  license: MIT
+  maintainers:
+    - avaitla
+
+repo:
+  github: avaitla/duck_diff
+  ref: fae4c5ca4a28a3074f73746e69ec203ddd489308
+
+docs:
+  hello_world: |
+    LOAD duck_diff;
+
+    -- Create two sample snapshots
+    CREATE TABLE users_v1 AS SELECT * FROM (VALUES
+        (1, 'Ada',   'ada@x.com',   100),
+        (2, 'Linus', 'linus@x.com',  50),
+        (3, 'Grace', 'grace@x.com',  75)
+    ) t(id, name, email, credits);
+
+    CREATE TABLE users_v2 AS SELECT * FROM (VALUES
+        (1, 'Ada',   'ada@x.com',   120),   -- credits changed
+        (2, 'Linus', 'linus@x.com',  50),   -- unchanged
+        (4, 'Mike',  'mike@x.com',   10)    -- new (id 3 removed)
+    ) t(id, name, email, credits);
+
+    -- Diff them off the primary key
+    SELECT id, diff_status, diff_data, credits_left, credits_right
+    FROM table_diff('FROM users_v1', 'FROM users_v2', pk := 'id')
+    ORDER BY id;
+
+    -- Or get counts and percentages per status
+    SELECT * FROM table_diff_summary('FROM users_v1', 'FROM users_v2', pk := 'id');
+
+  extended_description: |
+    `duck_diff` diffs two relations off a primary key. Given a "left" and a "right" relation
+    (written as query strings, e.g. `'FROM orders'` or a full `SELECT ...`), it reports — per
+    key — whether the row is **identical**, **different**, or exists only on one side, and
+    exactly what changed. Each result row carries both a JSON `diff_data` summary of the
+    changed columns *and* per-column expanded columns (`<c>_left` / `<c>_right` /
+    `<c>_diff_status`). Composite primary keys and selecting a subset of columns to diff or
+    ignore are supported.
+
+    **Functions:**
+
+    | Function | Returns | Purpose |
+    |----------|---------|---------|
+    | `table_diff(left, right, pk := ...)` | table | one row per key: key column(s), `diff_status`, `diff_data`, expanded columns |
+    | `table_diff_summary(left, right, pk := ...)` | one row | counts (and percentages) per status |
+    | `schema_diff(left, right)` | table | per-column name/type comparison |
+
+    `table_diff` options include `numeric_tolerance` (treat numbers within a band as equal),
+    `timestamp_precision` (truncate timestamps before comparing), `null_equals_empty`,
+    `columns` / `ignore` (restrict or exclude compared columns), `context` (surface
+    non-compared columns alongside the diff), and `require_matching_columns` /
+    `upcast_types` for relations whose schemas don't match exactly.
+
+    Because each relation argument is a query string, any table function from another
+    extension works — diff CSV/Parquet files, or relations from attached databases
+    (Postgres, MySQL, BigQuery, ...) against each other.
+
+    **Use cases:**
+    - Refactoring SQL (possibly onto a new database) and verifying the results are identical
+    - Capturing the differences between snapshots or points in time
+    - Replication integrity — spot-check that a replica matches its source
+    - Regression tests in CI — assert a model's output still matches its golden snapshot
+    - Giving coding agents a ground-truth check that a refactor produced identical results
+
+    See the [function reference](https://github.com/avaitla/duck_diff/blob/main/docs/functions.md)
+    for full documentation.

--- a/extensions/duck_diff/description.yml
+++ b/extensions/duck_diff/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: avaitla/duck_diff
-  ref: fae4c5ca4a28a3074f73746e69ec203ddd489308
+  ref: 997489ab8f66fbe2edb2b84c57dc69b0e4fdb314
 
 docs:
   hello_world: |

--- a/extensions/duck_diff/description.yml
+++ b/extensions/duck_diff/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: avaitla/duck_diff
-  ref: 997489ab8f66fbe2edb2b84c57dc69b0e4fdb314
+  ref: 3f278772095f7abb1c67a7cd17e039cd48dee20c
 
 docs:
   hello_world: |


### PR DESCRIPTION
Adds the [duck_diff](https://github.com/avaitla/duck_diff) extension.

`duck_diff` diffs two relations (tables, queries) off a primary key. For each key it reports whether the row is identical, different, or exists only on one side, with both a JSON `diff_data` summary of the changed columns and expanded per-column `<c>_left` / `<c>_right` / `<c>_diff_status` columns. Includes `table_diff`, `table_diff_summary`, and `schema_diff` functions, with options for numeric tolerance, timestamp precision, column subsets, and composite keys.

- Language: C++ (extension template)
- Build: cmake
- License: MIT
- Pinned ref: `3f278772095f7abb1c67a7cd17e039cd48dee20c` (v0.3.0)