### PR TITLE
Update pic2vec source ref

### DIFF
--- a/extensions/pic2vec/description.yml
+++ b/extensions/pic2vec/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: nkwork9999/pic2vec
-  ref: 674180718b5b4e63cf97288d71c4357d179b45c8
+  ref: 113ee24b4e48419e4d56dd3b4e8b0f49e9d184ee
 
 docs:
   hello_world: |

--- a/extensions/pic2vec/description.yml
+++ b/extensions/pic2vec/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: nkwork9999/pic2vec
-  ref: 97059943d85becdaf1076e0a7364b14efda0af17
+  ref: 81c15d5a1329cbde7b749d545c640ac135cacff8
 
 docs:
   hello_world: |

--- a/extensions/pic2vec/description.yml
+++ b/extensions/pic2vec/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: nkwork9999/pic2vec
-  ref: 81c15d5a1329cbde7b749d545c640ac135cacff8
+  ref: 674180718b5b4e63cf97288d71c4357d179b45c8
 
 docs:
   hello_world: |


### PR DESCRIPTION
Update pic2vec source ref
- pic2vec: 9705994 -> 81c15d5
- Split from #2045 because the community-extensions build workflow accepts one changed descriptor per PR.