### PR TITLE
Update ducklink to v0.5.1

### DIFF
--- a/extensions/ducklink/description.yml
+++ b/extensions/ducklink/description.yml
@@ -3,7 +3,7 @@
 extension:
   name: ducklink
   description: Run WebAssembly component extensions inside DuckDB
-  version: 0.2.0
+  version: 0.5.1
   language: Rust
   build: cargo
   license: MIT
@@ -19,13 +19,13 @@ extension:
 
 repo:
   github: tegmentum/ducklink-extension
-  ref: v0.2.0
+  ref: v0.5.1
 
 docs:
   hello_world: |
     -- The extension ships one built-in, so loading works with no component:
     LOAD ducklink;
-    SELECT ducklink_version();   -- e.g. 'ducklink 0.2.0'
+    SELECT ducklink_version();   -- e.g. 'ducklink 0.5.1'
 
     -- To expose a component's functions, point ducklink at one or more
     -- `duckdb:extension` WebAssembly components via the DUCKLINK_COMPONENTS

--- a/extensions/ducklink/description.yml
+++ b/extensions/ducklink/description.yml
@@ -3,7 +3,7 @@
 extension:
   name: ducklink
   description: Run WebAssembly component extensions inside DuckDB
-  version: 0.5.1
+  version: 0.5.2
   language: Rust
   build: cargo
   license: MIT
@@ -19,13 +19,13 @@ extension:
 
 repo:
   github: tegmentum/ducklink-extension
-  ref: v0.5.1
+  ref: v0.5.2
 
 docs:
   hello_world: |
     -- The extension ships one built-in, so loading works with no component:
     LOAD ducklink;
-    SELECT ducklink_version();   -- e.g. 'ducklink 0.5.1'
+    SELECT ducklink_version();   -- e.g. 'ducklink 0.5.0'
 
     -- To expose a component's functions, point ducklink at one or more
     -- `duckdb:extension` WebAssembly components via the DUCKLINK_COMPONENTS


### PR DESCRIPTION
Updates `extensions/ducklink/description.yml` from v0.2.0 to **v0.5.1**.

### What ducklink is
ducklink is a native DuckDB loadable extension that embeds wasmtime to run portable `duckdb:extension` WebAssembly components. A component is built once against the `duckdb:extension` WIT world and runs unchanged across platforms, so a single artifact exposes scalar / table / aggregate functions without per-platform native builds.

### Capability parity
This release ships **full capability parity** across two tiers:

- **Common tier** — scalar / table / aggregate functions on DuckDB's **stable C Extension API**. Built on **every** supported platform, including `windows_amd64`.
- **Advanced tier** — parser / optimizer / table-function filter pushdown, via a small C++ shim bound to DuckDB's internal ABI. **Active on linux and macOS**, and **version-guarded** to the exact built-against DuckDB version: on any other host it degrades gracefully to the common tier, never touching an internal-ABI symbol. The advanced tier is compiled out entirely on Windows (the deferred-undefined-symbol link model the shim relies on has no portable PE/COFF equivalent), so Windows builds the common tier — exactly as in v0.4.0.

### Why this supersedes the earlier holds
The previous version bumps (#2150 / #2152 / #2153) were intentionally held by the maintainer pending the advanced dispatch tier, so the community release would reflect full native parity rather than the common tier alone. That tier has now landed, and the v0.5.0 advanced build's Windows regression has been fixed in v0.5.1, so the hold is resolved.

### Cross-platform build verification
Before submitting, the exact community-CI build (`cargo build --release --features loadable`, the default feature set) was run on a clean `ubuntu-latest` / `macos-latest` / `windows-latest` matrix:

- `windows-latest`: **green** — produces `ducklink.dll` (common tier, MSVC, no undefined internal symbols).
- `ubuntu-latest`: **green** — common + advanced tier (tar-extract + C++ shim compiled against internal headers in a clean sandbox).
- `macos-latest`: **green** — common + advanced tier.

`requires_toolchains: "rust;python3"` is sufficient — the linux build image and the macOS runner already provide a C++ compiler for the advanced-tier shim. `excluded_platforms` is unchanged from the merged v0.2.0 manifest (`windows_amd64` remains included).