### PR TITLE
ducksmiles: bump to 0.5.0

### DIFF
--- a/extensions/ducksmiles/description.yml
+++ b/extensions/ducksmiles/description.yml
@@ -1,6 +1,6 @@
 extension:
   name: ducksmiles
-  description: Cheminformatics toolkit for DuckDB - SMILES, InChI, MOL/SDF, PDB, SELFIES, descriptors (LogP, MolMR, TPSA, QED, ring counts), Morgan/MACCS fingerprints, and a full bit-fingerprint similarity family from SQL
+  description: Cheminformatics toolkit for DuckDB - SMILES, InChI, MOL/SDF, PDB, SELFIES; descriptors (LogP, TPSA, QED), Morgan/MACCS fingerprints + similarity, drug-likeness/toxicophore filters, and a native in-silico docking pipeline, from SQL
   version: 0.5.0
   language: C++
   build: cmake
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: nkwork9999/duckSMILES
-  ref: 5eb627da5eb04d65606eece67d96620119c9be4e
+  ref: 96c85cc2c895e5fdaecb3e2e30009d1201fa5103
 
 docs:
   hello_world: |
@@ -30,22 +30,24 @@ docs:
     SELECT round(qed('CC(=O)Oc1ccccc1C(=O)O'), 3);
     -- 0.550   (aspirin)
 
-    -- Ring-count descriptors (RDKit rdMolDescriptors)
-    SELECT num_aromatic_heterocycles('c1ccncc1'), num_saturated_carbocycles('C1CCCCC1');
-    -- 1, 1
+    -- Drug-likeness rule panels + toxicophore alerts
+    SELECT lipinski_violations('CC(=O)Oc1ccccc1C(=O)O'),
+           druglikeness_pass('CC(=O)Oc1ccccc1C(=O)O', 'veber'),
+           structural_alerts_json('O=Cc1ccccc1');
+    -- 0, 1, ["aldehyde","aldehyde_any"]
 
-    -- Morgan/ECFP fingerprint as 2048-bit BLOB (ECFP4 default)
-    SELECT bit_count(CAST(morgan_fp_bits('CC(=O)Oc1ccccc1C(=O)O') AS BIT));
-    -- 26   (aspirin popcount)
+    -- Morgan/ECFP fingerprint + similarity between two BLOBs
+    SELECT round(tanimoto_bit(morgan_fp_bits('CCO'), morgan_fp_bits('CCN')), 4);
+    -- 0.3333
 
-    -- Similarity between two fingerprint BLOBs: Tanimoto, Dice, Tversky, ...
-    SELECT round(tanimoto_bit(morgan_fp_bits('CCO'), morgan_fp_bits('CCN')), 4),
-           round(dice_bit(morgan_fp_bits('CCO'), morgan_fp_bits('CCN')), 4);
-    -- 0.3333, 0.5000
+    -- In-silico docking: SMILES ligand vs PDB receptor -> ranked poses (JSON)
+    SELECT dock('CCO', :receptor_pdb, 1.7,0.2,0.5, 8,8,8, 20, 42);
 
-    -- Validate and extract InChI layers
-    SELECT inchi_formula('InChI=1S/C2H4O2/c1-2(3)4/h1H3,(H,3,4)');
-    -- C2H4O2
+    -- Retrospective virtual-screening enrichment over a docked, labelled library
+    SELECT roc_auc(list(score), list(is_active)),
+           enrichment_factor(list(score), list(is_active), 0.01),
+           bedroc(list(score), list(is_active), 20.0)
+    FROM docked_library;
 
     -- Convert SMILES to SELFIES (ML-friendly notation)
     SELECT smiles_to_selfies('CCO');
@@ -62,37 +64,46 @@ docs:
     - PDB/CIF/XYZ: protein structure analysis (atom, chain, residue, model counts)
     - SELFIES: bidirectional SMILES-SELFIES conversion for ML pipelines
 
-    **110+ scalar SQL functions** for molecular property extraction, format conversion,
-    structural comparison, fingerprinting, similarity search, and physicochemical /
-    drug-likeness prediction. Ideal for cheminformatics datasets, drug discovery
-    pipelines, and molecular ML feature engineering.
+    **130+ scalar SQL functions** for molecular property extraction, format conversion,
+    structural comparison, fingerprinting, similarity search, drug-likeness /
+    toxicophore filtering, and structure-based virtual screening.
 
     **Descriptors (RDKit-faithful ports):**
-    - `logp_crippen()` / `mol_mr()` - Wildman-Crippen LogP and molar refractivity from
-      a single 110-pattern atom-contribution table; match RDKit for small molecules.
-    - `tpsa()` - Ertl topological polar surface area (RDKit default scope).
-    - `qed()` - QED drug-likeness (Bickerton 2012), a port of RDKit `Chem.QED`. Maps
-      eight properties through asymmetric-double-sigmoidal desirability functions;
-      reproduces RDKit's reference values closely (paper molecules 0.253 / 0.234).
+    - `logp_crippen()` / `mol_mr()` - Wildman-Crippen LogP and molar refractivity.
+    - `tpsa()` - Ertl topological polar surface area.
+    - `qed()` - QED drug-likeness (Bickerton 2012), a port of RDKit `Chem.QED`.
     - Lipinski set: `num_h_donors()`, `num_h_acceptors()`, `num_rotatable_bonds()`,
-      `fraction_csp3()`, `num_heteroatoms()`.
-    - Ring counts: `num_aromatic_rings()`, `num_aliphatic_rings()`,
-      `num_saturated_rings()`, and the aromatic/saturated/aliphatic x
-      heterocycle/carbocycle splits.
+      `fraction_csp3()`, `num_heteroatoms()`, and the full ring-count descriptor family.
 
     **Fingerprints & similarity:**
-    - `morgan_fp_bits()` ports RDKit's MorganGenerator (layered BFS + hash_combine +
-      dead-atom dedup); ECFP4 / 2048-bit default, with a `(smi, radius, n_bits)` overload.
-    - `maccs_keys()` returns the 167-bit MACCS key vector.
-    - Full bit-fingerprint similarity family over raw BLOBs (no `CAST AS BIT` round-trip),
-      faithful to RDKit `DataStructs/BitOps.cpp`: `tanimoto_bit`, `dice_bit`, `cosine_bit`,
-      `kulczynski_bit`, `sokal_bit`, `mcconnaughey_bit`, `asymmetric_bit`,
-      `braun_blanquet_bit`, `russel_bit`, and asymmetric `tversky_bit(a, b, alpha, beta)`.
-      Mismatched lengths raise a clear `InvalidInputException`; empty-vs-empty returns
-      `0.0` (RDKit convention).
+    - `morgan_fp_bits()` (RDKit MorganGenerator, ECFP4 / 2048-bit default) and
+      `maccs_keys()` (167-bit MACCS).
+    - Full bit-fingerprint similarity family over raw BLOBs, faithful to RDKit
+      `DataStructs/BitOps.cpp`: `tanimoto_bit`, `dice_bit`, `cosine_bit`, `kulczynski_bit`,
+      `sokal_bit`, `mcconnaughey_bit`, `asymmetric_bit`, `braun_blanquet_bit`,
+      `russel_bit`, and asymmetric `tversky_bit(a, b, alpha, beta)`.
 
     **Structure tools:** SMARTS substructure search/counting, Bemis-Murcko and generic
     scaffolds, scaffold networks, ring-system extraction, maximum common substructure
     (MCS), and MolHash standardization.
 
-    **Architecture:** Rust (core logic, 5 crates) + C++ (DuckDB integration via FFI)
+    **Drug-likeness & toxicophore filtering:**
+    - `admet_json()` - a full report: descriptors plus six drug-likeness rule panels.
+    - `druglikeness_pass(smiles, rule)` for Lipinski, Veber, Ghose, Egan, Muegge and
+      Lead-likeness; `lipinski_violations()` for the Rule-of-Five count.
+    - `structural_alerts_json()` / `structural_alert_count()` over a curated
+      Brenk / PAINS reactive-group toxicophore catalogue.
+
+    **In-silico docking pipeline (structure-based virtual screening, end-to-end in SQL):**
+    - `smiles_to_pdbqt()` - 3D conformer generation (distance geometry + an L-BFGS-
+      minimised lite force field with aromatic-ring planarity) emitted as PDBQT.
+    - `prepare_receptor(pdb, ph)` - pH-dependent protonation states + polar-hydrogen
+      addition, so the receptor can donate H-bonds.
+    - `dock(smiles, pdb, cx, cy, cz, sx, sy, sz, n_runs, seed [, ph])` - flexible
+      torsion-tree docking with an AutoDock-Vina-style scoring function and 3D affinity
+      maps; returns ranked poses with coordinates as JSON.
+    - Retrospective-validation harness: `roc_auc`, `enrichment_factor(fraction)`,
+      `bedroc(alpha)` to measure how well a docked library enriches known actives.
+
+    **Architecture:** Rust (core logic, zero external chemistry crates) + C++ (DuckDB
+    integration via FFI).

--- a/extensions/ducksmiles/description.yml
+++ b/extensions/ducksmiles/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: ducksmiles
-  description: Cheminformatics toolkit for DuckDB - SMILES, InChI, MOL/SDF, PDB, SELFIES, Wildman-Crippen LogP, Morgan/ECFP fingerprints, and Tanimoto similarity from SQL
-  version: 0.4.0
+  description: Cheminformatics toolkit for DuckDB - SMILES, InChI, MOL/SDF, PDB, SELFIES, descriptors (LogP, MolMR, TPSA, QED, ring counts), Morgan/MACCS fingerprints, and a full bit-fingerprint similarity family from SQL
+  version: 0.5.0
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: nkwork9999/duckSMILES
-  ref: 51c796e9340e70c0ff8592771782916954fb4b08
+  ref: 6a66b485be14f3a6830ff82e9ff46ee1427cb92e
 
 docs:
   hello_world: |
@@ -22,17 +22,26 @@ docs:
     SELECT round(mol_weight('c1ccccc1'), 2);
     -- 78.11
 
-    -- Wildman-Crippen LogP (matches RDKit)
-    SELECT round(logp_crippen('CCO'), 4);
-    -- -0.0014
+    -- Wildman-Crippen LogP and molar refractivity (match RDKit)
+    SELECT round(logp_crippen('CCO'), 4), round(mol_mr('c1ccccc1'), 3);
+    -- -0.0014, 26.442
+
+    -- QED drug-likeness score (RDKit Chem.QED, weights_mean)
+    SELECT round(qed('CC(=O)Oc1ccccc1C(=O)O'), 3);
+    -- 0.550   (aspirin)
+
+    -- Ring-count descriptors (RDKit rdMolDescriptors)
+    SELECT num_aromatic_heterocycles('c1ccncc1'), num_saturated_carbocycles('C1CCCCC1');
+    -- 1, 1
 
     -- Morgan/ECFP fingerprint as 2048-bit BLOB (ECFP4 default)
     SELECT bit_count(CAST(morgan_fp_bits('CC(=O)Oc1ccccc1C(=O)O') AS BIT));
     -- 26   (aspirin popcount)
 
-    -- Tanimoto similarity between two fingerprint BLOBs (no CAST AS BIT needed)
-    SELECT round(tanimoto_bit(morgan_fp_bits('CCO'), morgan_fp_bits('CCN')), 4);
-    -- 0.3333
+    -- Similarity between two fingerprint BLOBs: Tanimoto, Dice, Tversky, ...
+    SELECT round(tanimoto_bit(morgan_fp_bits('CCO'), morgan_fp_bits('CCN')), 4),
+           round(dice_bit(morgan_fp_bits('CCO'), morgan_fp_bits('CCN')), 4);
+    -- 0.3333, 0.5000
 
     -- Validate and extract InChI layers
     SELECT inchi_formula('InChI=1S/C2H4O2/c1-2(3)4/h1H3,(H,3,4)');
@@ -47,32 +56,43 @@ docs:
     library dependencies (no RDKit required).
 
     **Supported Formats:**
-    - SMILES: Molecular validation, formula, weight, atom/bond counts, LogP
-    - InChI/InChIKey: Layer extraction, stereochemistry detection, skeleton matching
-    - MOL/SDF: V2000/V3000 block parsing, molecule counting
-    - PDB/CIF/XYZ: Protein structure analysis (atom, chain, residue, model counts)
-    - SELFIES: Bidirectional SMILES-SELFIES conversion for ML pipelines
+    - SMILES: validation, formula, weight, atom/bond counts, canonicalization, aromaticity
+    - InChI/InChIKey: layer extraction, stereochemistry detection, skeleton matching
+    - MOL/SDF: V2000/V3000 block parsing, 3D geometry, molecule counting
+    - PDB/CIF/XYZ: protein structure analysis (atom, chain, residue, model counts)
+    - SELFIES: bidirectional SMILES-SELFIES conversion for ML pipelines
 
-    **39 scalar SQL functions** for molecular property extraction, format conversion,
-    structural comparison, and physicochemical property prediction. Ideal for
-    cheminformatics datasets, drug discovery pipelines, and molecular ML feature
-    engineering.
+    **110+ scalar SQL functions** for molecular property extraction, format conversion,
+    structural comparison, fingerprinting, similarity search, and physicochemical /
+    drug-likeness prediction. Ideal for cheminformatics datasets, drug discovery
+    pipelines, and molecular ML feature engineering.
 
-    **LogP:** `logp_crippen()` implements the Wildman-Crippen atom-contribution
-    method (110 SMARTS patterns, 68 atom types) and matches RDKit's
-    `Crippen.MolLogP` exactly for small molecules.
+    **Descriptors (RDKit-faithful ports):**
+    - `logp_crippen()` / `mol_mr()` - Wildman-Crippen LogP and molar refractivity from
+      a single 110-pattern atom-contribution table; match RDKit for small molecules.
+    - `tpsa()` - Ertl topological polar surface area (RDKit default scope).
+    - `qed()` - QED drug-likeness (Bickerton 2012), a port of RDKit `Chem.QED`. Maps
+      eight properties through asymmetric-double-sigmoidal desirability functions;
+      reproduces RDKit's reference values closely (paper molecules 0.253 / 0.234).
+    - Lipinski set: `num_h_donors()`, `num_h_acceptors()`, `num_rotatable_bonds()`,
+      `fraction_csp3()`, `num_heteroatoms()`.
+    - Ring counts: `num_aromatic_rings()`, `num_aliphatic_rings()`,
+      `num_saturated_rings()`, and the aromatic/saturated/aliphatic x
+      heterocycle/carbocycle splits.
 
-    **Morgan / ECFP fingerprint:** `morgan_fp_bits()` ports RDKit's MorganGenerator
-    (layered BFS + hash_combine + dead-atom dedup) to Rust and returns a fixed-width
-    bit vector as `BLOB`. Defaults to ECFP4 (radius=2, 2048 bit); 3-arg overload
-    `morgan_fp_bits(smi, radius, n_bits)` exposes full control.
+    **Fingerprints & similarity:**
+    - `morgan_fp_bits()` ports RDKit's MorganGenerator (layered BFS + hash_combine +
+      dead-atom dedup); ECFP4 / 2048-bit default, with a `(smi, radius, n_bits)` overload.
+    - `maccs_keys()` returns the 167-bit MACCS key vector.
+    - Full bit-fingerprint similarity family over raw BLOBs (no `CAST AS BIT` round-trip),
+      faithful to RDKit `DataStructs/BitOps.cpp`: `tanimoto_bit`, `dice_bit`, `cosine_bit`,
+      `kulczynski_bit`, `sokal_bit`, `mcconnaughey_bit`, `asymmetric_bit`,
+      `braun_blanquet_bit`, `russel_bit`, and asymmetric `tversky_bit(a, b, alpha, beta)`.
+      Mismatched lengths raise a clear `InvalidInputException`; empty-vs-empty returns
+      `0.0` (RDKit convention).
 
-    **Tanimoto similarity:** `tanimoto_bit(BLOB, BLOB) -> DOUBLE` computes
-    `popcount(a & b) / popcount(a | b)` directly on raw BLOB bytes (no
-    `CAST AS BIT` round-trip), processing 8 bytes at a time via `count_ones()`
-    so it lowers to POPCNT on x86_64 / CNT on aarch64. Mismatched lengths raise
-    a clear `InvalidInputException`; empty-vs-empty returns `0.0` (RDKit
-    convention). The SQL-level `bit_count(a & b)::DOUBLE / bit_count(a | b)`
-    is still available and produces bit-exact identical results.
+    **Structure tools:** SMARTS substructure search/counting, Bemis-Murcko and generic
+    scaffolds, scaffold networks, ring-system extraction, maximum common substructure
+    (MCS), and MolHash standardization.
 
     **Architecture:** Rust (core logic, 5 crates) + C++ (DuckDB integration via FFI)

--- a/extensions/ducksmiles/description.yml
+++ b/extensions/ducksmiles/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: nkwork9999/duckSMILES
-  ref: 6a66b485be14f3a6830ff82e9ff46ee1427cb92e
+  ref: 5eb627da5eb04d65606eece67d96620119c9be4e
 
 docs:
   hello_world: |

--- a/extensions/ducksmiles/description.yml
+++ b/extensions/ducksmiles/description.yml
@@ -4,13 +4,14 @@ extension:
   version: 0.5.0
   language: C++
   build: cmake
+  requires_toolchains: rust
   license: MIT
   maintainers:
     - nkwork9999
 
 repo:
   github: nkwork9999/duckSMILES
-  ref: 96c85cc2c895e5fdaecb3e2e30009d1201fa5103
+  ref: 3b5940d3189ec1cf999e96359685cd98e2a74225
 
 docs:
   hello_world: |
@@ -69,6 +70,11 @@ docs:
     toxicophore filtering, and structure-based virtual screening.
 
     **Descriptors (RDKit-faithful ports):**
+    - 21 structural-profile functions: fragments, formal charge, hydrogen and
+      bond counts, ring membership, elemental counts, fractions, isotope-aware
+      heavy-atom mass and mean heavy-atom degree. A pinned RDKit 2025.09.6
+      reference suite checks 4,510 inputs; this is finite-corpus validation,
+      not a guarantee of full RDKit parser/sanitizer equivalence.
     - `logp_crippen()` / `mol_mr()` - Wildman-Crippen LogP and molar refractivity.
     - `tpsa()` - Ertl topological polar surface area.
     - `qed()` - QED drug-likeness (Bickerton 2012), a port of RDKit `Chem.QED`.

--- a/extensions/ducksmiles/description.yml
+++ b/extensions/ducksmiles/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: nkwork9999/duckSMILES
-  ref: 3b5940d3189ec1cf999e96359685cd98e2a74225
+  ref: 84f2ce56eaedcf57638bba3a6afa73a68c455869
 
 docs:
   hello_world: |
@@ -82,8 +82,9 @@ docs:
       `fraction_csp3()`, `num_heteroatoms()`, and the full ring-count descriptor family.
 
     **Fingerprints & similarity:**
-    - `morgan_fp_bits()` (RDKit MorganGenerator, ECFP4 / 2048-bit default) and
-      `maccs_keys()` (167-bit MACCS).
+    - `morgan_fp_bits()` (Morgan/ECFP-style, radius 2 / 2048-bit default) and
+      `maccs_keys()` (167-bit MACCS). Morgan bit positions are not claimed to
+      be identical to RDKit's MorganGenerator.
     - Full bit-fingerprint similarity family over raw BLOBs, faithful to RDKit
       `DataStructs/BitOps.cpp`: `tanimoto_bit`, `dice_bit`, `cosine_bit`, `kulczynski_bit`,
       `sokal_bit`, `mcconnaughey_bit`, `asymmetric_bit`, `braun_blanquet_bit`,

--- a/extensions/ducksmiles/description.yml
+++ b/extensions/ducksmiles/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: nkwork9999/duckSMILES
-  ref: 9b276da5821e2df6a739ecd5ddd55e5419f4e9f6
+  ref: b9aabbaae28ff6935ce2115e7c91b2d13831c2eb
 
 docs:
   hello_world: |

--- a/extensions/ducksmiles/description.yml
+++ b/extensions/ducksmiles/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: nkwork9999/duckSMILES
-  ref: 84f2ce56eaedcf57638bba3a6afa73a68c455869
+  ref: 9b276da5821e2df6a739ecd5ddd55e5419f4e9f6
 
 docs:
   hello_world: |

--- a/extensions/ducksmiles/description.yml
+++ b/extensions/ducksmiles/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: nkwork9999/duckSMILES
-  ref: b9aabbaae28ff6935ce2115e7c91b2d13831c2eb
+  ref: ff7c681ca14698d7ed6ec4a5d7a15fc40cefe834
 
 docs:
   hello_world: |


### PR DESCRIPTION
## CI verified (2026-09-05)

Verified source commit: `ff7c681ca14698d7ed6ec4a5d7a15fc40cefe834`. Community PR head: `42d25c854f8720d561ace44082c7642e09e0c46d` (tested merge commit `65f5631b4c72dbf66b1eb49c5eb62c191c1dbca3`).

- [Source distribution CI](https://github.com/nkwork9999/duckSMILES/actions/runs/33967219971): **success, 12 jobs passed**.
- [Community stable / DuckDB 1.5.5](https://github.com/duckdb/community-extensions/actions/runs/33967236944): **success, 11 jobs passed**.
- [Community development / DuckDB 2.0-cyanoptera](https://github.com/duckdb/community-extensions/actions/runs/33967236959): **success, 11 jobs passed**.
- [Rust PR tests](https://github.com/nkwork9999/duckSMILES/actions/runs/33967219730): **676 passed, 1 pre-existing ignored**; six Wasm-validator tests also passed.
- Actual Linux SQL test logs confirm **304 assertions in 3 cases** on stable DuckDB and **3 cases passed, 0 skipped** on development DuckDB. Local native execution also passed 141 statement/query checks.

Existing disabled/documentation/deployment jobs remain skipped according to the workflows; they are not counted as passed. No platform exclusions or test-disabling changes were added. These results verify builds and the executed tests, not publication or universal RDKit compatibility. Wasm checks establish side-module link integrity, not DuckDB-Wasm runtime SQL coverage.

## Build and runtime compatibility fixes

- Keep DuckDB 1.5.5 and development vector APIs compatible, including nullable callbacks, mutable output access and read-only list children. Add constant/NULL, filtered-vector and multi-batch regressions.
- Mark the ten BLOB similarity callbacks and 25 dynamic-string callbacks that can throw as fallible; test expected errors, row-wise TRY recovery and connection reuse.
- Correct cross-platform Rust target selection and toolchain declarations; forward all Rust archives into the actual Wasm final link.
- Match pinned Emscripten 3.1.71 with Rust nightly-2025-02-01 and a Wasm-only std rebuild, including threaded features. Validate missing symbols and self-resolved GOT relocations against the actual binary. [Wasm build contract](https://github.com/nkwork9999/duckSMILES/blob/ff7c681ca14698d7ed6ec4a5d7a15fc40cefe834/WASM_BUILD.md).

Updates `ducksmiles` to **0.5.0** (source ref `ff7c681ca14698d7ed6ec4a5d7a15fc40cefe834`).

Features carried forward since 0.4.0, with SQL regression tests in the source repository:

- **Bit-fingerprint similarity family** over raw fingerprint BLOBs (ported from `DataStructs/BitOps.cpp`): `dice_bit`, `cosine_bit`, `kulczynski_bit`, `sokal_bit`, `mcconnaughey_bit`, `asymmetric_bit`, `braun_blanquet_bit`, `russel_bit`, and asymmetric `tversky_bit(a, b, α, β)` — joining the existing `tanimoto_bit`.
- **`mol_mr`** — Wildman-Crippen molar refractivity (shares the LogP atom-contribution table).
- **`qed`** — QED drug-likeness, a port of RDKit `Chem.QED`; reproduces the `QED.py` reference values closely.
- **Ring-count descriptors** — `num_saturated_rings`, `num_aliphatic_rings`, and the aromatic/saturated/aliphatic × heterocycle/carbocycle splits (RDKit `rdMolDescriptors`).

Additional changes in the current revision:

- Adds 21 structural-profile descriptors: fragment, charge and hydrogen counts; bond, ring and element statistics; heavy-atom mass and graph fractions.
- Adds a pinned RDKit 2025.09.6 suite: 4,510 distinct SMILES inputs and 94,710 scalar comparisons. Inputs include alternative spellings, isolated elements and isotopes. This is finite-corpus agreement, **not** universal RDKit parser/sanitizer or fingerprint compatibility.
- Fixes the reported ListVector header build failure across stable and newer DuckDB layouts.
- Adds `extension.requires_toolchains: rust` and correct Rust target selection for community cross-platform builds. Source CI now uses DuckDB v1.5.5 and v1.5-variegata tools.

Validation: current-ref source, community stable and community development CI all passed; exact runs, test counts and intentional skips are recorded above.

Source PR: https://github.com/nkwork9999/duckSMILES/pull/14
Definitions and limits: https://github.com/nkwork9999/duckSMILES/blob/ff7c681ca14698d7ed6ec4a5d7a15fc40cefe834/PROFILE_PARITY.md