### PR TITLE
keboola: bump to v0.1.7

### DIFF
--- a/extensions/keboola/description.yml
+++ b/extensions/keboola/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: keboola
   description: "DuckDB extension for Keboola Storage — query and write Keboola tables using standard SQL"
-  version: "0.1.6"
+  version: "0.1.7"
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: keboola/duckdb-extension
-  ref: 0559b174fedc95afbca09a428770b55094a76923
+  ref: b5a8b9fcccb4f23136942fcb2948c200ef613bba
 
 docs:
   hello_world: |


### PR DESCRIPTION
Updates the keboola extension to [v0.1.7](https://github.com/keboola/duckdb-extension/releases/tag/v0.1.7).

Highlights:
* Workspace creation fixed on Keboola stacks where Snowflake removed the `LEGACY_SERVICE` user type — the extension now requests a `snowflake-service-keypair` workspace user with a throwaway in-memory RSA key (legacy request kept as automatic fallback for older stacks).
* `INSERT` into Keboola typed tables fixed (system column no longer sent to the import API).
* Proper `User-Agent` on all HTTP traffic.
* Builds against DuckDB v1.5.4.