### PR TITLE
Update duckdb-otlp to v0.6.0

### DIFF
--- a/extensions/otlp/description.yml
+++ b/extensions/otlp/description.yml
@@ -1,18 +1,18 @@
 extension:
   name: otlp
   description: Query OpenTelemetry traces, logs, and metrics with SQL — or stream live OTLP/HTTP into DuckDB, DuckLake, or Iceberg
-  version: 92be607837490e8246ca876619cee393bff27981
+  version: 0.6.0
   language: C++
   build: cmake
   license: MIT
-  excluded_platforms: "wasm_mvp;wasm_threads;linux_amd64_musl"
+  excluded_platforms: "wasm_mvp;wasm_threads;linux_amd64_musl;windows_amd64;windows_amd64_mingw"
   requires_toolchains: rust
   maintainers:
     - smithclay
 
 repo:
   github: smithclay/duckdb-otlp
-  ref: v0.5.0
+  ref: 5f32698962567b9e30bf79746b166e89543bffb0
 
 docs:
   hello_world: |


### PR DESCRIPTION
Updates duckdb-otlp to `v0.6.0` 

Some cool new features in this release:
* Experimental [OpenTelemetry Arrow](https://github.com/open-telemetry/otel-arrow) protocol support
* Can promote OpenTelemetry attributes at ingest-time to columns for faster queries