### PR TITLE
raquet: 0.2.7

### DIFF
--- a/extensions/raquet/description.yml
+++ b/extensions/raquet/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: raquet
   description: "Raster analytics on Raquet files with QUADBIN spatial indexing, raster ingestion, and PostGIS-style functions"
-  version: 0.2.6
+  version: 0.2.7
   language: C++
   build: cmake
   license: Apache-2.0
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: jatorre/duckdb-raquet
-  ref: e077a7c36f4527949cd5e36719cf4c81289d9d4b
+  ref: b6e348baa9f522a21adc647671ca79d65e7ff6a5
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps **raquet** to **0.2.7**.

- `version`: 0.2.6 → 0.2.7
- `ref`: `e077a7c` → `b6e348b` (jatorre/duckdb-raquet@main)

### Changes since 0.2.6 (single commit, jatorre/duckdb-raquet#17)

Fixes `read_raster()` collapsing any full-globe (±90° latitude) EPSG:4326 raster into a single zoom-0 tile.

The WGS84 fast path (`CalculateResolutionFromWGS84`) fed raw corner latitudes into `LatToMercatorY`, which had no latitude clamp. At the poles the Web Mercator projection diverges — `tan(π/2) → ∞` at +90°, `log(0) = −∞` at −90° — so the projected Y extent became infinite, the computed resolution exploded, and the zoom rounded down to 0. The entire raster was then written as one world tile (`num_blocks=1`), silently discarding the data.

The fix clamps latitude to ±85.0511° (the Web Mercator limit) inside `LatToMercatorY`, matching the clamp already applied in the QUADBIN cell math (`lonlat_to_tile` / `lonlat_to_pixel`). Rasters whose latitudes stay within ±85° are unaffected (the clamp branch is never taken).

Verified on a real 362,880×181,440 global raster: output went from 2 rows / 1 block to ~350k blocks at the native resolution, tiling correctly in WebMercatorQuad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)