### PR TITLE
urlpattern: 0.3.2 → 0.4.0 (correctness + hardening)

### DIFF
--- a/extensions/urlpattern/description.yml
+++ b/extensions/urlpattern/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: urlpattern
   description: WHATWG URLPattern API for matching and extracting components from URLs using pattern syntax
-  version: 0.3.2
+  version: 0.4.0
   language: C++
   build: cmake
   license: MIT
@@ -12,8 +12,8 @@ extension:
 
 repo:
   github: teaguesterling/duckdb_urlpattern
-  andium: 740ab52dd074d5abd2e942e79e09e48230a80aef
-  ref: 740ab52dd074d5abd2e942e79e09e48230a80aef
+  andium: bc9864b9fad37bffe15f7499fc5b9021e970eaf8
+  ref: bc9864b9fad37bffe15f7499fc5b9021e970eaf8
 
 docs:
   hello_world: |


### PR DESCRIPTION
Follow-up to #2170 (which shipped 0.3.2 — the DuckDB v1.5.4 build fix + query percent-decoding + `init:` `;` fix). Bumps **0.3.2 → 0.4.0** with the remaining review-hardening items (issue #5). No security advisory — all findings are correctness/robustness.

### Changes since 0.3.2
- **Correctness (⚠️ breaking):** `urlpattern_extract` now returns **NULL** for no-match / absent group (previously an empty string); a matched-but-empty group still returns `''`. Callers using `urlpattern_extract(...) = ''` to detect "no match" should switch to `IS NULL`. This is the reason for a minor (not patch) bump.
- **Hardening:** unbounded per-connection pattern cache replaced with a bounded LRU (cap 1024); patterns over 1 MiB are rejected (DoS backstop).
- **Robustness:** load-time self-test for the RE2 case-sensitivity workaround, so it fails loudly (instead of silently inverting `ignore_case`) if DuckDB ever fixes the underlying `set_case_sensitive` inversion.
- **Docs:** RE2's lack of backreferences/lookahead documented as the intentional ReDoS-immunity tradeoff.

### Validation
- Clean build + full test suite pass locally against **DuckDB v1.5.4** (152 assertions).
- `excluded_platforms` and `vcpkg_commit` unchanged.

Ref: `teaguesterling/duckdb_urlpattern@v0.4.0` (`bc9864b`).