### PR TITLE
Add ai extension

### DIFF
--- a/extensions/ai/description.yml
+++ b/extensions/ai/description.yml
@@ -1,7 +1,7 @@
 extension:
-  name: duckdb_ai
+  name: ai
   description: AI functions for SQL — completions, classification, extraction, embeddings, and read-only SQL generation across local and hosted model providers
-  version: 0.2.0
+  version: 0.3.0
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: leonardovida/duckdb-ai
-  ref: 2fe84f87ca3765fa3a3c633c3de4895e51273fa7
+  ref: 39be40998181b5f4f9948181d955fca32c99aec2
 
 docs:
   hello_world: |

--- a/extensions/ai/description.yml
+++ b/extensions/ai/description.yml
@@ -5,7 +5,7 @@ extension:
   language: C++
   build: cmake
   license: MIT
-  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw"
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads"
   maintainers:
     - leonardovida
 

--- a/extensions/ai/description.yml
+++ b/extensions/ai/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: ai
   description: AI functions for SQL — completions, classification, extraction, embeddings, and read-only SQL generation across local and hosted model providers
-  version: 0.3.0
+  version: 0.3.1
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: leonardovida/duckdb-ai
-  ref: 39be40998181b5f4f9948181d955fca32c99aec2
+  ref: 44b34ec71e03e243ddd53e370ce454476c7ce76b
 
 docs:
   hello_world: |

--- a/extensions/duckdb_ai/description.yml
+++ b/extensions/duckdb_ai/description.yml
@@ -1,0 +1,47 @@
+extension:
+  name: duckdb_ai
+  description: AI functions for SQL — completions, classification, extraction, embeddings, and read-only SQL generation across local and hosted model providers
+  version: 0.2.0
+  language: C++
+  build: cmake
+  license: MIT
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw"
+  maintainers:
+    - leonardovida
+
+repo:
+  github: leonardovida/duckdb-ai
+  ref: 2fe84f87ca3765fa3a3c633c3de4895e51273fa7
+
+docs:
+  hello_world: |
+    -- Use a free local model via Ollama (https://ollama.com)
+    SET duckdb_ai_provider = 'ollama';
+    SET duckdb_ai_model = 'gemma4:e4b';
+
+    SELECT ai_summarize('DuckDB is an analytical database built for fast local queries.');
+
+    -- Or a hosted provider, with the key kept in a DuckDB secret
+    CREATE SECRET openai_ai (TYPE duckdb_ai, AI_PROVIDER 'openai', API_KEY '...', MODEL 'gpt-4o-mini');
+    SELECT ai_classify('invoice overdue', 'billing, support', secret := 'openai_ai');
+  extended_description: |
+    duckdb_ai adds model-backed analytical functions to SQL: completions
+    (`ai_complete`), text tasks (`ai_summarize`, `ai_classify`, `ai_extract`,
+    `ai_translate`, `ai_redact`, `ai_filter`), structured output validated
+    against a JSON Schema (`ai_complete_json`, `ai_complete_record`,
+    `ai_extract_record`), embeddings and similarity (`ai_embed`,
+    `ai_similarity`, `ai_rerank`), aggregates (`ai_agg`, `ai_summarize_agg`),
+    and a SQL assistant that only returns parser-validated read-only `SELECT`
+    statements (`ai_sql`, `ai_query_data`).
+
+    It supports local Ollama and OpenAI-compatible servers as well as OpenAI,
+    Azure OpenAI, Anthropic, Gemini, Mistral, DeepSeek, OpenRouter, Databricks,
+    Snowflake Cortex, and Z.ai. Credentials come from environment variables or
+    DuckDB `TYPE duckdb_ai` secrets — never SQL arguments. The runtime includes
+    concurrency/rate controls, retries with backoff, opt-in response and
+    provider-side prompt caching, batched embedding requests, a network egress
+    allowlist, and local usage/cost tracking via `ai_usage()`.
+
+    The extension performs no network calls at load time; providers are only
+    contacted when an `ai_*` function that needs one is executed. Full docs:
+    https://github.com/leonardovida/duckdb-ai


### PR DESCRIPTION
This PR adds the `ai` extension to the community extensions repository.

`ai` brings AI/LLM functions to DuckDB SQL: completions, text tasks (summarize/classify/extract/translate/redact/filter), JSON-Schema-validated structured output projected into typed DuckDB columns, embeddings with automatic per-chunk batching, aggregates, and a SQL assistant that only emits parser-validated read-only `SELECT` statements. It works with local models (Ollama, any OpenAI-compatible server) and hosted providers (OpenAI, Azure OpenAI, Anthropic, Gemini, Mistral, DeepSeek, OpenRouter, Databricks, Snowflake Cortex, Z.ai).

```sql
INSTALL ai FROM community;
LOAD ai;
SELECT ai_summarize('DuckDB is an analytical database built for fast local queries.');
```

Notes for review:
- Dependencies: libcurl only via `vcpkg.json` in the extension repo. WASM platforms are excluded because the extension needs raw socket access through libcurl.
- Network behavior: no network activity at extension load; HTTP requests happen only when a provider-backed `ai_*` function executes. An egress allowlist (`duckdb_ai_allowed_hosts`) is available, and redirects are not followed.
- Credentials are resolved from env vars or DuckDB `TYPE duckdb_ai` secrets, never from SQL arguments; API keys are redacted from error messages and secret listings.
- Docs: https://github.com/leonardovida/duckdb-ai (function reference, provider guides, security/data-flow notes).

