### PR TITLE
fix(splink_udfs): repoint repo to RobinL/splink_udfs after org repo deletion

### DIFF
--- a/extensions/splink_udfs/description.yml
+++ b/extensions/splink_udfs/description.yml
@@ -9,7 +9,7 @@ extension:
     - RobinL
 
 repo:
-  github: moj-analytical-services/splink_udfs
+  github: RobinL/splink_udfs
   ref: cf00056f887486d0aee0a853a764f9775aa40438
 
 docs:


### PR DESCRIPTION
## Summary

`extensions/splink_udfs/description.yml` points at `moj-analytical-services/splink_udfs`, which now returns 404 (see #1924). As a result CI cannot fetch the source and no binaries have been published since v1.5.2 — `INSTALL splink_udfs FROM community` 404s on v1.5.3 for every platform.

The maintainer's repository `RobinL/splink_udfs` is live (last updated 2026-06-03) and contains the exact pinned ref `cf00056f887486d0aee0a853a764f9775aa40438` (verified via the GitHub API — same commit, "Merge pull request #30 … fix ngrams issue"). This PR changes only the `repo.github` pointer; the `ref` is untouched, so the built artifact is identical.

Fixes #1924

cc @RobinL

🤖 Generated with [Claude Code](https://claude.com/claude-code)