### PR TITLE
Update salesforce to v0.14.1

### DIFF
--- a/extensions/salesforce/description.yml
+++ b/extensions/salesforce/description.yml
@@ -6,12 +6,12 @@
 # extension for every supported platform from the pinned repo ref below.
 #
 # STAGED in flozer/duckdb-salesforce only. Submitting it is HUMAN-GATED (gate
-# C.5) and has NOT been done. Submission ref: v0.9.2.
+# C.5) and has NOT been done. Submission ref: v0.14.1.
 
 extension:
   name: salesforce
   description: Read-only access to Salesforce orgs as DuckDB SQL tables over the official REST and Bulk APIs — OAuth refresh-token or JWT-bearer auth (credentials from inline options, environment variables, or an SFDX auth URL), native ATTACH, projection + predicate pushdown, COUNT pushdown, explicit server-side aggregates with GROUP BY, lazy/auto/Bulk transports with PK chunking (Bulk blob/base64 compatibility guard), a per-job API quota governor, parent + grandparent relationship STRUCT columns with diagnostics, queryAll (archived + deleted), Tooling-API fast schema, and metadata helpers (manual cache refresh, picklist values, record types).
-  version: 0.9.2
+  version: 0.14.1
   language: C++
   build: cmake
   license: MIT
@@ -27,7 +27,7 @@ extension:
 repo:
   github: flozer/duckdb-salesforce
   # community-extensions CI checks out exactly this ref to build + sign.
-  ref: v0.9.2
+  ref: v0.14.1
 
 docs:
   hello_world: |


### PR DESCRIPTION
Updates the Salesforce extension community ref to v0.14.1.\n\nValidation from flozer/duckdb-salesforce:\n- DuckDB matrix v1.5.2, v1.5.3, v1.5.4 passed.\n- DuckDB v1.5.4 LOAD smoke passed.\n- v0.14.1 includes the build_matrix assertion-count parsing fix used for validation.\n\nDuckDB extension binaries remain version/platform-specific; new DuckDB releases require explicit validation.