### PR TITLE
duckton: bump to v0.6.2

### DIFF
--- a/extensions/duckton/description.yml
+++ b/extensions/duckton/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duckton
   description: Turn DuckDB into a node of a trustless peer-to-peer query grid — SQL is cross-checked by independent hosts to a verifiable quorum over QUIC, with optional pay-per-query compute settled on TON
-  version: 0.6.1
+  version: 0.6.2
   language: Rust
   build: cmake
   license: Apache-2.0
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: Angelerator/duckton
-  ref: 040c45638927fb56053033409bb28bc3796f4a1b
+  ref: 310b6fb4e1bf8e802b08f95731464dd139b0ef39
 
 docs:
   hello_world: |
@@ -26,7 +26,7 @@ docs:
     │ protocol_version      │ 1.0.0        │
     │ min_supported_version │ 1.0.0        │
     │ schema_version        │ 1            │
-    │ extension_version     │ 0.6.1        │
+    │ extension_version     │ 0.6.2        │
     │ alpn                  │ duckdb-p2p/1 │
     └───────────────────────┴──────────────┘
 
@@ -105,7 +105,7 @@ docs:
     - `p2p_query(sql, [overrides...])` — run SQL on the grid (local-first; or
       `prefer => 'remote'` to dispatch to hosts). Per-call overrides include
       `replicas`, `quorum`, `min_trust`, `min_attestation`, `payment`, `prefer`,
-      `network`, `groups`, `regions`, `require_staked_hosts`.
+      `network`, `groups`, `regions`, `nodes`, `require_staked_hosts`.
     - `p2p_query_meta(sql, ...)` — the verification/execution metadata for a query.
     - `p2p_info()` / `p2p_peers()` / `p2p_status()` / `p2p_config()` — inspect
       protocol identity, discovery seeds, node status and effective configuration.
@@ -114,18 +114,24 @@ docs:
     - Admin/economics setters: `p2p_trust`, `p2p_economics`, `p2p_wallet`,
       `p2p_block` / `p2p_unblock` / `p2p_blocklist`, and more.
 
-    ### New in v0.6.1
-    A bug-fix release over v0.6.0. It fixes a **two-node-grid hang** where a
-    requester could spin forever re-dispatching to a dual-role node that rejected a
-    full-budget job; this is now bounded by a no-progress guard plus a governor
-    served-ceiling clamp so dispatch always makes progress or fails cleanly. It also
-    hardens **secure spill**: a `max_temp_directory_size` cap, `temp_file_encryption`,
-    and temp-dir/sandbox alignment so on-disk spill stays inside the locked-down
-    sandbox and is encrypted at rest. v0.6.0 added smart size-aware routing with
-    robust failover (jobs are placed by result size and re-dispatched around slow or
-    failing hosts), a process-wide capacity governor that caps concurrent compute, an
-    optional presigned-URL credential mode for object-store access, and stronger
-    stake weighting in host selection.
+    ### New in v0.6.2
+    A security-hardening and capability release over v0.6.1. It closes a set of
+    audit findings across transport/admission, trust, sandbox and settlement —
+    most notably binding a `Dispatch` to a prior accepting `Bid` from the same
+    authenticated peer (so the offer-phase admission/SSRF-fail-safe gates can't be
+    skipped), cryptographically binding the attestation tier into its signed
+    evidence (no level inflation), a panic-free/bounded BoC parser, interrupting
+    abandoned/over-deadline queries, and capped result materialization. On-chain it
+    adds **participation-commission (κ) enforcement** in the per-job escrow and a
+    **timelocked code upgrade** for the record-anchor contract, alongside
+    chain-synced fee binding and fail-closed treasury handling. New capability:
+    **per-call node targeting** — `p2p_query(..., nodes => ['b3:...'])` pins a job
+    to exact node id(s), composable with `replicas`/`quorum`/`prefer` to route a
+    whole query to a single chosen node (or run it locally). Plus detailed
+    structured troubleshooting logs across admission, dispatch, attestation,
+    execution and the on-chain escrow lifecycle. v0.6.1 was a bug-fix release
+    (two-node-grid hang bound + secure-spill hardening) over v0.6.0's size-aware
+    routing, capacity governor, presigned-URL credentials and stake weighting.
 
     ### Built on solid foundations (and honest about limits)
     A Rust extension built against DuckDB's **stable C extension API** (loadable


### PR DESCRIPTION
Bumps **duckton** to **v0.6.2** (`repo.ref` → `310b6fb4e1bf8e802b08f95731464dd139b0ef39`, built against DuckDB **v1.5.4**).

The diff is only `extensions/duckton/description.yml` (version, ref, example `extension_version`, the `nodes` per-call override, and the release-notes section).

Highlights of v0.6.2:
- Security hardening across transport/admission, trust, sandbox and settlement (e.g. binding a `Dispatch` to a prior accepting `Bid` from the same authenticated peer; attestation tier bound into its signed evidence; panic-free/bounded BoC parser; query interruption on timeout; capped result materialization).
- On-chain: participation-commission (κ) enforcement in the per-job escrow and a timelocked code upgrade for the record-anchor contract, plus chain-synced fee binding and fail-closed treasury handling.
- New capability: per-call node targeting — `p2p_query(..., nodes => ['b3:...'])` pins a job to exact node id(s), composable with `replicas`/`quorum`/`prefer`.
- Detailed structured troubleshooting logs across the request + on-chain escrow lifecycle.

Verified locally: `cargo build --workspace`, the test suites, 99 TON contract tests, and the loadable-extension `LOAD` on a DuckDB v1.5.4 CLI (`SELECT * FROM p2p_info()` → `extension_version 0.6.2`).

Made with [Cursor](https://cursor.com)