### PR TITLE
scalarfs: bump to 1.4.1

### DIFF
--- a/extensions/scalarfs/description.yml
+++ b/extensions/scalarfs/description.yml
@@ -5,6 +5,9 @@ extension:
   language: C++
   build: cmake
   license: MIT
+  # Windows excluded: duckdb's vendored fmt fails on the build runner's MSVC
+  # (stdext checked_array_iterator removed) -- upstream, not scalarfs.
+  excluded_platforms: "windows_amd64;windows_amd64_mingw"
   maintainers:
     - teaguesterling
 repo:

--- a/extensions/scalarfs/description.yml
+++ b/extensions/scalarfs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: scalarfs
   description: A collection of virtual filesystems for working with scalars
-  version: 1.4.0
+  version: 1.4.1
   language: C++
   build: cmake
   license: MIT
@@ -9,9 +9,9 @@ extension:
     - teaguesterling
 repo:
   github: teaguesterling/duckdb_scalarfs
-  andium: 1e283b92ab821cc0138b5f1369fa66a86fb8c494
-  ref: 1e283b92ab821cc0138b5f1369fa66a86fb8c494
-  ref_next: 1e283b92ab821cc0138b5f1369fa66a86fb8c494
+  andium: 62ca2530e273ab9daa7d563519e1f22569e71741
+  ref: 62ca2530e273ab9daa7d563519e1f22569e71741
+  ref_next: 62ca2530e273ab9daa7d563519e1f22569e71741
 docs:
   hello_world: |
     LOAD scalarfs;


### PR DESCRIPTION
Bumps `scalarfs` from 1.4.0 to 1.4.1 (patch). `ref`, `andium`, and `ref_next` all updated to tag `v1.4.1`.

What's in this release (compatibility + test portability; no new features):
- duckdb v1.5.3 build support (stable build bumped from v1.4.4).
- duckdb-main build compatibility, guarded by `__has_include` so v1.4/v1.5 builds are unaffected (handles duckdb main's typed `Identifier` for `user_variables` keys, `child_list_t` STRUCT-field keys, and the COPY bind path).
- Test portability: a missing-file error assertion now matches the common errno substring "no such file or directory" instead of a backend-specific prefix, so it passes on both native and wasm.

Builds clean on Linux/macOS/wasm for v1.5.3 and on the v1.4 LTS line. (The duckdb-main canary is paused upstream while duckdb's Identifier migration is in flight.)
