### PR TITLE
Bump se3

### DIFF
--- a/extensions/se3/description.yml
+++ b/extensions/se3/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: se3
   description: Provides SE(3) rigid transformations (combinations of rotations and translations in 3D) as DuckDB scalar functions.
-  version: 0.2.0
+  version: 0.3.1
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
     - jokasimr
 repo:
   github: jokasimr/se3
-  ref: v0.2.0
+  ref: v0.3.1
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bugfix:

* `null` in operations only invalidated top level struct, access to child entries returned non-`null`.


Documentation improvements.