### PR TITLE
[PDAL] Update extension to DuckDB v1.5.4

### DIFF
--- a/extensions/pdal/description.yml
+++ b/extensions/pdal/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: ahuarte47/duckdb-pdal
-  ref: 175f8a0b8a0fde48d52d6d1ce503c7cbf4534e20
+  ref: e4b61ba9175cd50226d6aa583afc7701ff8f45cb
 
 docs:
   hello_world: |


### PR DESCRIPTION
Changes:
* Bumb extension to DuckDB v1.5.4
* Fix `PDAL_Read` function when opening remote files with `http` or `https` protocols.