### PR TITLE
Update ducklink to v0.3.0

### DIFF
--- a/extensions/ducklink/description.yml
+++ b/extensions/ducklink/description.yml
@@ -3,7 +3,7 @@
 extension:
   name: ducklink
   description: Run WebAssembly component extensions inside DuckDB
-  version: 0.2.0
+  version: 0.3.0
   language: Rust
   build: cargo
   license: MIT
@@ -19,13 +19,13 @@ extension:
 
 repo:
   github: tegmentum/ducklink-extension
-  ref: v0.2.0
+  ref: v0.3.0
 
 docs:
   hello_world: |
     -- The extension ships one built-in, so loading works with no component:
     LOAD ducklink;
-    SELECT ducklink_version();   -- e.g. 'ducklink 0.2.0'
+    SELECT ducklink_version();   -- e.g. 'ducklink 0.3.0'
 
     -- To expose a component's functions, point ducklink at one or more
     -- `duckdb:extension` WebAssembly components via the DUCKLINK_COMPONENTS


### PR DESCRIPTION
Updates the `ducklink` extension from v0.2.0 to v0.3.0.

ducklink is a native DuckDB loadable extension that embeds wasmtime to run
`duckdb:extension` WebAssembly components, bridging the scalar, table, and
aggregate functions a component registers into DuckDB's function catalog.

## What changed in v0.3.0

- Retargets the WebAssembly component contract to `duckdb:extension@3.1.0`
  (contract digest `1b94f15d2c41f9a81de50c6d4d8cf508bf76333c4b901c00f511b811b8eb4983`),
  matching the live component catalog so published components load unchanged.
- Scalar dispatch hot path: per-chunk batched dispatch with resolve-once handle
  lookup, a reused per-thread marshalling scratch, and column-major read/write
  hoists (validity fetched once per column, NULL mask allocated only when
  needed). Steady-state evaluation allocates no per-row marshalling memory.
- NULL-correctness: input NULLs are propagated to NULL results per SQL
  semantics; panic-guarded FFI callbacks turn a callback panic into a query
  error instead of aborting the host.

The manifest change is limited to the version, the tag ref, and the version
string in the hello-world example. The source tag is
`tegmentum/ducklink-extension` at `v0.3.0`.
