### PR TITLE
laterite_ags4: bump to 0.6.2

### DIFF
--- a/extensions/laterite_ags4/description.yml
+++ b/extensions/laterite_ags4/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: laterite_ags4
   description: Read AGS4 geotechnical data files as typed, UUID-keyed tables directly from SQL — born-typed columns, deterministic content-addressed keys that join across groups by construction, embedded AGS dictionary, and opt-in validation. Local, http(s):// and s3:// (with httpfs).
-  version: 0.5.0
+  version: 0.6.0
   language: Rust
   build: cargo
   license: MIT
@@ -23,7 +23,7 @@ repo:
   github: niko86/laterite-duckdb
   # Pin to the release commit SHA once the repo is pushed + tagged (community-
   # extensions pins a SHA, not a branch). Placeholder until then:
-  ref: 35275386640d76c0f726c8df60b48d65057a3bef
+  ref: 5713898470a46f58dfcedfa3a38c60a0a3bf8289
 
 docs:
   hello_world: |

--- a/extensions/laterite_ags4/description.yml
+++ b/extensions/laterite_ags4/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: laterite_ags4
   description: Read AGS4 geotechnical data files as typed, UUID-keyed tables directly from SQL — born-typed columns, deterministic content-addressed keys that join across groups by construction, embedded AGS dictionary, and opt-in validation. Local, http(s):// and s3:// (with httpfs).
-  version: 0.6.0
+  version: 0.6.2
   language: Rust
   build: cargo
   license: MIT
@@ -23,7 +23,7 @@ repo:
   github: niko86/laterite-duckdb
   # Pin to the release commit SHA once the repo is pushed + tagged (community-
   # extensions pins a SHA, not a branch). Placeholder until then:
-  ref: 5713898470a46f58dfcedfa3a38c60a0a3bf8289
+  ref: 67049839f5bdb728897f1024a362e692519c9b87
 
 docs:
   hello_world: |
@@ -84,9 +84,13 @@ docs:
     | `ags_relationships()` | `(child, parent, shared_keys)` — the spec parent→child graph that `_parent_id` follows. |
     | `validate_ags(path[, dict_version := '4.2'][, warnings := true][, fyi := true])` | `(rule, line, group, severity, desc)` — a clean-room AGS4 rule check; the edition auto-detects from `TRAN_AGS` unless forced, and only `error`-severity findings show unless the `warnings` / `fyi` tiers are opted in. |
     | `certify_ags(path[, dict_version := '4.2'])` | validate, then mint a sibling `.ags.idx` certificate; returns a one-row status (`certified`, `groups`/`errors`/`warnings`/`fyi` counts, `dict_version`, `message`). |
+    | `validate_ags_text(content[, dict_version := '4.2'][, warnings := true][, fyi := true])` | the same rule check as `validate_ags`, over an **inline AGS4 string** (no filesystem) — the twin of `read_ags_text`. |
+    | `certify_ags_text(content[, dict_version := '4.2'])` | validate an inline AGS4 string and, when clean, return the `.ags.idx` certificate **JSON in a `cert` column** (nothing written to disk) — the in-memory analog of `certify_ags`. |
     | `load_ags_script(path)` | `(seq, stmt)` — CREATE-TABLE DDL to materialise every group into an indexed, repeat-/remote-queryable store. |
 
     Readers stream lazily (≈2048-row vector chunks); a non-conforming numeric cell becomes
     `NULL`, never an error (the born-typed behaviour). Optional arguments are **named**
-    (`dict_version := '4.2'`, `warnings := true`), the rest positional. There is no repair
-    surface — mutation stays in the `lat-check` CLI / the `laterite` library.
+    (`dict_version := '4.2'`, `warnings := true`), the rest positional. The path verbs
+    take an `encoding` named param (e.g. `encoding := 'windows-1252'`) for non-UTF-8
+    sources; the `_text` variants are UTF-8 (their input is already a `VARCHAR`). There
+    is no repair surface — mutation stays in the `lat-check` CLI / the `laterite` library.

--- a/extensions/laterite_ags4/description.yml
+++ b/extensions/laterite_ags4/description.yml
@@ -23,7 +23,7 @@ repo:
   github: niko86/laterite-duckdb
   # Pin to the release commit SHA once the repo is pushed + tagged (community-
   # extensions pins a SHA, not a branch). Placeholder until then:
-  ref: 67049839f5bdb728897f1024a362e692519c9b87
+  ref: 6bb4057eacefe931623df0a09a50c8650ebab92f
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps `laterite_ags4` from 0.5.0 to **0.6.0**, pinned to release commit `5713898470a46f58dfcedfa3a38c60a0a3bf8289` (tag [`v0.6.0`](https://github.com/niko86/laterite-duckdb/releases/tag/v0.6.0)).

This aligns the extension with the wider laterite 0.6.0 release (Python wheel / npm / CLI all at 0.6.0). No new functions or signature changes in the extension itself since 0.5.0 — it's a version alignment build. The tagged commit builds + passes `make test_release` in the repo's release CI.