### PR TITLE
Update ducklink to v0.2.0

### DIFF
--- a/extensions/ducklink/description.yml
+++ b/extensions/ducklink/description.yml
@@ -3,7 +3,7 @@
 extension:
   name: ducklink
   description: Run WebAssembly component extensions inside DuckDB
-  version: 0.1.0
+  version: 0.2.0
   language: Rust
   build: cargo
   license: MIT
@@ -19,13 +19,13 @@ extension:
 
 repo:
   github: tegmentum/ducklink-extension
-  ref: v0.1.0
+  ref: v0.2.0
 
 docs:
   hello_world: |
     -- The extension ships one built-in, so loading works with no component:
     LOAD ducklink;
-    SELECT ducklink_version();   -- e.g. 'ducklink 0.1.0'
+    SELECT ducklink_version();   -- e.g. 'ducklink 0.2.0'
 
     -- To expose a component's functions, point ducklink at one or more
     -- `duckdb:extension` WebAssembly components via the DUCKLINK_COMPONENTS


### PR DESCRIPTION
## ducklink v0.2.0

Bumps the `ducklink` community extension from v0.1.0 to v0.2.0 (`repo.ref: v0.2.0`).

ducklink runs `duckdb:extension` WebAssembly **components** inside DuckDB — one
portable component, built once, runs on every platform without per-platform
native builds.

### What's new since v0.1.0
- **Versioned contract + load guard.** The `duckdb:extension` WIT contract is now
  versioned (`@2.0.0`) with a content-addressed identity (a `witcanon` digest of
  the contract shape). The host rejects components built against an incompatible
  contract at load time with an actionable message instead of silently
  mis-marshalling values.
- **Rich logical types.** Full marshalling for the expanded logical-type set —
  int8/16/32, the unsigned ints, float32, date/time/timestamp/timestamptz,
  interval, decimal, uuid, and the nested escape-hatch — across the component
  boundary.
- **wasmtime 46.0.1** (from the prior pin) and an embedded, vendored runtime so
  the build is self-contained.

`ducklink_version()` is built in, so the extension is usable and testable before
any component is configured:

```sql
LOAD ducklink;
SELECT ducklink_version();   -- 'ducklink 0.2.0'
```

Builds and tests green locally (`make release` + `make test_release` → SUCCESS).
