### PR TITLE
webbed: 2.2.1 -> 2.4.0 (DuckDB 1.5.4)

### DIFF
--- a/extensions/webbed/description.yml
+++ b/extensions/webbed/description.yml
@@ -6,9 +6,8 @@ extension:
   build: cmake
   license: MIT
   requires_toolchains: vcpkg
-  # Windows excluded: DuckDB's vendored fmt fails to compile against the community runner's
-  # current MSVC STL (stdext::checked_array_iterator removed); not fixable from the extension.
-  excluded_platforms: windows_amd64;windows_amd64_mingw
+  # Windows re-included for v2.4.0: DuckDB v1.5.4's vendored fmt no longer uses the removed
+  # MSVC STL API (the old compile blocker), and the extension builds on Windows in CI.
   maintainers:
     - teaguesterling
   vcpkg_commit: 68a1c387f660632f2f65cdb7e8cd093a08840e5d

--- a/extensions/webbed/description.yml
+++ b/extensions/webbed/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: webbed
   description: Comprehensive processing extension for web markup languages (XML and HTML) with SAX streaming for large files, intelligent schema inference, XPath-based data extraction, and HTML table parsing.
-  version: 2.2.1
+  version: 2.4.0
   language: C++
   build: cmake
   license: MIT
@@ -15,7 +15,7 @@ extension:
 repo:
   github: teaguesterling/duckdb_webbed
   andium: ddda30f11352138b2451657419640370d1612137
-  ref: ddda30f11352138b2451657419640370d1612137
+  ref: ad2a912d1758a9380a3f9759b78987dd374565ed
 docs:
   docs_url: https://duckdb-webbed.readthedocs.io
   hello_world: |


### PR DESCRIPTION
Bumps **webbed** `2.2.1 → 2.4.0`, tracking the extension's move to **DuckDB v1.5.4** (restores the missing v1.5.4 build).

Highlights in 2.4.0:
- `read_xml` out-of-sample type detection catches outliers by default (larger `sample_size`)
- Large XML/HTML documents now read 2 GiB–4 GiB (chunked read + IO-based libxml2 parse)
- Serializer parity: literal UTF-8 + DOM/SAX-consistent control-char escaping

`ref` → the `v2.4.0` release commit. `excluded_platforms` unchanged (Windows still excluded pending a separate read-path fix on Windows). vcpkg_commit unchanged.

Release: https://github.com/teaguesterling/duckdb_webbed/releases/tag/v2.4.0
