### PR TITLE
[Eurostat] Update extension to v0.3.0

### DIFF
--- a/extensions/eurostat/description.yml
+++ b/extensions/eurostat/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: eurostat
   description: Extension that adds support for reading data from EUROSTAT database using SQL.
-  version: 0.2.1
+  version: 0.3.0
   language: C++
   build: cmake
   excluded_platforms: "windows_amd64_mingw"
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: ahuarte47/duckdb-eurostat
-  ref: 519b958f00af9513669dc3fbc6773b807568526b
+  ref: 1a4d0fc189106a0ba889a3bdcb7b2c53997d4e9a
 
 docs:
   hello_world: |

--- a/extensions/eurostat/docs/functions.md
+++ b/extensions/eurostat/docs/functions.md
@@ -128,6 +128,7 @@ SELECT provider_id, organization, description FROM EUROSTAT_Endpoints();
 │ provider_id │ organization │                     description                      │
 │   varchar   │   varchar    │                       varchar                        │
 ├─────────────┼──────────────┼──────────────────────────────────────────────────────┤
+│ COMEXT      │ EUROSTAT     │ Comext reference database                            │
 │ ECFIN       │ DG ECFIN     │ Economic and Financial Affairs                       │
 │ EMPL        │ DG EMPL      │ Employment, Social Affairs and Inclusion             │
 │ ESTAT       │ EUROSTAT     │ EUROSTAT database                                    │


### PR DESCRIPTION
Changes:
* Adds **Comext** reference database (https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-getting-started/comext-database).