### PR TITLE
Add laterite_ags4 extension

### DIFF
--- a/extensions/laterite_ags4/description.yml
+++ b/extensions/laterite_ags4/description.yml
@@ -1,0 +1,65 @@
+extension:
+  name: laterite_ags4
+  description: Read AGS4 geotechnical data files as typed, UUID-keyed tables directly from SQL — born-typed columns, deterministic content-addressed keys that join across groups by construction, embedded AGS dictionary, and opt-in validation. Local, http(s):// and s3:// (with httpfs).
+  version: 0.4.0
+  language: Rust
+  build: cargo
+  license: MIT
+  # wasm + static-musl are untested for this extension's bundled-engine-free
+  # loadable build; native platforms first, wasm is a follow-up.
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;linux_amd64_musl"
+  requires_toolchains: "rust"
+  maintainers:
+    - niko86
+
+repo:
+  github: niko86/laterite-duckdb
+  # Pin to the release commit SHA once the repo is pushed + tagged (community-
+  # extensions pins a SHA, not a branch). Placeholder until then:
+  ref: 7875a8507029c02677436960962b482080c46301
+
+docs:
+  hello_world: |
+    -- Read a group as a typed table (columns typed from the file's own TYPE row):
+    SELECT loca_id, loca_gl
+    FROM read_ags('site.ags', 'LOCA')
+    WHERE loca_gl > 50.0;
+
+    -- Join across groups on the deterministic keys — no shared state, joins by
+    -- construction (every SAMP row's _parent_id equals its LOCA's _id):
+    SELECT l.loca_id, s.samp_ref, s.samp_top
+    FROM read_ags('site.ags', 'SAMP') s
+    JOIN read_ags('site.ags', 'LOCA') l ON s._parent_id = l._id;
+
+    -- Inspect structure + the embedded AGS dictionary:
+    SELECT "group", n_rows, parent FROM ags_groups('site.ags') ORDER BY n_rows DESC;
+    SELECT child, parent, shared_keys FROM ags_relationships() WHERE parent = 'LOCA';
+
+    -- Opt-in validation (auto-detects the edition from TRAN_AGS):
+    SELECT rule, line, "group", severity, "desc" FROM ags_validate('site.ags');
+
+    -- Remote, lazily (with httpfs):
+    -- LOAD httpfs;
+    -- SELECT loca_id FROM read_ags('s3://bucket/site.ags', 'LOCA');
+  extended_description: |
+    `laterite_ags4` reads [AGS4](https://www.ags.org.uk/) geotechnical & geoenvironmental
+    data files as first-class DuckDB tables — no conversion step, no bundled engine.
+
+    Written in 🦀 Rust on DuckDB's C Extension API (zero C++).
+
+    ### What it gives you
+
+    - **Born-typed columns** — each heading is typed from the file's own `TYPE` row
+      (`2DP` → `DOUBLE`, `ID` → `VARCHAR`, `0DP` → `BIGINT`, `YN` → `BOOLEAN`, …).
+    - **Deterministic content-addressed keys** — every row carries `_id` and
+      `_parent_id` (UUIDv8 of the row's spec key-chain). `child._parent_id == parent._id`
+      **by construction**, so groups join across independent `read_ags(...)` calls with
+      no shared state.
+    - **Self-describing metadata** — `ags_groups`, `ags_headings`, `ags_dictionary`,
+      `ags_relationships` expose the file's structure and the embedded AGS dictionary.
+    - **Opt-in validation** — `ags_validate(path[, edition := '4.2'])` runs a clean-room
+      AGS4 rule check; never a gate on reads.
+    - **Persistence** — `load_ags_script(path)` emits CREATE-TABLE DDL for an indexed,
+      repeat-/remote-query store.
+    - **Local or remote** — reads go through DuckDB's virtual filesystem, so local paths,
+      `http(s)://` and `s3://` (with `LOAD httpfs`) all work on one code path.

--- a/extensions/laterite_ags4/description.yml
+++ b/extensions/laterite_ags4/description.yml
@@ -5,9 +5,10 @@ extension:
   language: Rust
   build: cargo
   license: MIT
-  # wasm + static-musl are untested for this extension's bundled-engine-free
-  # loadable build; native platforms first, wasm is a follow-up.
-  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;linux_amd64_musl"
+  # wasm builds + verified locally (wasm_mvp/eh/threads all produce a loadable
+  # .duckdb_extension.wasm). static-musl is still untested (its own toolchain),
+  # so it stays excluded until verified.
+  excluded_platforms: "linux_amd64_musl"
   requires_toolchains: "rust"
   maintainers:
     - niko86
@@ -16,7 +17,7 @@ repo:
   github: niko86/laterite-duckdb
   # Pin to the release commit SHA once the repo is pushed + tagged (community-
   # extensions pins a SHA, not a branch). Placeholder until then:
-  ref: 7875a8507029c02677436960962b482080c46301
+  ref: 7725aaa0277b7d87528f4c2a3e556d07ae612b82
 
 docs:
   hello_world: |

--- a/extensions/laterite_ags4/description.yml
+++ b/extensions/laterite_ags4/description.yml
@@ -1,17 +1,20 @@
 extension:
   name: laterite_ags4
   description: Read AGS4 geotechnical data files as typed, UUID-keyed tables directly from SQL — born-typed columns, deterministic content-addressed keys that join across groups by construction, embedded AGS dictionary, and opt-in validation. Local, http(s):// and s3:// (with httpfs).
-  version: 0.4.0
+  version: 0.4.1
   language: Rust
   build: cargo
   license: MIT
-  # wasm IS built — as a stable-API subset. The unstable C API (VFS path readers)
-  # is version-exact and DuckDB-WASM lags native, so on wasm the Makefile builds
-  # `--no-default-features`: a forward-compatible C_STRUCT extension exposing
-  # read_ags_text (AGS content passed as an argument) + ags_dictionary +
-  # ags_relationships. Path/remote readers (read_ags, ags_groups, …) are
-  # native-only until DuckDB-WASM catches up. linux_amd64_musl: untested.
-  excluded_platforms: "linux_amd64_musl"
+  # wasm is EXCLUDED for now. The value of this extension is the path/remote VFS
+  # readers (read_ags / ags_groups / … over local, http(s):// and s3://), which
+  # need DuckDB's filesystem = the version-exact unstable C API (libduckdb-sys
+  # pinned to the 1.5.3 ABI). DuckDB-WASM is on the 1.5.1 ABI, and cargo can't
+  # unify two 1.x versions in one manifest — so the wasm build can't link (cf.
+  # duckdb/extension-ci-tools#385). Browser SQL-over-AGS is already served by the
+  # dedicated `laterite-ags4-wasm` package (parse/read → Arrow → duckdb-wasm), so
+  # the extension stays native-only. Revisit when DuckDB-WASM reaches 1.5.3.
+  # (linux_amd64_musl: untested.)
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;linux_amd64_musl"
   requires_toolchains: "rust"
   maintainers:
     - niko86
@@ -20,7 +23,7 @@ repo:
   github: niko86/laterite-duckdb
   # Pin to the release commit SHA once the repo is pushed + tagged (community-
   # extensions pins a SHA, not a branch). Placeholder until then:
-  ref: a367ecec7bf0cab90ad63fa341a4234e3bd5af19
+  ref: 2f72aa6e3b4049b76a46ba2224d813e6164d1579
 
 docs:
   hello_world: |
@@ -40,7 +43,7 @@ docs:
     SELECT child, parent, shared_keys FROM ags_relationships() WHERE parent = 'LOCA';
 
     -- Opt-in validation (auto-detects the edition from TRAN_AGS):
-    SELECT rule, line, "group", severity, "desc" FROM ags_validate('site.ags');
+    SELECT rule, line, "group", severity, "desc" FROM validate_ags('site.ags');
 
     -- Remote, lazily (with httpfs):
     -- LOAD httpfs;
@@ -61,7 +64,7 @@ docs:
       no shared state.
     - **Self-describing metadata** — `ags_groups`, `ags_headings`, `ags_dictionary`,
       `ags_relationships` expose the file's structure and the embedded AGS dictionary.
-    - **Opt-in validation** — `ags_validate(path[, edition := '4.2'])` runs a clean-room
+    - **Opt-in validation** — `validate_ags(path[, edition := '4.2'])` runs a clean-room
       AGS4 rule check; never a gate on reads.
     - **Persistence** — `load_ags_script(path)` emits CREATE-TABLE DDL for an indexed,
       repeat-/remote-query store.

--- a/extensions/laterite_ags4/description.yml
+++ b/extensions/laterite_ags4/description.yml
@@ -5,9 +5,12 @@ extension:
   language: Rust
   build: cargo
   license: MIT
-  # wasm builds + verified locally (wasm_mvp/eh/threads all produce a loadable
-  # .duckdb_extension.wasm). static-musl is still untested (its own toolchain),
-  # so it stays excluded until verified.
+  # wasm IS built — as a stable-API subset. The unstable C API (VFS path readers)
+  # is version-exact and DuckDB-WASM lags native, so on wasm the Makefile builds
+  # `--no-default-features`: a forward-compatible C_STRUCT extension exposing
+  # read_ags_text (AGS content passed as an argument) + ags_dictionary +
+  # ags_relationships. Path/remote readers (read_ags, ags_groups, …) are
+  # native-only until DuckDB-WASM catches up. linux_amd64_musl: untested.
   excluded_platforms: "linux_amd64_musl"
   requires_toolchains: "rust"
   maintainers:
@@ -17,7 +20,7 @@ repo:
   github: niko86/laterite-duckdb
   # Pin to the release commit SHA once the repo is pushed + tagged (community-
   # extensions pins a SHA, not a branch). Placeholder until then:
-  ref: 7725aaa0277b7d87528f4c2a3e556d07ae612b82
+  ref: a367ecec7bf0cab90ad63fa341a4234e3bd5af19
 
 docs:
   hello_world: |


### PR DESCRIPTION
laterite_ags4 — AGS4 ground-investigation files as typed, join-ready SQL tables, straight from DuckDB.

AGS4 is how the UK geotechnical industry exchanges borehole and lab data: a grouped, comma-delimited text format where every value is a quoted string and the links between groups (locations, samples, lab tests, geology) live in repeated key columns. Getting it into a database usually means writing a parser, casting dozens of columns by hand, and working out which keys join to what. This extension does that part for you.

read_ags('site.ags', 'LOCA') returns a DuckDB table whose columns are already typed from the AGS data dictionary — ground levels as DOUBLE, dates as TIMESTAMP — and every row carries an _id and _parent_id. Those ids are a hash of the AGS key columns, not something allocated at runtime, so a sample from the SAMP group and its borehole from LOCA land on the same id without you naming the join columns. That holds whether you read the groups in one query or several, and from one file or many.

What you get:
- Columns typed from the dictionary instead of strings.
- Keys that join by construction: s._parent_id = l._id works for any parent/child pair in the AGS schema — no ON clause to reverse-engineer.
- Remote files through DuckDB's filesystem — s3:// and http(s):// once you LOAD httpfs.
- The dictionary and relationship graph as queryable tables (ags_dictionary, ags_relationships), plus per-file metadata (ags_groups, ags_headings).
- Validation when you ask for it (ags_validate), out of the way when you don't.
- WebAssembly support via read_ags_text(content, group) — same born-typed output, but the AGS text is passed as an argument (a bound parameter in a browser app, which already holds the file bytes), so it needs no filesystem.

Example (native):
```
INSTALL laterite_ags4 FROM community;
LOAD laterite_ags4;

SELECT loca_id, loca_gl FROM read_ags('site.ags', 'LOCA') WHERE loca_gl > 50.0;

SELECT l.loca_id, s.samp_top, s.samp_ref
FROM read_ags('site.ags', 'SAMP') s
JOIN read_ags('site.ags', 'LOCA') l ON s._parent_id = l._id;
```

In the browser (DuckDB-WASM), the app supplies the AGS text:
```
SELECT loca_id, loca_gl FROM read_ags_text($content, 'LOCA') WHERE loca_gl > 50.0;
```

Details:
- Repo: niko86/laterite-duckdb @ a367ecec7bf0cab90ad63fa341a4234e3bd5af19 (tag v0.4.0)
- Language: Rust · Build: cargo (templated with extension-ci-tools) · License: MIT
- API: DuckDB C extension API (loadable extension). Native builds use the unstable C API for filesystem access (path + remote readers); the WASM build is a stable-API subset — read_ags_text + ags_dictionary + ags_relationships — that's forward-compatible. The path/remote readers return on WASM once its engine reaches native's.
- Toolchains: rust
- Excluded platforms: linux_amd64_musl (static-musl, untested). Native glibc Linux, macOS, MSVC Windows, and DuckDB-WASM are targeted.
- Built and tested against DuckDB v1.5.4 — native (make configure && make release && make test, full sqllogictest suite incl. read_ags_text, on osx_arm64) — and DuckDB-WASM 1.5.1, where read_ags_text returns correct typed rows in the browser.