### PR TITLE
pdf: render scalars (pdf_to_html/xml/svg) + to_pdf document→PDF (bump repo.ref → df35aa9)

### DIFF
--- a/extensions/pdf/description.yml
+++ b/extensions/pdf/description.yml
@@ -26,7 +26,7 @@ extension:
 
 repo:
   github: asubbarao/duckdb-pdf
-  ref: 03380d1f5ece904b96fc0963d08cd7331ebe0c3f
+  ref: fbc9999aa5b70333ec6d13e131c230ed089cdf08
 
 docs:
   hello_world: |

--- a/extensions/pdf/description.yml
+++ b/extensions/pdf/description.yml
@@ -26,7 +26,7 @@ extension:
 
 repo:
   github: asubbarao/duckdb-pdf
-  ref: fbc9999aa5b70333ec6d13e131c230ed089cdf08
+  ref: 4ee32668b3b7130857baa7ad16fab1d65b3d510d
 
 docs:
   hello_world: |

--- a/extensions/pdf/description.yml
+++ b/extensions/pdf/description.yml
@@ -9,7 +9,7 @@
 
 extension:
   name: pdf
-  description: Read text, metadata, words, lines, and tables from PDF files, with optional Tesseract OCR for scanned pages.
+  description: Read text, metadata, words, lines, and tables from PDF files (with optional Tesseract OCR), and convert documents (docx, odt, rtf, html, ...) to PDF.
   version: 0.1.0
   language: C++
   build: cmake
@@ -26,7 +26,7 @@ extension:
 
 repo:
   github: asubbarao/duckdb-pdf
-  ref: 4ee32668b3b7130857baa7ad16fab1d65b3d510d
+  ref: df35aa9979c07688bb9530c15428380418ddc41f
 
 docs:
   hello_world: |
@@ -51,6 +51,11 @@ docs:
 
     -- Whole document as plain text (scalar)
     SELECT pdf_to_text('report.pdf') AS full_text;
+
+    -- Convert a document (docx, odt, rtf, html, ...) to PDF, then read it back
+    -- (requires LibreOffice installed at runtime)
+    SELECT to_pdf('resume.docx');                    -- writes resume.pdf, returns the path
+    SELECT * FROM read_pdf((SELECT to_pdf('resume.docx')));
 
   extended_description: |
     The `pdf` extension brings native PDF reading to DuckDB using the Poppler
@@ -82,6 +87,28 @@ docs:
     - `pdf_to_html(path)` — document rendered to HTML.
     - `pdf_to_xml(path)` — document rendered to XML (Poppler pdftoxml format).
     - `pdf_to_svg(path, page)` — a single page rendered to SVG.
+    - `to_pdf(path[, output_path])` — convert a document (docx, doc, odt, rtf,
+      html, odp, pptx, xlsx, ...) to PDF; writes alongside the input (extension
+      swapped to `.pdf`) or to `output_path`, and returns the written path. See
+      "Saving documents to PDF" below.
+
+    **Saving documents to PDF**
+
+    `to_pdf` converts office and markup documents to PDF by invoking LibreOffice
+    at runtime (the conversion engine is not bundled — only a runtime process is
+    spawned, so nothing is added to the build). LibreOffice is auto-detected on
+    `$PATH` (`soffice`/`libreoffice`), in the macOS app bundle, or via the
+    `LIBREOFFICE_PATH` environment variable; if none is found it raises a clear,
+    actionable error (install with `brew install --cask libreoffice`,
+    `apt-get install libreoffice`, or the Windows installer). A pure-SQL
+    alternative needs no new function at all — compose the `shellfs` extension
+    with LibreOffice's headless converter:
+
+        LOAD shellfs;
+        SELECT * FROM read_text(
+          'soffice --headless --convert-to pdf --outdir /tmp "resume.docx" && echo ok |'
+        );
+        SELECT * FROM read_pdf('/tmp/resume.pdf');
 
     **OCR (scanned / image-only PDFs)**
 


### PR DESCRIPTION
Follow-up to #2133 (which added the `pdf` extension). Bumps `extensions/pdf/description.yml` `repo.ref` to **`df35aa9`**, which lands two batches of new functionality on top of the released extension:

### Render scalars (poppler-cpp, no external tools)
- `pdf_to_html(path)` — document as positioned HTML
- `pdf_to_xml(path)` — document as `pdftoxml`-style XML
- `pdf_to_svg(path, page[, dpi])` — a page as SVG (raster PNG embedded as base64)

These are implemented entirely against the already-linked **poppler-cpp** library — no external CLI processes, no new dependencies. (One macOS-only static-link regression — a duplicate `mbedtls_cipher_*` symbol from vcpkg's `libmbedcrypto.a` vs DuckDB's bundled mbedTLS once `image::save(..., "png")` extended the link closure — was fixed by excluding `libmbed*` from the over-link glob so DuckDB's bundled copy owns those symbols.)

### `to_pdf` — document → PDF conversion
- `to_pdf(path[, output_path])` — convert a document (docx, doc, odt, rtf, html, odp, pptx, xlsx, …) to PDF; writes alongside the input or to `output_path`, returns the path.

**This adds no build/link dependency.** Conversion shells out to **LibreOffice at runtime only** (auto-detected on `$PATH`, the macOS app bundle, or `LIBREOFFICE_PATH`); if LibreOffice isn't installed it raises a clear, actionable error — exactly the graceful-require pattern the extension already uses for the Tesseract OCR model. The extension compiles and CI builds unchanged whether or not a converter is present. The descriptor also documents a pure-SQL alternative composing the `shellfs` extension with `soffice --headless --convert-to pdf`, for users who'd rather not call a scalar function.

### Tests
`make test` is green locally with **no converter installed** — the `to_pdf` graceful-require/error path runs in CI, and the positive conversion path is gated behind `require-env LIBREOFFICE_PATH` (mirrors the OCR tests' `require-env TESSDATA_PREFIX`).

@carlopi — this supersedes the earlier `fbc9999`/`4ee3266` scope on the same PR. Whenever you have a moment to approve the workflow run + review/merge, much appreciated. (Separately, if the community-extensions docs site could be regenerated — `list_of_extensions` is currently built against DuckDB v1.5.2, so `pdf` isn't listed there yet even though it builds and installs fine — that'd be great.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
