### PR TITLE
ai: bump to v0.4.4

### DIFF
--- a/extensions/ai/description.yml
+++ b/extensions/ai/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: ai
   description: AI functions for SQL — completions, classification, extraction, embeddings, and read-only SQL generation across local and hosted model providers
-  version: 0.4.3
+  version: 0.4.4
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: leonardovida/duckdb-ai
-  ref: 09f0c769ad05622f7385ffcb6473bd065615a7aa
+  ref: 3665cb6196cc021a8535f84038708e56db6c86ff
 
 docs:
   hello_world: |

--- a/extensions/ai/description.yml
+++ b/extensions/ai/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: ai
   description: AI functions for SQL — completions, classification, extraction, embeddings, and read-only SQL generation across local and hosted model providers
-  version: 0.4.2
+  version: 0.4.3
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: leonardovida/duckdb-ai
-  ref: 18bf421047a69cfed47ebb0d49680da96a3fc6ab
+  ref: 09f0c769ad05622f7385ffcb6473bd065615a7aa
 
 docs:
   hello_world: |

--- a/extensions/ai/description.yml
+++ b/extensions/ai/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: ai
   description: AI functions for SQL — completions, classification, extraction, embeddings, and read-only SQL generation across local and hosted model providers
-  version: 0.4.0
+  version: 0.4.2
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: leonardovida/duckdb-ai
-  ref: 42139d114b5513b18a6e674a9bc689b2e2762c04
+  ref: 18bf421047a69cfed47ebb0d49680da96a3fc6ab
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bump the `ai` community extension package to v0.4.4.

Source release: https://github.com/leonardovida/duckdb-ai/releases/tag/v0.4.4

This picks up public provider metadata/runtime fixes:

- current Mistral `mistral-small-latest` pricing metadata
- current OpenRouter optional title attribution header
- current Snowflake default model path

Local validation:

- Parsed `extensions/ai/description.yml` with `DUCKDB_VERSION=v1.5.4 DUCKDB_LATEST_STABLE=v1.5.4 ALL_CHANGED_FILES=extensions/ai/description.yml uv run --with pyyaml python scripts/build.py`
- `git diff --check`
