### PR TITLE
yaml: bump to v1.6.6

### DIFF
--- a/extensions/yaml/description.yml
+++ b/extensions/yaml/description.yml
@@ -1,7 +1,11 @@
 extension:
   name: yaml
   description: Read YAML files into DuckDB with native YAML type support, comprehensive extraction functions, and seamless JSON interoperability
-  version: 1.6.5
+  version: 1.6.6
+  # Windows excluded: DuckDB's vendored fmt fails to compile against the community
+  # runner's current MSVC STL (stdext::checked_array_iterator removed); not fixable
+  # from the extension.
+  excluded_platforms: windows_amd64;windows_amd64_mingw
   language: C++
   build: cmake
   license: MIT
@@ -13,8 +17,8 @@ extension:
   
 repo:
   github: teaguesterling/duckdb_yaml
-  andium: 9d57e9557742ede442be4095951dfa56227282b2
-  ref: 9d57e9557742ede442be4095951dfa56227282b2
+  andium: 8a1d8444af06682a3cb2933068a6a35af0fec3b2
+  ref: 8a1d8444af06682a3cb2933068a6a35af0fec3b2
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps the yaml extension to v1.6.6.

- Fixes the DuckDB-WASM build, which installed but failed to load because yaml-cpp was not linked into the `-sSIDE_MODULE=2` module (#40). Adds a static WASM symbol-resolution gate + a live duckdb-wasm load test.
- Bumps to DuckDB v1.5.3 and adds duckdb-main cross-version compatibility (#39).
- Excludes Windows (DuckDB's vendored fmt vs the runner's MSVC STL).

Release: https://github.com/teaguesterling/duckdb_yaml/releases/tag/v1.6.6