### PR TITLE
urlpattern: 0.3.0 → 0.3.2 (fix DuckDB v1.5.4 build + correctness)

### DIFF
--- a/extensions/urlpattern/description.yml
+++ b/extensions/urlpattern/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: urlpattern
   description: WHATWG URLPattern API for matching and extracting components from URLs using pattern syntax
-  version: 0.3.0
+  version: 0.3.2
   language: C++
   build: cmake
   license: MIT
@@ -12,8 +12,8 @@ extension:
 
 repo:
   github: teaguesterling/duckdb_urlpattern
-  andium: 91719fd6a03574be86bf53f73b3d0fc8a9c3d493
-  ref: 91719fd6a03574be86bf53f73b3d0fc8a9c3d493
+  andium: 740ab52dd074d5abd2e942e79e09e48230a80aef
+  ref: 740ab52dd074d5abd2e942e79e09e48230a80aef
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps the `urlpattern` extension from **0.3.0 → 0.3.2**.

### Why
The extension currently **fails to build against DuckDB v1.5.4**, so it is unusable on the latest release. This release fixes that, plus two correctness findings.

### Changes in 0.3.2
- **Build fix (the unblock):** a C++-standard mismatch caused a duplicate-symbol link error (`multiple definition of BufferedFileWriter::DEFAULT_OPEN_FLAGS`). The `ada` dependency exports `cxx_std_20` as an INTERFACE compile-feature, which propagated to targets linking the extension and bumped them to c++20, while DuckDB's core object libraries stayed at c++11 — turning that member into a strong symbol on one side and an inline (mergeable) variable on the other. Fixed by pinning the build to a single standard (`-DCMAKE_CXX_STANDARD=17`) so it's an inline variable everywhere.
- **Correctness:** query params are now percent-decoded per WHATWG URLSearchParams (`+`→space, `%XX` decode) in `url_search_params`/`url_search_param`.
- **Correctness:** `urlpattern_init` component values containing `;` no longer truncate (the `init:` handle now escapes `;`).

### Validation
- Clean build + full test suite pass locally against **DuckDB v1.5.4** (145 assertions, up from 138 — added regression tests for both correctness fixes).
- `excluded_platforms` and `vcpkg_commit` unchanged from 0.3.0.

Ref: `teaguesterling/duckdb_urlpattern@v0.3.2` (`740ab52`).