### PR TITLE
Update the dicom extension to v0.5.0

### DIFF
--- a/extensions/dicom/description.yml
+++ b/extensions/dicom/description.yml
@@ -2,7 +2,7 @@ extension:
   name: dicom
   description: |
     DuckDB integration with medical imaging data (DICOM - Digital Imaging and Communication in Medicine).
-  version: 0.4.0
+  version: 0.5.0
   language: C++
   build: cmake
   excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads"
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: nmontesg/duck-dicom
-  ref: v0.4.0
+  ref: v0.5.0
 
 docs:
   hello_world: |
@@ -35,5 +35,5 @@ docs:
     * `DICOM_TAG` - Custom type to work with DICOM tags, including conversion to and from `VARCHAR`.
     * `tag_group()`, `tag_element()`, `tag_name()` - Scalar functions to work with DICOM tags.
     * `dicom` secret type - Store credentials to establish connection with remote DICOM modalities, such as PACS systems.
-    * `query_dicom()` - Table function to retrieve DICOM datasets from a remote modality directly into DuckDB using
-    C-FIND commands.
+    * `query_dicom()` and `retrieve_dicom()` - Table functions to query and retrieve DICOM datasets from a remote
+    modalities directly into DuckDB using C-FIND and C-MOVE commands.


### PR DESCRIPTION
This PR updates the `dicom` extension to v0.5.0.
Changes:
* Adds the `retrieve_dicom()` table function to retrieve full DICOM datasets from remote modalities.