### PR TITLE
duckton: bump to v0.6.1 (fix two-node grid hang)

### DIFF
--- a/extensions/duckton/description.yml
+++ b/extensions/duckton/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duckton
   description: Turn DuckDB into a node of a trustless peer-to-peer query grid — SQL is cross-checked by independent hosts to a verifiable quorum over QUIC, with optional pay-per-query compute settled on TON
-  version: 0.6.0
+  version: 0.6.1
   language: Rust
   build: cmake
   license: Apache-2.0
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: Angelerator/duckton
-  ref: c0c6087f6e5267c4c06d761f088504181ebba99f
+  ref: 040c45638927fb56053033409bb28bc3796f4a1b
 
 docs:
   hello_world: |
@@ -26,7 +26,7 @@ docs:
     │ protocol_version      │ 1.0.0        │
     │ min_supported_version │ 1.0.0        │
     │ schema_version        │ 1            │
-    │ extension_version     │ 0.6.0        │
+    │ extension_version     │ 0.6.1        │
     │ alpn                  │ duckdb-p2p/1 │
     └───────────────────────┴──────────────┘
 
@@ -114,11 +114,18 @@ docs:
     - Admin/economics setters: `p2p_trust`, `p2p_economics`, `p2p_wallet`,
       `p2p_block` / `p2p_unblock` / `p2p_blocklist`, and more.
 
-    ### New in v0.6.0
-    Smart size-aware routing with robust failover (jobs are placed by result size
-    and re-dispatched around slow or failing hosts), a process-wide capacity
-    governor that caps concurrent compute, an optional presigned-URL credential
-    mode for object-store access, and stronger stake weighting in host selection.
+    ### New in v0.6.1
+    A bug-fix release over v0.6.0. It fixes a **two-node-grid hang** where a
+    requester could spin forever re-dispatching to a dual-role node that rejected a
+    full-budget job; this is now bounded by a no-progress guard plus a governor
+    served-ceiling clamp so dispatch always makes progress or fails cleanly. It also
+    hardens **secure spill**: a `max_temp_directory_size` cap, `temp_file_encryption`,
+    and temp-dir/sandbox alignment so on-disk spill stays inside the locked-down
+    sandbox and is encrypted at rest. v0.6.0 added smart size-aware routing with
+    robust failover (jobs are placed by result size and re-dispatched around slow or
+    failing hosts), a process-wide capacity governor that caps concurrent compute, an
+    optional presigned-URL credential mode for object-store access, and stronger
+    stake weighting in host selection.
 
     ### Built on solid foundations (and honest about limits)
     A Rust extension built against DuckDB's **stable C extension API** (loadable


### PR DESCRIPTION
Bumps the `duckton` community extension from **v0.6.0** to **v0.6.1**, a bug-fix release.

- `repo.ref` → `040c45638927fb56053033409bb28bc3796f4a1b` (tag `v0.6.1` on `Angelerator/duckton`)
- `version` / `extension_version` → `0.6.1`

### What v0.6.1 fixes
v0.6.0 (currently in the registry, #2090) contains a **two-node-grid hang**: a requester could spin forever re-dispatching to a dual-role node that rejected a full-budget job. v0.6.1 fixes this with a **bounded no-progress guard** plus a **governor served-ceiling clamp**, so dispatch always makes forward progress or fails cleanly.

### Also in v0.6.1: secure spill
- `max_temp_directory_size` cap on on-disk spill
- `temp_file_encryption` (spill encrypted at rest)
- temp-dir / sandbox alignment so spill stays inside the locked-down sandbox

### Build
Built and tested against **DuckDB v1.5.4**. The diff is limited to `extensions/duckton/description.yml`.

