### PR TITLE
Update ducklink to v0.2.1

### DIFF
--- a/extensions/ducklink/description.yml
+++ b/extensions/ducklink/description.yml
@@ -3,7 +3,7 @@
 extension:
   name: ducklink
   description: Run WebAssembly component extensions inside DuckDB
-  version: 0.2.0
+  version: 0.2.1
   language: Rust
   build: cargo
   license: MIT
@@ -19,13 +19,13 @@ extension:
 
 repo:
   github: tegmentum/ducklink-extension
-  ref: v0.2.0
+  ref: v0.2.1
 
 docs:
   hello_world: |
     -- The extension ships one built-in, so loading works with no component:
     LOAD ducklink;
-    SELECT ducklink_version();   -- e.g. 'ducklink 0.2.0'
+    SELECT ducklink_version();   -- e.g. 'ducklink 0.2.1'
 
     -- To expose a component's functions, point ducklink at one or more
     -- `duckdb:extension` WebAssembly components via the DUCKLINK_COMPONENTS


### PR DESCRIPTION
## ducklink v0.2.1

Bumps the `ducklink` community extension from v0.2.0 to v0.2.1 (`repo.ref: v0.2.1`).

ducklink runs `duckdb:extension` WebAssembly **components** inside DuckDB — one
portable component, built once, runs on every platform without per-platform
native builds. It embeds wasmtime, loads each component named in the
`DUCKLINK_COMPONENTS` environment variable, captures the scalar/table/aggregate
functions the component registers, and bridges them into DuckDB's function
catalog. A built-in `ducklink_version()` scalar is always available, so the
extension is usable and testable before any component is configured:

```sql
LOAD ducklink;
SELECT ducklink_version();   -- 'ducklink 0.2.1'
```

### What's new since v0.2.0
This is a patch release: an optimization and test-coverage pass over the native
bridge, with no public API or behavior change.

- **Faster scalar dispatch.** The per-chunk result write is hoisted to a
  column-major path, removing redundant per-row work in the scalar hot loop.
- **Broadened bridge test suite.** Expanded coverage of the value/logical-type
  marshalling, NULL handling, multi-argument and multi-chunk scalars,
  table-function chunking, the aggregate path (init/update/combine/finalize +
  per-group state), multi-component registration, error surfacing, and
  concurrency.

### Validation
- `cargo build --release` is clean.
- `cargo clippy` is clean.
- The Rust bridge test suite is green against a contract-matched component
  corpus (scalar, table, and aggregate end-to-end), and the bundled SQL
  version test is updated to match.
