### PR TITLE
zim: bump to v0.4.1

### DIFF
--- a/extensions/zim/description.yml
+++ b/extensions/zim/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: zim
   description: Read .zim (Kiwix / openZIM) archives directly in DuckDB via libzim, from local files or remote S3/HTTP — offline Wikipedia, WikiMed, Stack Exchange, iFixit, and more, with a zim:// filesystem and full-text search.
-  version: 0.4.0
+  version: 0.4.1
   language: C++
   build: cmake
   license: GPL-2.0-or-later
@@ -12,7 +12,7 @@ extension:
   vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
 repo:
   github: teaguesterling/duckdb_zim
-  ref: a4a173f33e0dd3dfd8e6fca300b23cd49f83a1b3
+  ref: 3736b4c1ee0055c89a32b03626e2aa9403a4beb5
 docs:
   hello_world: |
     -- Load the extension


### PR DESCRIPTION
Bumps the zim extension to v0.4.1.

Fixes the DuckDB-WASM build, which installed but failed to load because libzim (and its transitive zstd/lzma) were not linked into the `-sSIDE_MODULE=2` module. `CMakeLists.txt` now resolves libzim's static link set from pkg-config and feeds it to the WASM link (grouped for ICU's circular refs); a runtime-free static symbol gate is wired into CI. ICU dead-strips (libzim's read path doesn't use it), so the `.wasm` stays ~0.5 MB. No functional/native changes.

Note: this makes the extension *load* under duckdb-wasm; reading a ZIM in the browser is separate (libzim's local mmap path; tracked for a later release).

Release: https://github.com/teaguesterling/duckdb_zim/releases/tag/v0.4.1