### PR TITLE
Release h3 v1.5.4

### DIFF
--- a/extensions/h3/description.yml
+++ b/extensions/h3/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: h3
   description: Hierarchical hexagonal indexing for geospatial data
-  version: 1.5.3
+  version: 1.5.4
   language: C++
   build: cmake
   license: Apache-2.0
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: isaacbrodsky/h3-duckdb
-  ref: de5de2f7bb9f44712b8dbf97749f3708c424b393
+  ref: be9ee91ad4b9718c5d0cc95647c013c5d907a237
 
 docs:
   hello_world: |


### PR DESCRIPTION
Windows tests that use `spatial` were disabled, possibly related to libgeos/geos#1449