### PR TITLE
release: duckdb delta sharing v1.5.4.0

### DIFF
--- a/extensions/duckdb_delta_sharing/description.yml
+++ b/extensions/duckdb_delta_sharing/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duckdb_delta_sharing
   description: The most efficient way to query Delta Lake tables directly from DuckDB via the Delta Sharing protocol.
-  version: 0.3.2
+  version: 0.6.1
   language: C++
   build: cmake
   license: Apache-2.0
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: prequel-co/DuckDB-Delta-Sharing
-  ref: 5440afadc620643cfbffcfce0c325d32202e6cfe
+  ref: 9bcc9cc2abafcf0d5445709910dd77f6773c3555
 
 docs:
   hello_world: |
@@ -34,8 +34,11 @@ docs:
     CREATE SECRET (TYPE delta_sharing, PROVIDER env);
 
     -- Discovering Content
-    SELECT * FROM delta_share_list();
-    SELECT * FROM delta_share_list('my_share');
+    SELECT * FROM delta_share_list();                                   -- shares
+    SELECT * FROM delta_share_list('my_share');                         -- schemas in a share
+    SELECT * FROM delta_share_list('my_share', 'my_schema');            -- tables in a schema
+    SELECT * FROM delta_share_list_all_tables('my_share');              -- every table across all schemas
+    SELECT * FROM delta_share_list('my_share', 'my_schema', 'my_table');-- a table's columns
 
     -- Reading Tables
     SELECT * FROM delta_share_read('my_share', 'my_schema', 'my_table') 


### PR DESCRIPTION
Bumps the pinned ref to the released v1.5.4.0 tag

Changes:
- DuckDB 1.5.4 upgrade
- New discovery functions: `delta_share_list_all_tables` and arity-3 `delta_share_list` for column metadata)
- Extension version 0.3.2 -> 0.6.1.