### PR TITLE
add concurrency rule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,10 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: build-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ inputs.extension_name || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   prepare:
     outputs:


### PR DESCRIPTION
implements: https://github.com/duckdblabs/duckdb-internal/issues/7036

in-progress workflow runs are cancelled if additional commits are added to a PR
