### PR TITLE
ducklink: update to v4.0.2

### DIFF
--- a/extensions/ducklink/description.yml
+++ b/extensions/ducklink/description.yml
@@ -3,7 +3,7 @@
 extension:
   name: ducklink
   description: Load portable WebAssembly extension modules into DuckDB from SQL
-  version: 4.0.0
+  version: 4.0.2
   language: Rust
   build: cargo
   license: MIT
@@ -19,7 +19,7 @@ extension:
 
 repo:
   github: tegmentum/ducklink-extension
-  ref: v4.0.0
+  ref: v4.0.2
 
 docs:
   hello_world: |
@@ -49,11 +49,12 @@ docs:
 
     A set of system views makes everything introspectable:
 
-      * ducklink.modules      — the full catalog, with a `loaded` flag
-      * ducklink.functions    — every function with its full SQL signature
-      * ducklink.capabilities — what this host build supports
-      * ducklink.cache        — the local component cache
-      * ducklink.versions     — module generations and compatibility
+      * ducklink.modules               — the full catalog, with a `loaded` flag
+      * ducklink.functions             — every function with its full SQL signature
+      * ducklink.host_capabilities     — capability kinds this host build satisfies
+      * ducklink.host                  — this host's WIT contract version + DuckDB build info
+      * ducklink.cache                 — the local component cache
+      * ducklink.module_compatibility  — per module × generation: runnable, selected, lifecycle
 
     On Linux and macOS an advanced tier also enables a `LOAD WASM '<name>'`
     statement — an explicit, sandbox-aware alternative to `ducklink_load` that


### PR DESCRIPTION
Updates `ducklink` from v4.0.0 (upstream) to v4.0.2. Supersedes [#2192](https://github.com/duckdb/community-extensions/pull/2192) (v4.0.1); that PR merged but the post-merge build hit a transient `vcpkg` download failure on `osx_arm64` and the CDN kept serving v0.5.2. Rather than a re-run, v4.0.2 rolls the intervening perf pass + discovery-view UX cleanup into a fresh submission.

## Perf pass

Measured medians on aarch64-darwin, v4.0.1 baseline → v4.0.2:

- `aggregate_query/sample_sum_1M`: 76.2 ms → 73.3 ms (**−3.7%**)
- `scalar_dispatch/plus_one_i64_2048`: 139.8 µs → 134.3 µs (**−5.3%**)
- new `scalar_dispatch/plus_one_col_i64_2048`: 86.4 µs — the col-native path is **~35% faster** than the row-major sibling
- `parallel_scalar/parallel_cross_ext`: flat within CI after cache-line-padding the callback registry

Highlights: column-native scalar and aggregate dispatch (skip the runtime's row-major pivot on both sides of the WIT crossing), per-instance locking so cross-extension parallelism doesn't serialize on one mutex, and the advanced-tier pushdown scan now writes column-hoisted.

## Discovery views

Renamed for readability (SQL surface change, no wasm ABI impact — a v4.0.x host still loads every v4.0.x guest):

- `ducklink.versions` → `ducklink.module_compatibility`
- `ducklink.capabilities` → `ducklink.host_capabilities`
- new `ducklink.host` view — this host's WIT contract version + DuckDB build info
- `ducklink.modules.language` dropped (source language isn't useful — everything is wasm at runtime)
- `ducklink.modules.requires` → `capabilities` (pairs with `host_capabilities`: host provides, module uses)

Manifest `extended_description` updated to match.