### PR TITLE
web_archive: bump to 2026062703 (gzip auto-decompression + wayback fixes, DuckDB v1.5.4)

### DIFF
--- a/extensions/web_archive/description.yml
+++ b/extensions/web_archive/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: web_archive
   description: Query Common Crawl and Wayback Machine web archive CDX APIs directly from SQL
-  version: '2026062701'
+  version: '2026062702'
   language: C++
   build: cmake
   license: MIT
@@ -11,8 +11,8 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb-web-archive
-  andium: 59eb0c1faac8ffd27b9e79fdba4a7e59cdbcae1e
-  ref: 885e02ef3a03af1efcffa8467c8daf74fd8f55a3
+  andium: b8436ee3efcb1533896722b45e51d08e3679ce6d
+  ref: 8d644eb2645370cefff98fc683cea1319b14df7c
 
 docs:
   hello_world: |

--- a/extensions/web_archive/description.yml
+++ b/extensions/web_archive/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: web_archive
   description: Query Common Crawl and Wayback Machine web archive CDX APIs directly from SQL
-  version: '2026020301'
+  version: '2026062701'
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb-web-archive
-  andium: 90c67cb283d668aec7154b8abd3e3001669696b7
+  andium: 59eb0c1faac8ffd27b9e79fdba4a7e59cdbcae1e
   ref: 885e02ef3a03af1efcffa8467c8daf74fd8f55a3
 
 docs:

--- a/extensions/web_archive/description.yml
+++ b/extensions/web_archive/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: web_archive
   description: Query Common Crawl and Wayback Machine web archive CDX APIs directly from SQL
-  version: '2026062702'
+  version: '2026062703'
   language: C++
   build: cmake
   license: MIT
@@ -11,8 +11,8 @@ extension:
 
 repo:
   github: midwork-finds-jobs/duckdb-web-archive
-  andium: b8436ee3efcb1533896722b45e51d08e3679ce6d
-  ref: 8d644eb2645370cefff98fc683cea1319b14df7c
+  andium: 33968f9147d851ff565b19546650162c73b85f5e
+  ref: fa55e897d42ad8859f9d707d793b58807a8c8e84
 
 docs:
   hello_world: |


### PR DESCRIPTION
Updates the `web_archive` community extension to **2026062703**, built against latest stable DuckDB **v1.5.4**.

- **ref** → `fa55e89` (v1.5 branch HEAD, stable build)
- **andium** → `33968f9` (v1.4 branch HEAD, v1.4.5 build)

Changes since last published version:
1. **gzip auto-decompression** — `wayback_machine().response.body` now transparently inflates gzip/zlib archived bodies (the `…id_/` endpoint returns original Content-Encoding. serve gzip). No more manual gunzip before HTML parsing.
2. **response.body fetch fix** — `response` no longer returns empty when `url`/`timestamp` columns aren't projected (CDX `&fl=` now always includes `original`/`timestamp`).

Verified building + `make test` (304 assertions) against v1.5.4;