### PR TITLE
duck_hunt: bump to 1.10.0

### DIFF
--- a/extensions/duck_hunt/description.yml
+++ b/extensions/duck_hunt/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duck_hunt
   description: Parse and analyze test results, build outputs, and CI/CD pipeline logs from 110+ formats with severity filtering, format auto-detection, and context extraction
-  version: 1.9.0
+  version: 1.10.0
   language: C++
   build: cmake
   license: MIT
@@ -10,8 +10,8 @@ extension:
 
 repo:
   github: teaguesterling/duck_hunt
-  andium: da4f3d787f5bea20fba247b703b46abc9833ebeb
-  ref: da4f3d787f5bea20fba247b703b46abc9833ebeb
+  andium: 22c142f3dee138566589783afb56a5e7f2858886
+  ref: 22c142f3dee138566589783afb56a5e7f2858886
 
 docs:
   readme: https://duck-hunt.readthedocs.io/

--- a/extensions/duck_hunt/description.yml
+++ b/extensions/duck_hunt/description.yml
@@ -5,6 +5,11 @@ extension:
   language: C++
   build: cmake
   license: MIT
+  # Windows excluded: duckdb's vendored fmt (third_party/fmt) fails to compile on
+  # the build runner's MSVC (stdext::checked_array_iterator removed). Upstream
+  # issue, not duck_hunt code; no Windows artifact has ever been published for
+  # this extension. Revisit when duckdb ships a newer vendored fmt.
+  excluded_platforms: "windows_amd64;windows_amd64_mingw"
   maintainers:
     - teaguesterling
 


### PR DESCRIPTION
Bumps `duck_hunt` from 1.9.0 to 1.10.0.

Both `ref` and `andium` are updated to `22c142f` (tag `v1.10.0`).

What's in this release:
- duckdb v1.5.3 support (bumped from v1.4.4).
- duckdb-main build compatibility (templated `Catalog::GetEntry<T>`, `Identifier`-wrapped lookups gated by `__has_include`).
- A WASM symbol-resolution + live-load test harness under `test/wasm/` (repo-only; does not change the shipped extension).

No new parsers or user-facing functional changes. Verified to build against both v1.5.x and the v1.4 "Andium" LTS line (templated `GetEntry<T>` and `lambda` syntax both exist in v1.4).
