### PR TITLE
Add `pdf` extension

### DIFF
--- a/extensions/pdf/description.yml
+++ b/extensions/pdf/description.yml
@@ -26,7 +26,7 @@ extension:
 
 repo:
   github: asubbarao/duckdb-pdf
-  ref: 323af182abef7df45a886e88e9a67a491b61db83
+  ref: 6e7dbcc12f77d2670e1bab32462bc684afc44932
 
 docs:
   hello_world: |

--- a/extensions/pdf/description.yml
+++ b/extensions/pdf/description.yml
@@ -1,13 +1,21 @@
+# Community-extensions submission descriptor for the `pdf` extension.
+#
+# To submit this extension to the DuckDB community-extensions registry:
+#   1. Fork https://github.com/duckdb/community-extensions
+#   2. Copy this file to extensions/pdf/description.yml in your fork
+#   3. Set repo.ref below to the exact git SHA of the release commit in
+#      asubbarao/duckdb-pdf that the registry should build from
+#   4. Open a pull request against duckdb/community-extensions
+
 extension:
   name: pdf
   description: >-
     Read and extract content from PDF files. Provides table functions for
-    page-level text (read_pdf), layout-preserving lines (read_pdf_lines),
-    document metadata (read_pdf_meta), word-level bounding-box extraction
-    (read_pdf_words), and table detection (read_pdf_tables), plus scalar
-    functions for full-document conversion to plain text, HTML, XML, and SVG
-    (pdf_to_text, pdf_to_html, pdf_to_xml, pdf_to_svg). Supports OCR of scanned
-    PDFs via Tesseract.
+    page-level text (read_pdf), document metadata (read_pdf_meta), word-level
+    bounding-box extraction (read_pdf_words), and table detection
+    (read_pdf_tables), plus scalar functions for full-document conversion to
+    plain text, HTML, XML, and SVG (pdf_to_text, pdf_to_html, pdf_to_xml,
+    pdf_to_svg). Supports OCR of scanned PDFs via Tesseract.
   version: 0.1.0
   language: C++
   build: cmake
@@ -24,7 +32,7 @@ extension:
 
 repo:
   github: asubbarao/duckdb-pdf
-  ref: c0956afb5e46e1013a6c105aa67b02b3ef3b053c
+  ref: 3ffb8d85c4ea4ce65876657027cd49719e7d8808
 
 docs:
   hello_world: |
@@ -57,7 +65,8 @@ docs:
     All table functions accept a single path, a list of paths, or a glob
     (`'docs/*.pdf'`). Shared named parameters: `first_page`, `last_page`,
     `password`, `layout` ('reading' | 'physical' | 'raw'), and the OCR knobs
-    `ocr`, `auto_ocr`, `ocr_language`, `ocr_dpi`, `ocr_psm`, `ocr_oem`.
+    `ocr`, `auto_ocr`, `ocr_language`, `ocr_dpi`, `ocr_psm`, `ocr_oem`,
+    `tessdata_dir`.
 
     **Table functions**
 
@@ -84,13 +93,17 @@ docs:
 
     Pages with no extractable text layer are OCR'd automatically (`auto_ocr`,
     on by default); pass `ocr := true` to force OCR on every page. OCR requires a
-    Tesseract language model at runtime, located via the `TESSDATA_PREFIX`
-    environment variable — package managers do not ship one. Install a model
-    (`brew install tesseract-lang` on macOS; `apt-get install tesseract-ocr-eng`
-    on Debian/Ubuntu; or download `eng.traineddata` from the tessdata_fast repo)
-    and point `TESSDATA_PREFIX` at its directory. Select the language with
-    `ocr_language` (e.g. `ocr_language := 'deu'`). If no model is found, OCR
-    raises a clear error with these instructions rather than returning empty text.
+    Tesseract language model at runtime — package managers do not ship one — but
+    once you install one the usual way it works with **no configuration**: the
+    extension auto-detects the standard model directories used by Homebrew
+    (`brew install tesseract tesseract-lang`), apt
+    (`apt-get install tesseract-ocr tesseract-ocr-eng`), and the Windows
+    installer. To use a non-standard location, pass
+    `tessdata_dir := '/path/to/tessdata'` per query, or set the `TESSDATA_PREFIX`
+    environment variable (resolution order: `tessdata_dir` → `TESSDATA_PREFIX` →
+    auto-detected paths). Select the language with `ocr_language`
+    (e.g. `ocr_language := 'deu'`). If no model is found anywhere, OCR raises a
+    clear, actionable error rather than returning empty text.
 
     **Table extraction: scope**
 

--- a/extensions/pdf/description.yml
+++ b/extensions/pdf/description.yml
@@ -26,7 +26,7 @@ extension:
 
 repo:
   github: asubbarao/duckdb-pdf
-  ref: 6e7dbcc12f77d2670e1bab32462bc684afc44932
+  ref: 03380d1f5ece904b96fc0963d08cd7331ebe0c3f
 
 docs:
   hello_world: |

--- a/extensions/pdf/description.yml
+++ b/extensions/pdf/description.yml
@@ -32,7 +32,7 @@ extension:
 
 repo:
   github: asubbarao/duckdb-pdf
-  ref: 3ffb8d85c4ea4ce65876657027cd49719e7d8808
+  ref: 655a81dc0228ffe8503fdd5811bd373e42f1c22e
 
 docs:
   hello_world: |

--- a/extensions/pdf/description.yml
+++ b/extensions/pdf/description.yml
@@ -1,0 +1,117 @@
+extension:
+  name: pdf
+  description: >-
+    Read and extract content from PDF files. Provides table functions for
+    page-level text (read_pdf), layout-preserving lines (read_pdf_lines),
+    document metadata (read_pdf_meta), word-level bounding-box extraction
+    (read_pdf_words), and table detection (read_pdf_tables), plus scalar
+    functions for full-document conversion to plain text, HTML, XML, and SVG
+    (pdf_to_text, pdf_to_html, pdf_to_xml, pdf_to_svg). Supports OCR of scanned
+    PDFs via Tesseract.
+  version: 0.1.0
+  language: C++
+  build: cmake
+  license: GPL-2.0-or-later
+  maintainers:
+    - asubbarao
+  # windows_amd64 (MSVC/vcpkg) builds and is supported. mingw/rtools use a
+  # different toolchain than the MSVC static linkage this extension relies on;
+  # windows_arm64 is untested; wasm cannot link Poppler/Tesseract.
+  excluded_platforms: wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;windows_amd64_rtools;windows_arm64
+  requires_toolchains: vcpkg
+  vcpkg_url: https://github.com/microsoft/vcpkg.git
+  vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
+
+repo:
+  github: asubbarao/duckdb-pdf
+  ref: c0956afb5e46e1013a6c105aa67b02b3ef3b053c
+
+docs:
+  hello_world: |
+    -- Load the extension
+    LOAD pdf;
+
+    -- One row per page (filename, page, page_count, text, width, height).
+    -- Accepts a single file, a list, or a glob.
+    SELECT page, text
+    FROM read_pdf('report.pdf');
+
+    -- Search across many PDFs at once
+    SELECT filename, page
+    FROM read_pdf('reports/*.pdf')
+    WHERE text ILIKE '%revenue%';
+
+    -- Document metadata, one row per file
+    SELECT title, author, pages FROM read_pdf_meta('report.pdf');
+
+    -- Extract tabular regions from digital PDFs
+    SELECT * FROM read_pdf_tables('financial_report.pdf');
+
+    -- Whole document as plain text (scalar)
+    SELECT pdf_to_text('report.pdf') AS full_text;
+
+  extended_description: |
+    The `pdf` extension brings native PDF reading to DuckDB using the Poppler
+    library for rendering and Tesseract for OCR of scanned pages.
+
+    All table functions accept a single path, a list of paths, or a glob
+    (`'docs/*.pdf'`). Shared named parameters: `first_page`, `last_page`,
+    `password`, `layout` ('reading' | 'physical' | 'raw'), and the OCR knobs
+    `ocr`, `auto_ocr`, `ocr_language`, `ocr_dpi`, `ocr_psm`, `ocr_oem`.
+
+    **Table functions**
+
+    - `read_pdf(path, ...)` — one row per page; columns: filename, page,
+      page_count, text, width, height (page size in PDF points).
+    - `read_pdf_lines(path, ...)` — one row per layout-preserving line of text;
+      columns: filename, page, line, text. A PDF-aware analog to `read_lines`.
+    - `read_pdf_meta(path)` — one row per file; columns: filename, title, author,
+      subject, keywords, creator, producer, pages, pdf_version, encrypted.
+    - `read_pdf_words(path, ...)` — one row per word; columns: filename, page,
+      word, x0, y0, x1, y1 (bounding box in PDF user-space points, origin
+      bottom-left), font_name, font_size.
+    - `read_pdf_tables(path, ...)` — extracts tabular regions from digital PDFs;
+      columns: filename, page, table_index, row_index, cells (VARCHAR[]).
+
+    **Scalar functions**
+
+    - `pdf_to_text(path[, layout])` — entire document as a plain-text VARCHAR.
+    - `pdf_to_html(path)` — document rendered to HTML.
+    - `pdf_to_xml(path)` — document rendered to XML (Poppler pdftoxml format).
+    - `pdf_to_svg(path, page)` — a single page rendered to SVG.
+
+    **OCR (scanned / image-only PDFs)**
+
+    Pages with no extractable text layer are OCR'd automatically (`auto_ocr`,
+    on by default); pass `ocr := true` to force OCR on every page. OCR requires a
+    Tesseract language model at runtime, located via the `TESSDATA_PREFIX`
+    environment variable — package managers do not ship one. Install a model
+    (`brew install tesseract-lang` on macOS; `apt-get install tesseract-ocr-eng`
+    on Debian/Ubuntu; or download `eng.traineddata` from the tessdata_fast repo)
+    and point `TESSDATA_PREFIX` at its directory. Select the language with
+    `ocr_language` (e.g. `ocr_language := 'deu'`). If no model is found, OCR
+    raises a clear error with these instructions rather than returning empty text.
+
+    **Table extraction: scope**
+
+    `read_pdf_tables` uses a precision-first geometric heuristic (word
+    bounding-box column clustering with a regularity gate) on digital PDFs. It
+    reliably handles clean, aligned tables and avoids emitting spurious tables
+    from prose, but it does not do ML-based table-structure recognition — merged
+    cells, borderless/sparse tables, and scanned tables are out of scope. For
+    state-of-the-art document understanding, reach for tools like docling,
+    marker, or a cloud Document AI service; this extension targets the ~80% of
+    everyday text/word/line/metadata/simple-table extraction directly in SQL.
+
+    **Platform support**
+
+    Linux (x86_64, arm64), macOS (x86_64, arm64), and Windows (x64, MSVC) are
+    supported — all dependencies are resolved through vcpkg and statically linked.
+    The mingw/rtools Windows variants and windows_arm64 are excluded (different
+    toolchain / untested), and WebAssembly is excluded because Poppler and
+    Tesseract cannot be linked into the wasm target.
+
+    **License**
+
+    GPL-2.0-or-later. Poppler is GPL-2.0; statically linking it requires the
+    combined work to be distributed under the GPL.

--- a/extensions/pdf/description.yml
+++ b/extensions/pdf/description.yml
@@ -9,13 +9,7 @@
 
 extension:
   name: pdf
-  description: >-
-    Read and extract content from PDF files. Provides table functions for
-    page-level text (read_pdf), document metadata (read_pdf_meta), word-level
-    bounding-box extraction (read_pdf_words), and table detection
-    (read_pdf_tables), plus scalar functions for full-document conversion to
-    plain text, HTML, XML, and SVG (pdf_to_text, pdf_to_html, pdf_to_xml,
-    pdf_to_svg). Supports OCR of scanned PDFs via Tesseract.
+  description: Read text, metadata, words, lines, and tables from PDF files, with optional Tesseract OCR for scanned pages.
   version: 0.1.0
   language: C++
   build: cmake
@@ -32,7 +26,7 @@ extension:
 
 repo:
   github: asubbarao/duckdb-pdf
-  ref: 655a81dc0228ffe8503fdd5811bd373e42f1c22e
+  ref: ad440c5a28e46cac69e799d691f5f6e317bfb1bb
 
 docs:
   hello_world: |

--- a/extensions/pdf/description.yml
+++ b/extensions/pdf/description.yml
@@ -26,7 +26,7 @@ extension:
 
 repo:
   github: asubbarao/duckdb-pdf
-  ref: 5bfd93e51144e2da2866a1fbd5aa9dfbb74100b2
+  ref: 323af182abef7df45a886e88e9a67a491b61db83
 
 docs:
   hello_world: |

--- a/extensions/pdf/description.yml
+++ b/extensions/pdf/description.yml
@@ -26,7 +26,7 @@ extension:
 
 repo:
   github: asubbarao/duckdb-pdf
-  ref: ad440c5a28e46cac69e799d691f5f6e317bfb1bb
+  ref: 5bfd93e51144e2da2866a1fbd5aa9dfbb74100b2
 
 docs:
   hello_world: |


### PR DESCRIPTION
Adds the **`pdf`** community extension: read and extract content from PDF files directly in SQL, built on **Poppler** (parsing/rendering/metadata) and **Tesseract + Leptonica** (OCR of scanned PDFs).

**Repo:** https://github.com/asubbarao/duckdb-pdf

### Functions
- Table functions: `read_pdf` (page text + dimensions), `read_pdf_lines` (layout-preserving lines), `read_pdf_meta` (document metadata), `read_pdf_words` (word bounding boxes + fonts), `read_pdf_tables` (precision-first table extraction on digital PDFs)
- Scalar functions: `pdf_to_text` (with optional `layout`), `pdf_to_html`, `pdf_to_xml`, `pdf_to_svg`
- All table functions accept a single path, a list, or a glob; shared named params for page range, password, layout, and OCR knobs.

### Platforms
Builds and tests pass on **Linux (x86_64, arm64), macOS (x86_64, arm64), and Windows x64 (MSVC)** — all dependencies resolved via vcpkg and statically linked. mingw/rtools, windows_arm64, and wasm are excluded (toolchain/linkage constraints).

### OCR note
OCR requires a Tesseract language model at runtime (located via `TESSDATA_PREFIX`); package managers don't ship one, so the extension raises a clear, actionable error when a model is absent rather than returning empty text. The repo's OCR tests are gated on a model being present.

### License
GPL-2.0-or-later (statically links Poppler, which is GPL-2.0).