### PR TITLE
Update substrait to DuckDB v1.5.4

### DIFF
--- a/extensions/substrait/description.yml
+++ b/extensions/substrait/description.yml
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: substrait-io/duckdb-substrait-extension
-  ref: 7a0eb124f2c2998724c9e67823a00716a873a313
+  ref: e61b3bdf6fa92120b52b583914b742b9f3c50130
 
 docs:
   hello_world: |

--- a/extensions/substrait/description.yml
+++ b/extensions/substrait/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: substrait
   description: Allows conversion execution of Substrait query plans
-  version: 1.2.1
+  version: 1.5.4
   language: C++
   build: cmake
   license: Apache-2.0
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: substrait-io/duckdb-substrait-extension
-  ref: ec9f8725df7aa22bae7217ece2f221ac37563da4
+  ref: 7a0eb124f2c2998724c9e67823a00716a873a313
 
 docs:
   hello_world: |


### PR DESCRIPTION
Updates the `substrait` community extension to build against DuckDB v1.5.4.

- Bumps `repo.ref` to the merged upstream commit `e61b3bdf` (substrait-io/duckdb-substrait-extension#202, "Update to DuckDB v1.5.4"), which ports the extension from DuckDB v1.4.3 → v1.5.4.
- Bumps `extension.version` 1.2.1 → 1.5.4.

Upstream PR (merged): https://github.com/substrait-io/duckdb-substrait-extension/pull/202