### PR TITLE
Revert "Bump `read_stat`"

### DIFF
--- a/extensions/read_stat/description.yml
+++ b/extensions/read_stat/description.yml
@@ -1,17 +1,17 @@
 extension:
   name: read_stat
   description: Read data sets from SAS, Stata, and SPSS with ReadStat
-  version: 0.3.0
+  version: 0.2.3
   language: C
   build: cmake
   license: MIT
   requires_toolchains: "python3"
   maintainers:
-    - dylanmeysmans
+    - mettekou
 
 repo:
-  github: dylanmeysmans/duckdb-read-stat
-  ref: 52c29607852663fc7c318c5e0dc5dcbd2d565aa6
+  github: mettekou/duckdb-read-stat
+  ref: d66821b3626caddbc8da7794617747e079f2ff64
 
 docs:
   hello_world: |


### PR DESCRIPTION
Reverts duckdb/community-extensions#2089

@mettekou and @dylanmeysmans, I did a mistake, and merged #2089 without a maintainer approval. Sorry both for the mistake. I am reverting that, since retargeting to a different repo by a non maintainer is not allowed.

Feel free to reopen, but an explicit OK by @mettekou would be needed for a merge.