### PR TITLE
Add ducklink extension

### DIFF
--- a/extensions/ducklink/description.yml
+++ b/extensions/ducklink/description.yml
@@ -1,0 +1,48 @@
+# DuckDB community-extensions manifest. Submitted to
+# https://github.com/duckdb/community-extensions as extensions/ducklink/description.yml
+extension:
+  name: ducklink
+  description: Run WebAssembly component extensions inside DuckDB
+  version: 0.1.0
+  language: Rust
+  build: cargo
+  license: MIT
+  maintainers:
+    - tegmentum
+  # Built via the Rust C Extension API. The community-extensions CI installs the
+  # Rust and Python toolchains for this build.
+  requires_toolchains: "rust;python3"
+  # ducklink embeds wasmtime (a Cranelift JIT) to run components, so it cannot be
+  # built for the wasm targets, and the JIT/loadable-cdylib combination excludes
+  # the static-musl and mingw triples.
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw;linux_amd64_musl"
+
+repo:
+  github: tegmentum/ducklink-extension
+  ref: v0.1.0
+
+docs:
+  hello_world: |
+    -- The extension ships one built-in, so loading works with no component:
+    LOAD ducklink;
+    SELECT ducklink_version();   -- e.g. 'ducklink 0.1.0'
+
+    -- To expose a component's functions, point ducklink at one or more
+    -- `duckdb:extension` WebAssembly components via the DUCKLINK_COMPONENTS
+    -- environment variable BEFORE starting DuckDB, e.g.
+    --   DUCKLINK_COMPONENTS=isin=/path/to/isin.wasm
+    -- then every function the component registers becomes callable:
+    --   LOAD ducklink;
+    --   SELECT isin_is_valid('US0378331005');
+  extended_description: |
+    ducklink lets a single, portable WebAssembly component — built once against
+    the `duckdb:extension` WIT world — load into DuckDB on any supported platform
+    without per-platform native builds. The extension embeds wasmtime, loads each
+    component named in the `DUCKLINK_COMPONENTS` environment variable (a
+    `:`-separated list of `name=path` entries, read when `LOAD ducklink` runs),
+    runs its `load()` to capture the scalar/table/aggregate functions it
+    registers, and bridges them into DuckDB's function catalog. A built-in
+    `ducklink_version()` scalar is always available so the extension is usable
+    and testable before any component is configured. The same components run
+    unchanged under the standalone `ducklink` host (DuckDB-compiled-to-wasm), so
+    one artifact targets both directions.


### PR DESCRIPTION
## ducklink

Adds **ducklink**, a Rust C-API extension that embeds [wasmtime](https://wasmtime.dev/) to run `duckdb:extension` **WebAssembly components** inside DuckDB. A component is built once against the `duckdb:extension` WIT world and loads into DuckDB on any supported platform without per-platform native builds; ducklink runs the component's `load()`, captures the scalar / table / aggregate functions it registers, and bridges them into DuckDB's catalog.

### Details
- **Language / build:** Rust, `build: cargo` (extension-template-rs layout, unstable C API).
- **Target:** DuckDB v1.5.4 (`duckdb` crate `1.10504.0`).
- **Built-in:** `ducklink_version()` is always available, so the hello-world works with no component configured. Components are supplied via the `DUCKLINK_COMPONENTS` environment variable (`name=path`, read at `LOAD` time).
- **Excluded platforms:** the wasm targets (the extension itself embeds a Cranelift JIT and cannot target wasm), plus `windows_amd64_mingw`, `windows_amd64_rtools`, and `linux_amd64_musl`.
- **Source:** [`tegmentum/ducklink-extension`](https://github.com/tegmentum/ducklink-extension) @ `v0.1.0`. Builds clean locally via `make configure && make release` (metadata-stamped `ducklink.duckdb_extension`, `duckdb_version=v1.5.4`, `abi_type=C_STRUCT_UNSTABLE`).

### Tests
`test/sql/ducklink.test` loads the extension and asserts `ducklink_version()`. The bridge has extensive upstream coverage (unit + corpus) in the source repo.
