### PR TITLE
ducklink: update to v4.0.1

### DIFF
--- a/extensions/ducklink/description.yml
+++ b/extensions/ducklink/description.yml
@@ -3,7 +3,7 @@
 extension:
   name: ducklink
   description: Load portable WebAssembly extension modules into DuckDB from SQL
-  version: 4.0.0
+  version: 4.0.1
   language: Rust
   build: cargo
   license: MIT
@@ -19,7 +19,7 @@ extension:
 
 repo:
   github: tegmentum/ducklink-extension
-  ref: v4.0.0
+  ref: v4.0.1
 
 docs:
   hello_world: |


### PR DESCRIPTION
Re-triggers the community build. The prior v4.0.0 post-merge build ([#2158](https://github.com/duckdb/community-extensions/pull/2158), [run 28497377246](https://github.com/duckdb/community-extensions/actions/runs/28497377246)) failed on `osx_arm64` with a transient vcpkg download failure (`curl (6) Could not resolve host: github.com`), so the CDN is still serving v0.5.2 and `SELECT * FROM ducklink.modules` fails against the community-installed extension.

v4.0.1 also folds in three fixes on top of v4.0.0:
- `feat(events)`: add the `ducklink.events` runtime audit-log system view
- `feat(compat)`: enforce strict same-major loading and re-embed the gen-4 snapshot
- `chore`: point community manifest ref at v4.0.1