### PR TITLE
agent_data: update to 0.2.0 (DuckDB v1.5.4, adds Codex & Gemini)

### DIFF
--- a/extensions/agent_data/description.yml
+++ b/extensions/agent_data/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: agent_data
   description: A DuckDB extension written in Rust for querying, analysing and inspecting AI coding agents history. Read conversations, plans, todos, history, and usage stats directly from your local agent data directories.
-  version: 0.1.0
+  version: 0.2.0
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: axsaucedo/agent_data_duckdb
-  ref: 537172a74104f520e642c20421520dcd88b865cc
+  ref: 1b9b232056763204c12046beacd5c99a6672442e
 
 docs:
   hello_world: |
@@ -53,9 +53,7 @@ docs:
 
   extended_description: |
 
-    **Supported agents:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (`~/.claude`) and [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) (`~/.copilot`).
-
-    > OpenAI Codex and Gemini CLI Coming Soon™.
+    **Supported agents:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (`~/.claude`), Claude Desktop, [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) (`~/.copilot`), [OpenAI Codex](https://openai.com/codex) (`~/.codex`), and [Gemini CLI](https://github.com/google-gemini/gemini-cli) (`~/.gemini`).
 
     Written in 🦀 Rust.
 
@@ -71,17 +69,19 @@ docs:
     | `read_history()` | `~/.claude` | Claude Code |
     | `read_stats()` | `~/.claude` | Claude Code |
 
-    To read Copilot data, pass the path explicitly:
+    To read another agent's data, pass the path explicitly:
 
     ```sql
     FROM read_conversations(path='~/.copilot');
+    FROM read_conversations(path='~/.codex');
+    FROM read_conversations(path='~/.gemini');
     ```
 
     ### Available Functions
 
     All functions accept two optional parameters:
-    - **`path`** — data directory path (default: `~/.claude`). Auto-detected from folder structure (`projects/` → Claude, `session-state/` → Copilot).
-    - **`source`** — explicit provider override: `'claude'` or `'copilot'`. Use when auto-detection fails or for non-standard directory layouts.
+    - **`path`** — data directory path (default: `~/.claude`). Auto-detected from folder structure (`projects/` → Claude, `session-state/` → Copilot, dated `sessions/` → Codex, `tmp/` + `installation_id` → Gemini).
+    - **`source`** — explicit provider override: `'claude'`, `'claude-desktop'`, `'copilot'`, `'codex'`, or `'gemini'`. Use when auto-detection fails or for non-standard directory layouts.
 
     Every table includes a **`source`** column (`'claude'` or `'copilot'`) as the first column.
 


### PR DESCRIPTION
Excited for this one! We're adding Codex & Gemini support 😀

## Summary
- bumps `extensions/agent_data/description.yml` `repo.ref` to `1b9b232056763204c12046beacd5c99a6672442e`
- the new source ref targets DuckDB `v1.5.4`, `duckdb`/`libduckdb-sys` crate `1.10504.0`, and `extension-ci-tools` `v1.5-variegata`
- this should restore latest-stable community binaries so `agent_data` appears in the generated DuckDB community extension list again

## Validation in source repo
Source PR: https://github.com/axsaucedo/duckdb-claude-ext/commit/1b9b232056763204c12046beacd5c99a6672442e

Local validation performed there:
- `cargo metadata --locked --format-version 1`
- `cargo check --locked`
- `make configure`
- `make debug`
- `make test`
- `cargo test --locked`
- `cd examples/tui && uv run pytest`
- manual DuckDB/Python smoke queries against `build/debug/agent_data.duckdb_extension` for Claude and Copilot synthetic data

## Current public baseline
- `https://duckdb.org/community_extensions/extensions/agent_data.html` returns 200
- `https://community-extensions.duckdb.org/v1.5.4/osx_arm64/agent_data.duckdb_extension.gz` returns 404 before trusted deployment
- aggregate list membership for `agent_data` is currently 0 before trusted deployment
- `INSTALL agent_data FROM community` currently fails on DuckDB 1.5.4 before trusted deployment

