### PR TITLE
Add lttb community extension

### DIFF
--- a/extensions/lttb/description.yml
+++ b/extensions/lttb/description.yml
@@ -1,0 +1,28 @@
+extension:
+  name: lttb
+  description: Largest-Triangle-Three-Buckets and related time-series downsampling aggregate functions.
+  version: 0.1.0
+  language: C++
+  build: cmake
+  license: MIT
+  maintainers:
+    - reformovo
+
+repo:
+  github: reformovo/duckdb-lttb
+  ref: abe26b4f84cc081ed038e1cda3ee60772d1b7b64
+
+docs:
+  hello_world: |
+    SELECT lttb(x, y, 4)
+    FROM (VALUES (1, 0), (2, 10), (3, -5), (4, 8), (5, 0)) AS t(x, y);
+  extended_description: |
+    The lttb extension provides aggregate functions for time-series downsampling directly in SQL.
+
+    It includes exact Largest-Triangle-Three-Buckets sampling with `lttb`, a ClickHouse-compatible
+    alias `largestTriangleThreeBuckets`, a sorted-input fast path with `lttb_sorted`, selected
+    index output with `lttb_indices`, approximate MinMax preselection with `minmax_lttb` and
+    `minmax_lttb_sorted`, and per-bucket summaries with `bucket_stats`.
+
+    Inputs may use numeric, decimal, date, and timestamp types. The sampled output preserves
+    the input `x` and `y` types as `STRUCT(x, y)[]`.

--- a/extensions/lttb/description.yml
+++ b/extensions/lttb/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: reformovo/duckdb-lttb
-  ref: abe26b4f84cc081ed038e1cda3ee60772d1b7b64
+  ref: 33e4c2682250082de97664a98b099a80e7932e6a
 
 docs:
   hello_world: |

--- a/extensions/lttb/docs/function_descriptions.csv
+++ b/extensions/lttb/docs/function_descriptions.csv
@@ -1,0 +1,8 @@
+function,description,comment,example
+lttb,Downsample points to n representative points using Largest-Triangle-Three-Buckets,"Sorts input by x before sampling.","SELECT lttb(x, y, 4) FROM (VALUES (1, 0), (2, 10), (3, -5), (4, 8), (5, 0)) AS t(x, y);"
+largestTriangleThreeBuckets,Alias for lttb with ClickHouse-compatible naming,"Sorts input by x before sampling.","SELECT largestTriangleThreeBuckets(x, y, 4) FROM (VALUES (1, 0), (2, 10), (3, -5), (4, 8), (5, 0)) AS t(x, y);"
+lttb_sorted,Downsample already-sorted points to n representative points,"Caller must guarantee input is ordered by x.","SELECT lttb_sorted(x, y, 4) FROM (VALUES (1, 0), (2, 10), (3, -5), (4, 8), (5, 0)) AS t(x, y);"
+lttb_indices,Return selected sorted-position indices from LTTB sampling,"Indices are returned as BIGINT[].","SELECT lttb_indices(x, y, 4) FROM (VALUES (1, 0), (2, 10), (3, -5), (4, 8), (5, 0)) AS t(x, y);"
+minmax_lttb,Downsample using MinMax preselection followed by LTTB,"Approximate method for large inputs. Pass NULL for the default minmax_ratio.","SELECT minmax_lttb(x, y, 4, NULL) FROM (VALUES (1, 0), (2, 10), (3, -5), (4, 8), (5, 0)) AS t(x, y);"
+minmax_lttb_sorted,Downsample already-sorted points using MinMax preselection followed by LTTB,"Approximate method for large inputs. Caller must guarantee input is ordered by x.","SELECT minmax_lttb_sorted(x, y, 4, NULL) FROM (VALUES (1, 0), (2, 10), (3, -5), (4, 8), (5, 0)) AS t(x, y);"
+bucket_stats,Return per-bucket statistical summaries over y with x range boundaries,"Returns STRUCT(bucket_start, bucket_end, count, min, max, mean, std, first, last)[].","SELECT bucket_stats(x, y, 3) FROM (VALUES (1, 0), (2, 10), (3, -5), (4, 8), (5, 0)) AS t(x, y);"


### PR DESCRIPTION
## Summary

Adds the `lttb` DuckDB community extension descriptor.

The extension provides time-series downsampling aggregate functions:

- `lttb`
- `largestTriangleThreeBuckets`
- `lttb_sorted`
- `lttb_indices`
- `minmax_lttb`
- `minmax_lttb_sorted`
- `bucket_stats`

## Source

- Repository: https://github.com/reformovo/duckdb-lttb
- Ref: `33e4c2682250082de97664a98b099a80e7932e6a`
- DuckDB version targeted by the extension workflow: `v1.5.4`

## Validation

Ran in the extension repository at `33e4c2682250082de97664a98b099a80e7932e6a`:

- `make format-check`
- `make tidy-check`
- `./build/release/test/unittest "test/sql/lttb.test"`

Also validated this descriptor locally with `scripts/build.py` using `ALL_CHANGED_FILES='extensions/lttb/description.yml'`.
