### PR TITLE
Update anofox_forecast to b64d99e (DuckDB v1.4.5 LTS + v1.5.4)

### DIFF
--- a/extensions/anofox_forecast/description.yml
+++ b/extensions/anofox_forecast/description.yml
@@ -10,4 +10,4 @@ extension:
     - sipemu
 repo:
   github: DataZooDE/anofox-forecast
-  ref: 1e1d4f2df15a08ec6bc5d4aa53fd10f709e147d1
+  ref: b64d99eadd17b688ccd80b42269d3a7e8dddd0ec


### PR DESCRIPTION
## Summary

Bumps `extensions/anofox_forecast/description.yml` `ref` from `1e1d4f2` to [`b64d99e`](https://github.com/DataZooDE/anofox-forecast/commit/b64d99eadd17b688ccd80b42269d3a7e8dddd0ec), the current `main` HEAD.

## What changed since the previous ref

[DataZooDE/anofox-forecast#221](https://github.com/DataZooDE/anofox-forecast/pull/221) replaces the single v1.5.x distribution build with a dual-track build:

- **DuckDB v1.4.5 LTS** via extension-ci-tools `v1.4-andium` branch
- **DuckDB v1.5.4 (latest)** via extension-ci-tools `v1.5-variegata` branch

It also adds a Linux-scoped `-Wl,--allow-multiple-definition` linker flag to handle a v1.4 LTS-specific issue: under glibc/GCC-14 with the forced C++17 standard, several `static constexpr` class-type members (e.g. `duckdb::LogicalType::FLOAT/DOUBLE/VARCHAR`, `duckdb::MultiFileReader::COLUMN_IDENTIFIER_*`) are emitted as strong symbols in both `libduckdb_static.a` and `libcore_functions_extension.a`/`libparquet_extension.a`, breaking the link of `libduckdb.so` / `libsqlite3_api_wrapper.so`. The definitions are byte-identical, so picking the first is safe; the flag is a no-op on the v1.5 line which has no duplicates.

## Verification

Both LTS and latest builds passed all platforms on the source PR ([anofox-forecast#221](https://github.com/DataZooDE/anofox-forecast/pull/221)) before merge: linux_amd64, linux_arm64, macOS amd64/arm64, DuckDB-Wasm (mvp/eh/threads), Windows amd64.