### PR TITLE
read_lines: bump to v0.2.1

### DIFF
--- a/extensions/read_lines/description.yml
+++ b/extensions/read_lines/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: read_lines
   description: Read line-based text files with line numbers and efficient subset extraction. Supports glob patterns, line selection, and context lines around matches.
-  version: 0.1.4
+  version: 0.2.1
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 repo:
   github: teaguesterling/duckdb_read_lines
   andium: 8075509bc21b936c228879ada22c8a46657109aa
-  ref: refs/tags/v0.1.4
+  ref: refs/tags/v0.2.1
 docs:
   hello_world: |
     -- Read all lines from a file
@@ -43,9 +43,12 @@ docs:
 
     **Functions:**
     - `read_lines(path)` - Read all lines from file(s) with glob support
-    - `read_lines(path, lines)` - Read selected lines (positional argument)
-    - `read_lines_lateral(path, lines)` - Lateral join variant for file paths from table columns
+    - `read_lines(path, lines[, trim])` - Read selected lines (positional arguments)
+    - `read_lines_lateral(path[, lines[, trim]])` - Lateral join variant for file paths from table columns
     - `parse_lines(text, ...)` - Parse lines from a string
+
+    Sources may be non-seekable (pipes/streams, e.g. shellfs commands), including
+    per-row commands in a correlated lateral join.
 
     **Output Schema:**
     | Column | Type | Description |
@@ -54,6 +57,13 @@ docs:
     | content | VARCHAR | Line content (preserves original line endings) |
     | byte_offset | BIGINT | Byte position of line start |
     | file_path | VARCHAR | Source file path (read_lines only) |
+
+    **Trimming** (`trim` argument; transforms content only, never changes which rows appear):
+    - `NULL` / `false` / `'none'` - Preserve exactly (default)
+    - `true` / `'endings'` - Strip the line terminator only
+    - `'right'` - Strip terminator and trailing spaces/tabs
+    - `'left'` - Strip leading spaces/tabs, keep terminator
+    - `'both'` - Both sides
 
     **Line Selection:**
     - Single line: `42` or `lines := 42`


### PR DESCRIPTION
Updates `read_lines` from v0.1.4 to [v0.2.1](https://github.com/teaguesterling/duckdb_read_lines/releases/tag/v0.2.1), now targeting DuckDB v1.5.4.

## Changes since v0.1.4

- **Non-seekable source support**: pipes and streams (e.g. shellfs commands) work in both `read_lines` and `read_lines_lateral`, including per-row commands in correlated lateral joins ([v0.2.0](https://github.com/teaguesterling/duckdb_read_lines/releases/tag/v0.2.0)).
- **Line-splitting correctness fixes** ([issue #5](https://github.com/teaguesterling/duckdb_read_lines/issues/5)): trailing terminator-final empty lines are no longer dropped, line terminators are preserved in `content` as documented, lone `\r` splits lines, UTF-8 BOM is skipped, invalid UTF-8 raises a clear error and is skippable via `ignore_errors`, and files/pipes/`parse_lines` now agree byte-for-byte.
- **New optional `trim` argument** (third positional or named): `true`/`'endings'`, `'left'`, `'right'`, `'both'` — content-only, never changes which rows appear ([v0.2.1](https://github.com/teaguesterling/duckdb_read_lines/releases/tag/v0.2.1)).

Extension CI is green on all platforms (linux amd64/arm64, macOS amd64/arm64, Windows MSVC/mingw, wasm ×3): https://github.com/teaguesterling/duckdb_read_lines/actions/runs/28638713164

## Descriptor notes

- `ref` → `refs/tags/v0.2.1`; `version` → `0.2.1`; docs updated for the new features.
- `andium` is intentionally left at the previous commit: v0.2.1 targets duckdb v1.5.4 and has not been build-verified against v1.4.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoeSgK1FVsbYk2FPGDyrSb