### PR TITLE
harbor: update to v0.4.0

### DIFF
--- a/extensions/harbor/description.yml
+++ b/extensions/harbor/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: harbor
   description: Client/server DuckDB over one HTTP port — web UI, JSON /sql, and native ATTACH (TYPE harbor)
-  version: 0.3.2
+  version: 0.4.0
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: shreeve/duckdb-harbor
-  ref: eebb64406bb2a1f77c8262eabc36285ef976e676
+  ref: 70a86f05775908e78b4479944c5beb40aac3e685
 
 docs:
   hello_world: |
@@ -74,7 +74,7 @@ docs:
     - Container-native deployments — `harbor_wait()` blocks until SIGTERM
       so harbor runs cleanly under systemd / Docker / Kubernetes.
 
-    **Status:** v0.3 release, tested across the DuckDB community-extension
+    **Status:** v0.4 release, tested across the DuckDB community-extension
     matrix (linux_amd64/arm64, osx_amd64/arm64, windows_amd64/_mingw,
     wasm_mvp/eh/threads).
 


### PR DESCRIPTION
Bumps `harbor` from v0.3.2 → **v0.4.0** (`ref` → `70a86f05775908e78b4479944c5beb40aac3e685`).

## What's new in v0.4.0
- **Fix — DuckDB UI update nag:** suppresses the permanent, undismissable "New UI extension version available" dialog. harbor rewrites only the `desiredDuckDBUIExtensionVersions[<duckdb_version>]` entry in the proxied `/config` body to match the version harbor actually serves, leaving every other field verbatim.
- **Feature — `__HARBOR_SELF__` authz scope:** authenticated callers can create/delete their own sessions (and run `BEGIN`/`COMMIT` transactions) without flipping `harbor_allow_admin_without_authz`. Unauthenticated/local-dev mode (`token := NULL`) now supports sessions too. Cross-principal session ops remain `__HARBOR_ADMIN__`-gated. (Migration note for custom-authz deployments in the release notes / SPEC §7.)
- **CI — Windows build:** pinned the MSVC build to `windows-2022`. GitHub's `windows-latest` advanced to an MSVC that removed `stdext::checked_array_iterator`, which DuckDB v1.5.3's vendored `fmt` still references.

## Validation
The tagged commit `70a86f0` already passed the full extension-ci-tools matrix (linux_amd64/arm64, osx_amd64/arm64, windows_amd64/_mingw, wasm_mvp/eh/threads) on the source repo, with per-platform binaries published.

Release notes: https://github.com/shreeve/duckdb-harbor/releases/tag/v0.4.0