### PR TITLE
Update ducklink to v0.4.0

### DIFF
--- a/extensions/ducklink/description.yml
+++ b/extensions/ducklink/description.yml
@@ -3,7 +3,7 @@
 extension:
   name: ducklink
   description: Run WebAssembly component extensions inside DuckDB
-  version: 0.2.0
+  version: 0.4.0
   language: Rust
   build: cargo
   license: MIT
@@ -19,13 +19,13 @@ extension:
 
 repo:
   github: tegmentum/ducklink-extension
-  ref: v0.2.0
+  ref: v0.4.0
 
 docs:
   hello_world: |
     -- The extension ships one built-in, so loading works with no component:
     LOAD ducklink;
-    SELECT ducklink_version();   -- e.g. 'ducklink 0.2.0'
+    SELECT ducklink_version();   -- e.g. 'ducklink 0.4.0'
 
     -- To expose a component's functions, point ducklink at one or more
     -- `duckdb:extension` WebAssembly components via the DUCKLINK_COMPONENTS


### PR DESCRIPTION
Updates the `ducklink` extension from v0.2.0 to v0.4.0.

ducklink is a native DuckDB loadable extension that embeds wasmtime to run
`duckdb:extension` WebAssembly components, bridging the scalar, table, and
aggregate functions a component registers into DuckDB's function catalog.

## What changed in v0.4.0

- Retargets the embedded component contract to `duckdb:extension@4.0.0`
  (contract digest `a2ad9764ac971345d6a650b92edbda034b160980acf148d354126f7e6f92ba40`),
  matching the live `@4.0.0` component catalog.
- The major-4 contract makes the hot dispatch path (scalar / aggregate / cast
  over a DataChunk) **columnar**: arguments cross the canonical ABI as typed
  columns -- one bulk transfer per fixed-width column -- instead of a per-cell
  tagged variant, removing the per-row marshalling on the dispatch boundary.
- The common tier (scalar / table / aggregate, plus window functions over
  component aggregates) runs on DuckDB's stable C Extension API.

## Validation

Built as a loadable `.duckdb_extension` and validated by loading the `@4.0.0`
component corpus into an in-process DuckDB: 193 components load and execute
through the extension; the bridge and runtime unit suites are green.

The extension still ships the built-in `ducklink_version()` scalar, so it is
loadable and testable before any component is configured.