### PR TITLE
Bump `read_stat`

### DIFF
--- a/extensions/read_stat/description.yml
+++ b/extensions/read_stat/description.yml
@@ -1,17 +1,17 @@
 extension:
   name: read_stat
   description: Read data sets from SAS, Stata, and SPSS with ReadStat
-  version: 0.2.3
+  version: 0.3.0
   language: C
   build: cmake
   license: MIT
   requires_toolchains: "python3"
   maintainers:
-    - mettekou
+    - dylanmeysmans
 
 repo:
-  github: mettekou/duckdb-read-stat
-  ref: d66821b3626caddbc8da7794617747e079f2ff64
+  github: dylanmeysmans/duckdb-read-stat
+  ref: 52c29607852663fc7c318c5e0dc5dcbd2d565aa6
 
 docs:
   hello_world: |


### PR DESCRIPTION
@carlopi @samansmink @rustyconover Moving to the unstable C API for DuckDB 1.5.4 to support reading files in WASM. See https://github.com/dylanmeysmans/duckdb-read-stat/issues/11 for details.