### PR TITLE
Bump to version 0.1.4

### DIFF
--- a/extensions/spxlsx/description.yml
+++ b/extensions/spxlsx/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: spxlsx
   description: Query SharePoint lists and Excel workbooks directly from DuckDB
-  version: 0.1.2
+  version: 0.1.4
   language: C++
   build: cmake
   license: MIT
@@ -9,7 +9,7 @@ extension:
     - paulmupeters
 repo:
   github: paulmupeters/spxlsx
-  ref: v0.1.2
+  ref: v0.1.4
 docs:
   hello_world: |
     LOAD spxlsx;


### PR DESCRIPTION
## Summary

Updates `spxlsx` from v0.1.2 to v0.1.4.

This release replaces the extension’s direct OpenSSL HTTP implementation with DuckDB’s `HTTPUtil`, enabling HTTP requests through DuckDB’s WASM transport.


If possible, could this release also be rebuilt for DuckDB 1.5.3 to replace the previously published non-functional WASM artifacts?