### PR TITLE
anofox_statistics: bump ref to v0.7.0 (GLM families + LARS)

### DIFF
--- a/extensions/anofox_statistics/description.yml
+++ b/extensions/anofox_statistics/description.yml
@@ -1,6 +1,6 @@
 extension:
   name: anofox_statistics
-  description: A DuckDB extension for statistical regression analysis, providing OLS, Ridge, Elastic Net, WLS, recursive least squares, robust estimators (Huber, RANSAC, Theil-Sen), GLMs, and time-series regression with full diagnostics and inference directly in SQL.
+  description: A DuckDB extension for statistical regression analysis, providing OLS, Ridge, Elastic Net, LARS/LassoLars, WLS, recursive least squares, robust estimators (Huber, RANSAC, Theil-Sen), GLMs (Poisson, Negative Binomial, Binomial, Tweedie, Gamma, Logistic), and time-series regression with full diagnostics and inference directly in SQL.
   language: C++
   build: cmake
   license: BSL 1.1
@@ -9,4 +9,4 @@ extension:
   requires_toolchains: rust
 repo:
   github: DataZooDE/anofox-statistics
-  ref: 606775851e1c3f8ddf3cf975b1ff377101991f99
+  ref: 5f9ab25c4dc263178cb50197b480892d5f2dcd4e


### PR DESCRIPTION
Bumps `anofox_statistics` to **v0.7.0** (`DataZooDE/anofox-statistics@5f9ab25`).

### Since the currently-published ref
- **GLM family completion**: Negative Binomial, Binomial, Tweedie, Gamma, and binary Logistic regression (alongside the existing Poisson) — Rust core + FFI + C++ aggregates + SQL.
- **LARS / LassoLars** regression.
- **Bug fix**: nondeterministic NaN/garbage predictions on rows with a NULL feature, across all `*_fit_predict` aggregates (uninitialized read).

Description updated to list the new GLM families and LARS. Builds against DuckDB v1.5.4 and v1.4.5 LTS.

Release: https://github.com/DataZooDE/anofox-statistics/releases/tag/v0.7.0