### PR TITLE
Add duckthink extension: natural-language SQL (ASK) for DuckDB, grounded in dbt

### DIFF
--- a/extensions/duckthink/description.yml
+++ b/extensions/duckthink/description.yml
@@ -1,0 +1,33 @@
+extension:
+  name: duckthink
+  description: ASK() — natural-language SQL for DuckDB, grounded in your dbt Semantic Layer
+  version: 0.1.0
+  language: C++
+  build: cmake
+  license: MIT
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64;windows_amd64_mingw"
+  maintainers:
+    - pedro-filardi
+repo:
+  github: pedro-filardi/duckthink
+  ref: a5b93d09875d3c48124d3bb7640730708cc8f36e
+docs:
+  hello_world: |
+    CREATE SECRET oai (TYPE openai, API_KEY 'sk-...');
+    CREATE MODEL('gpt', 'gpt-4o-mini', 'openai');
+    SET ask_model = 'gpt';
+    -- Ground ASK in your dbt Semantic Layer: metrics, entities and tags come from the
+    -- manifest, and a tag scopes the question to a business domain — no ON (...) needed.
+    SET ask_dbt_semantic_manifest = 'target/manifest.json';
+    SET ask_dbt_scope_tags = 'support';
+    ASK('average ticket resolution time by team this month')
+      RETURN (team VARCHAR, avg_hours DECIMAL);
+  extended_description: |
+    duckthink brings ASK() — natural-language-to-SQL — to DuckDB, grounded in your dbt Semantic
+    Layer. Point it at a dbt manifest (SET ask_dbt_semantic_manifest) and generation uses your
+    real semantic models, metrics, entities and tags — so "gross margin" or "attrition rate"
+    resolve to their exact definitions instead of the model's best guess — and a dbt tag
+    (SET ask_dbt_scope_tags) scopes a question to a business domain. ASK writes exactly one
+    read-only SELECT over the tables in scope, executes it, and returns typed rows. It also runs
+    over the plain DuckDB catalog with no dbt, and optional embedding-based table retrieval
+    (SET ask_embed_model) scales it to large schemas. Works with OpenAI, Ollama or Anthropic.


### PR DESCRIPTION
This PR adds the `duckthink` extension to the community extensions repository.

`duckthink` brings **`ASK()`** — natural-language-to-SQL — to DuckDB, **grounded in your dbt Semantic Layer**. Point it at a dbt manifest and generation uses your real semantic models, metrics, entities and tags — so "gross margin" or "attrition rate" resolve to their exact definitions instead of a guess, and a dbt tag scopes a question to a business domain. `ASK()` generates exactly one read-only `SELECT` over the tables in scope, executes it, and returns typed rows. It also runs over the plain DuckDB catalog with no dbt, and optional embedding-based table retrieval scales it to large schemas. Works with OpenAI, Ollama or Anthropic.

```sql
INSTALL duckthink FROM community;
LOAD duckthink;
CREATE SECRET oai (TYPE openai, API_KEY 'sk-...');
CREATE MODEL('gpt', 'gpt-4o-mini', 'openai');
SET ask_model = 'gpt';

-- Ground ASK in your dbt Semantic Layer: metrics, entities and tags from the manifest;
-- a tag scopes the question to a business domain — no ON (...) needed.
SET ask_dbt_semantic_manifest = 'target/manifest.json';
SET ask_dbt_scope_tags = 'support';
ASK('average ticket resolution time by team this month') RETURN (team VARCHAR, avg_hours DECIMAL);
```

**Notes for review:**
- **Dependencies:** OpenSSL only, via `vcpkg.json` in the extension repo. WASM is excluded (no sockets/OpenSSL); Windows (MSVC + mingw) is excluded for now (OpenSSL/socket linkage unvalidated). Builds and tests pass on linux (amd64/arm64) and macOS (amd64/arm64).
- **Network:** none at extension load; HTTPS happens only when an `ASK()`/embedding call runs. Temperature 0 and responses memoized per session.
- **Credentials:** resolved from DuckDB `TYPE openai|ollama|anthropic` secrets, never from SQL arguments; the API key never appears in a query, a log line, or the generated SQL.
- **Safety:** the generated statement is parsed and rejected unless it is a single read-only `SELECT` (via DuckDB's parser); it only sees the tables in scope.
- **Docs:** https://github.com/pedro-filardi/duckthink
