### PR TITLE
anofox_statistics: bump ref to v0.4.2-post-#87 (Huber + RANSAC + Theil-Sen, v1.5.3 support)

### DIFF
--- a/extensions/anofox_statistics/description.yml
+++ b/extensions/anofox_statistics/description.yml
@@ -1,6 +1,6 @@
 extension:
   name: anofox_statistics
-  description: A DuckDB extension for statistical regression analysis, providing OLS, Ridge, WLS, and time-series regression capabilities with complete diagnostics and inference directly in SQL.
+  description: A DuckDB extension for statistical regression analysis, providing OLS, Ridge, Elastic Net, WLS, recursive least squares, robust estimators (Huber, RANSAC, Theil-Sen), GLMs, and time-series regression with full diagnostics and inference directly in SQL.
   language: C++
   build: cmake
   license: BSL 1.1
@@ -9,4 +9,4 @@ extension:
   requires_toolchains: rust
 repo:
   github: DataZooDE/anofox-statistics
-  ref: 24403aeb0eb511273a9d885147aa38c67c2c2ea7
+  ref: 606775851e1c3f8ddf3cf975b1ff377101991f99


### PR DESCRIPTION
Refreshes \`anofox_statistics\`'s pinned commit so the community-extensions build picks up everything shipped since the original submission (commit \`24403ae\`, 2026-06-04). The previous pin was only ever built against DuckDB v1.4.4 because v1.5.3 wasn't in the build matrix at submission time; v1.5.3 has since been added (other extensions show this), but \`anofox_statistics\` was never rebuilt because \`description.yml\` didn't change. Users on DuckDB v1.5.3 currently hit:

\`\`\`
HTTP Error: Failed to download extension "anofox_statistics" at URL
"http://community-extensions.duckdb.org/v1.5.3/linux_amd64/anofox_statistics.duckdb_extension.gz" (HTTP 404)
\`\`\`

## What this bump pulls in

- **\`anofox-regression\` 0.5.7** ([sipemu/anofox-regression#20](https://github.com/sipemu/anofox-regression/issues/20)) — replaces \`is_multiple_of\` with \`n % 2 == 0\` in \`solvers/huber.rs\` and \`solvers/ransac.rs\` (the unstable-feature workaround that unblocks wasm32 and Rust < 1.87 builds, including the toolchain pinned in \`duckdb/extension-ci-tools\`).
- **Huber M-estimator robust regression** — scalar \`huber_fit\`, aggregate \`huber_fit_agg\` (with MAD scale + outlier mask), \`huber_fit_predict_agg\`, window function \`huber_fit_predict\`, and table macro \`huber_fit_predict_by\`. (anofox-statistics #67 / #69 / #70 / #71 / #72 / #73.)
- **RANSAC robust regression** — same five SQL surfaces; aggregate result surfaces \`residual_threshold\`, \`n_inliers\`, \`n_trials\`. (#74 / #75 / #76 / #77 / #78.)
- **Theil-Sen robust regression** — same five SQL surfaces. (#79 / #80 / #81 / #82 / #83.)

## Other change

The \`description\` text is updated to reflect the wider estimator catalogue (Elastic Net, RLS, robust estimators, GLMs).

## Verified

- \`cargo test --release --workspace\` — 156/156 (4 Huber + 4 RANSAC + 4 Theil-Sen + the pre-existing 144).
- \`cargo clippy --all-targets --all-features --release -- -D warnings\` clean.
- \`cargo fmt --all -- --check\` clean.
- v1.5.3 linux_amd64 build green on our own CI; the artifact deployed to \`get.erpl.io\` installs and loads successfully on DuckDB v1.5.3.

After this lands, \`INSTALL anofox_statistics FROM community; LOAD anofox_statistics;\` should work on DuckDB v1.5.3 the same way it currently works on v1.4.4.