### PR TITLE
webbed: bump to v2.2.1

### DIFF
--- a/extensions/webbed/description.yml
+++ b/extensions/webbed/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: webbed
   description: Comprehensive processing extension for web markup languages (XML and HTML) with SAX streaming for large files, intelligent schema inference, XPath-based data extraction, and HTML table parsing.
-  version: 2.2.0
+  version: 2.2.1
   language: C++
   build: cmake
   license: MIT
@@ -14,8 +14,8 @@ extension:
   vcpkg_commit: 68a1c387f660632f2f65cdb7e8cd093a08840e5d
 repo:
   github: teaguesterling/duckdb_webbed
-  andium: 465b37b04ee974d958e5a0b7559814b84f9f373b
-  ref: 465b37b04ee974d958e5a0b7559814b84f9f373b
+  andium: ddda30f11352138b2451657419640370d1612137
+  ref: ddda30f11352138b2451657419640370d1612137
 docs:
   docs_url: https://duckdb-webbed.readthedocs.io
   hello_world: |


### PR DESCRIPTION
Bumps the webbed extension to v2.2.1.

Fixes the DuckDB-WASM build, which installed but failed to load because LibXml2 (and its zlib dependency) were not linked into the `-sSIDE_MODULE=2` module (#96). Adds a static WASM symbol-resolution gate + a live duckdb-wasm load test. No functional/source changes; native test suite unchanged (2866 assertions, 82 cases).

Release: https://github.com/teaguesterling/duckdb_webbed/releases/tag/v2.2.1