### PR TITLE
ai: bump to v0.4.1

### DIFF
--- a/extensions/ai/description.yml
+++ b/extensions/ai/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: ai
   description: AI functions for SQL — completions, classification, extraction, embeddings, and read-only SQL generation across local and hosted model providers
-  version: 0.4.0
+  version: 0.4.1
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: leonardovida/duckdb-ai
-  ref: 42139d114b5513b18a6e674a9bc689b2e2762c04
+  ref: 8c2b2cabf293eac01a8eb9b8c22f4978e50efb7c
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps the ai community extension metadata to the duckdb-ai v0.4.1 release.\n\nChanges:\n- extension.version: 0.4.1\n- repo.ref: 8c2b2cabf293eac01a8eb9b8c22f4978e50efb7c\n\nRelease: https://github.com/leonardovida/duckdb-ai/releases/tag/v0.4.1