### PR TITLE
duckton: bump to v0.6.0

### DIFF
--- a/extensions/duckton/description.yml
+++ b/extensions/duckton/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duckton
   description: Turn DuckDB into a node of a trustless peer-to-peer query grid — SQL is cross-checked by independent hosts to a verifiable quorum over QUIC, with optional pay-per-query compute settled on TON
-  version: 0.5.2
+  version: 0.6.0
   language: Rust
   build: cmake
   license: Apache-2.0
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: Angelerator/duckton
-  ref: 3102f2573e6d27430c2c975d1e5bbcc18a8ab4df
+  ref: c0c6087f6e5267c4c06d761f088504181ebba99f
 
 docs:
   hello_world: |
@@ -26,7 +26,7 @@ docs:
     │ protocol_version      │ 1.0.0        │
     │ min_supported_version │ 1.0.0        │
     │ schema_version        │ 1            │
-    │ extension_version     │ 0.5.2        │
+    │ extension_version     │ 0.6.0        │
     │ alpn                  │ duckdb-p2p/1 │
     └───────────────────────┴──────────────┘
 
@@ -113,6 +113,12 @@ docs:
       node's compute (memory/threads/jobs) to become a host.
     - Admin/economics setters: `p2p_trust`, `p2p_economics`, `p2p_wallet`,
       `p2p_block` / `p2p_unblock` / `p2p_blocklist`, and more.
+
+    ### New in v0.6.0
+    Smart size-aware routing with robust failover (jobs are placed by result size
+    and re-dispatched around slow or failing hosts), a process-wide capacity
+    governor that caps concurrent compute, an optional presigned-URL credential
+    mode for object-store access, and stronger stake weighting in host selection.
 
     ### Built on solid foundations (and honest about limits)
     A Rust extension built against DuckDB's **stable C extension API** (loadable


### PR DESCRIPTION
Bumps the published **duckton** extension from v0.5.2 to **v0.6.0**.

Updates `extensions/duckton/description.yml`:
- `repo.ref` → `c0c6087f6e5267c4c06d761f088504181ebba99f` (tag `v0.6.0` on `Angelerator/duckton`)
- `version` → `0.6.0` (and the `extension_version` shown in the `hello_world` example)

### What's new in v0.6.0
- **Smart size-aware routing with robust failover** — jobs are placed by result size and re-dispatched around slow or failing hosts.
- **Process-wide capacity governor** — caps concurrent compute across the node.
- **Presigned-URL credential mode** — optional, for object-store access.
- **Stronger stake weighting** — stake counts for more in host selection.
- **Web/console refresh** and a **fresh on-chain proof**.

Built and tested against **DuckDB v1.5.4** (the registry's current version).
