### PR TITLE
Add anofox_tabfm community extension

### DIFF
--- a/extensions/anofox_tabfm/description.yml
+++ b/extensions/anofox_tabfm/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: DataZooDE/anofox-tabfm
-  ref: 29d6b1a0e509a76f74b9a1e441b53918c0030cd0
+  ref: 47b8ea213180ab9a3d78a69769e5d731fe5ab149
 
 docs:
   hello_world: |

--- a/extensions/anofox_tabfm/description.yml
+++ b/extensions/anofox_tabfm/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: DataZooDE/anofox-tabfm
-  ref: 2cb9683fa987ea4fb013516dd8b70ff5bb7d31fd
+  ref: a1530acf2139f5dd9bcae6a3a92c95cfa526b16c
 
 docs:
   hello_world: |

--- a/extensions/anofox_tabfm/description.yml
+++ b/extensions/anofox_tabfm/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: DataZooDE/anofox-tabfm
-  ref: 47b8ea213180ab9a3d78a69769e5d731fe5ab149
+  ref: 3f56c8e8dbf8f133b40ff8ab23848f23b216c116
 
 docs:
   hello_world: |

--- a/extensions/anofox_tabfm/description.yml
+++ b/extensions/anofox_tabfm/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: DataZooDE/anofox-tabfm
-  ref: a1530acf2139f5dd9bcae6a3a92c95cfa526b16c
+  ref: 2495ff177e97f7916fcba4dceb0916150a016d26
 
 docs:
   hello_world: |

--- a/extensions/anofox_tabfm/description.yml
+++ b/extensions/anofox_tabfm/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: DataZooDE/anofox-tabfm
-  ref: 3f56c8e8dbf8f133b40ff8ab23848f23b216c116
+  ref: 2cb9683fa987ea4fb013516dd8b70ff5bb7d31fd
 
 docs:
   hello_world: |

--- a/extensions/anofox_tabfm/description.yml
+++ b/extensions/anofox_tabfm/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: DataZooDE/anofox-tabfm
-  ref: 27c6aed0d6e983081e7a1b69e2f78018bbfbdf71
+  ref: 29d6b1a0e509a76f74b9a1e441b53918c0030cd0
 
 docs:
   hello_world: |

--- a/extensions/anofox_tabfm/description.yml
+++ b/extensions/anofox_tabfm/description.yml
@@ -1,0 +1,64 @@
+extension:
+  name: anofox_tabfm
+  description: Zero-shot tabular machine learning inside DuckDB — classification and regression via Google's TabFM foundation model on ONNX Runtime, no training loop
+  version: 0.1.0
+  language: C++
+  build: cmake
+  license: MIT
+  maintainers:
+    - sipemu
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;linux_amd64_musl"
+
+repo:
+  github: DataZooDE/anofox-tabfm
+  ref: 27c6aed0d6e983081e7a1b69e2f78018bbfbdf71
+
+docs:
+  hello_world: |
+    -- Enable Google's license gate and download the weight-free model once.
+    -- The extension ships only the computation graph; you fetch the weights
+    -- yourself from Hugging Face under Google's non-commercial license.
+    INSTALL httpfs; LOAD httpfs;                    -- weights are fetched over HTTPS
+    SET anofox_tabfm_accept_hf_license = true;      -- non-commercial, no redistribution
+    CALL tabfm_download('classification');          -- ~6.6 GB, cached under ~/.cache/anofox-tabfm
+
+    -- Zero-shot classification: the model reads labelled rows as in-context
+    -- examples and predicts the unlabelled ones — no training step.
+    CREATE TABLE history  AS SELECT * FROM VALUES
+      (25, 40000, true), (52, 90000, false), (31, 55000, true), (44, 62000, false)
+      AS t(age, income, churned);
+    CREATE TABLE prospects AS SELECT * FROM VALUES
+      (29, 48000), (60, 120000) AS t(age, income);
+
+    SELECT * FROM tabfm_classify('history', 'churned', test := 'prospects');
+
+  extended_description: |
+    **anofox_tabfm** embeds Google's [TabFM](https://github.com/google-research/tabfm)
+    tabular foundation model — a TabPFN-style in-context learner — into DuckDB, so
+    tabular classification and regression become a single SQL statement. There is no
+    training loop, no Python, and no MLOps: the model reads your labelled rows as
+    context and predicts the rest.
+
+    Inference runs on [ONNX Runtime](https://onnxruntime.ai/), statically linked into
+    the extension (CPU execution provider). CUDA and ROCm/MIGraphX flavors exist in
+    the source tree for self-builds; this community build ships the portable CPU
+    flavor.
+
+    ### License / weights
+    No Google model weights are distributed with this extension — it bundles only a
+    **weight-free** computation graph. You download the weights yourself from Hugging
+    Face after accepting Google's license
+    (`SET anofox_tabfm_accept_hf_license = true; CALL tabfm_download(...)`). The
+    weights (~6.6 GB for classification) are cached locally under
+    `~/.cache/anofox-tabfm` and reused across sessions.
+
+    ### Surface
+    - `tabfm_classify` / `tabfm_regress` — zero-shot predict over a test set
+    - `tabfm_predict`, `tabfm_predict_by`, `tabfm_predict_agg`, `tabfm_predict_win`
+    - `tabfm_download` / `tabfm_models` / `tabfm_load` / `tabfm_unload` / `tabfm_remove`
+    - `tabfm_devices` — discover CPU/GPU execution providers
+    - `SET anofox_tabfm_*` settings (license gate, cache dir, threads, device, tracing)
+
+    Full function names are `anofox_tabfm_*` with short `tabfm_*` aliases. See the
+    [project repository](https://github.com/DataZooDE/anofox-tabfm) for the full
+    SQL API and examples.

--- a/extensions/anofox_tabfm/description.yml
+++ b/extensions/anofox_tabfm/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: DataZooDE/anofox-tabfm
-  ref: 2495ff177e97f7916fcba4dceb0916150a016d26
+  ref: ee2c97599510f03c1221483899fa804b4d57d633
 
 docs:
   hello_world: |


### PR DESCRIPTION
## anofox_tabfm

Zero-shot tabular machine learning inside DuckDB. The extension embeds Google's [TabFM](https://github.com/google-research/tabfm) foundation model (a TabPFN-style in-context learner) via ONNX Runtime, turning classification and regression into a single SQL statement — no training loop, no Python.

```sql
INSTALL httpfs; LOAD httpfs;
SET anofox_tabfm_accept_hf_license = true;
CALL tabfm_download('classification');
SELECT * FROM tabfm_classify('history', 'churned', test := 'prospects');
```

### Notes for reviewers
- **Repo:** [DataZooDE/anofox-tabfm](https://github.com/DataZooDE/anofox-tabfm), MIT-licensed. Builds against DuckDB v1.5.4 with the standard `extension-ci-tools` flow (the extension's own `MainDistributionPipeline` is green).
- **ONNX Runtime is linked statically** via the vcpkg `onnxruntime` port (manifest feature `ort-vcpkg`, static triplets), so the distributed `.duckdb_extension` is a single self-contained file with no companion `libonnxruntime.so`. The vcpkg build is heavy on a cold cache.
- **No model weights are shipped.** The extension bundles only a weight-free computation graph; users download Google's weights themselves from Hugging Face after accepting Google's non-commercial license (`SET anofox_tabfm_accept_hf_license`, `CALL tabfm_download`). Weights are cached under `~/.cache/anofox-tabfm`.
- **Excluded platforms:** WASM (ORT + multi-GB inference are not WASM-compatible), `linux_amd64_musl`, and `windows_amd64_mingw`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)