### PR TITLE
docs: fix typo “paramaters” → “parameters” (mlpack description)

### DIFF
--- a/extensions/mlpack/description.yml
+++ b/extensions/mlpack/description.yml
@@ -53,7 +53,7 @@ docs:
     It uses three tables for data, parameters and results.
   
     ### General Information
-    A pair of paramaters "mlpack_verbose" (to show additional data) and "mlpack_silent" (to suppress display of minimal summaries) can also be set.
+    A pair of parameters "mlpack_verbose" (to show additional data) and "mlpack_silent" (to suppress display of minimal summaries) can also be set.
 
     The implementation still stresses the 'minimal' part of 'a (initial) MVP demo' (where MVP stands for 'minimally viable product').
     It wraps five supervised and unsupervised machine learning methods, and provides Linux and macOS builds.


### PR DESCRIPTION
Fixes a typo in the mlpack extension description (the source YAML that generates the docs page).