### PR TITLE
delta_classic: build against DuckDB 1.4.5

### DIFF
--- a/extensions/delta_classic/description.yml
+++ b/extensions/delta_classic/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: djouallah/delta_classic
-  andium: fdb489d9c28f4dc7e8690cbf92a5f9cb34733124
+  andium: 27b979b1f1c161c767f3bb24d9ee67fe28a2f16c
   ref: ff9914ee3d752b2c1c3e1ea021c7af5b922da63a
 
 docs:


### PR DESCRIPTION
Bumps the `andium` (DuckDB 1.4.x) ref for `delta_classic` to the `v145` branch tip, which pins **DuckDB v1.4.5**.

This is a bug-fix bump of the 1.4.x line only:
- `version` is unchanged (`0.1.0`) — no new functionality.
- The `ref` (DuckDB 1.5.0 / variegata) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)