### PR TITLE
laterite_ags4: bump to 0.7.0

### DIFF
--- a/extensions/laterite_ags4/description.yml
+++ b/extensions/laterite_ags4/description.yml
@@ -1,20 +1,25 @@
 extension:
   name: laterite_ags4
-  description: Read AGS4 geotechnical data files as typed, UUID-keyed tables directly from SQL — born-typed columns, deterministic content-addressed keys that join across groups by construction, embedded AGS dictionary, and opt-in validation. Local, http(s):// and s3:// (with httpfs).
-  version: 0.6.2
+  description: Read AGS4 geotechnical data files as typed, UUID-keyed tables directly from SQL — born-typed columns, deterministic content-addressed keys that join across groups by construction, and an embedded AGS dictionary. A read-only SQL surface. Local, http(s):// and s3:// (with httpfs).
+  version: 0.7.0
   language: Rust
   build: cargo
   license: MIT
-  # wasm is EXCLUDED for now. The value of this extension is the path/remote VFS
-  # readers (read_ags / ags_groups / … over local, http(s):// and s3://), which
-  # need DuckDB's filesystem = the version-exact unstable C API (libduckdb-sys
-  # pinned to the 1.5.3 ABI). DuckDB-WASM is on the 1.5.1 ABI, and cargo can't
-  # unify two 1.x versions in one manifest — so the wasm build can't link (cf.
-  # duckdb/extension-ci-tools#385). Browser SQL-over-AGS is already served by the
-  # dedicated `laterite-ags4-wasm` package (parse/read → Arrow → duckdb-wasm), so
-  # the extension stays native-only. Revisit when DuckDB-WASM reaches 1.5.3.
-  # (linux_amd64_musl: untested.)
-  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;linux_amd64_musl"
+  # wasm is BUILT for all three variants (wasm_mvp / wasm_eh / wasm_threads). The
+  # C-API extension (official duckdb-rs crate) compiles to a
+  # wasm32-unknown-emscripten staticlib example (src/wasm_lib.rs) that
+  # extension-ci-tools emcc-links as an emscripten SIDE_MODULE. Building on the
+  # duckdb crate (MSRV 1.85) lets the community wasm image's rustc 1.86 be used,
+  # which does NOT emit the `--enable-bulk-memory-opt` flag that the image's older
+  # binaryen wasm-opt rejects — the flag quack-rs's rustc-1.87 floor forced, which
+  # had blocked wasm entirely. read_ags_text + the metadata functions need no
+  # filesystem; browser SQL-over-AGS is also served by the dedicated
+  # `laterite-ags4-wasm` package.
+  #
+  # wasm_threads is enabled now the bulk-memory-opt blocker is gone on every
+  # variant (mvp + eh landed in the initial 0.7.0 cut; threads links clean on the
+  # same duckdb-crate path). linux_amd64_musl stays excluded (untested).
+  excluded_platforms: "linux_amd64_musl"
   requires_toolchains: "rust"
   maintainers:
     - niko86
@@ -23,7 +28,7 @@ repo:
   github: niko86/laterite-duckdb
   # Pin to the release commit SHA once the repo is pushed + tagged (community-
   # extensions pins a SHA, not a branch). Placeholder until then:
-  ref: 6bb4057eacefe931623df0a09a50c8650ebab92f
+  ref: 1629610de77beab11ead79be36fac4324138e7e7
 
 docs:
   hello_world: |
@@ -41,9 +46,6 @@ docs:
     -- Inspect structure + the embedded AGS dictionary:
     SELECT "group", n_rows, parent FROM ags_groups('site.ags') ORDER BY n_rows DESC;
     SELECT child, parent, shared_keys FROM ags_relationships() WHERE parent = 'LOCA';
-
-    -- Opt-in validation (auto-detects the edition from TRAN_AGS):
-    SELECT rule, line, "group", severity, "desc" FROM validate_ags('site.ags');
 
     -- Remote, lazily (with httpfs):
     -- LOAD httpfs;
@@ -64,13 +66,12 @@ docs:
       no shared state.
     - **Self-describing metadata** — `ags_groups`, `ags_headings`, `ags_dictionary`,
       `ags_relationships` expose the file's structure and the embedded AGS dictionary.
-    - **Opt-in validation** — `validate_ags(path[, dict_version := '4.2'])` runs a clean-room
-      AGS4 rule check (error-only by default; `warnings := true` / `fyi := true` add the lower
-      tiers); never a gate on reads.
-    - **Persistence** — `load_ags_script(path)` emits CREATE-TABLE DDL for an indexed,
+    - **Persistence** — `load_ags(path)` emits CREATE-TABLE DDL for an indexed,
       repeat-/remote-query store.
     - **Local or remote** — reads go through DuckDB's virtual filesystem, so local paths,
       `http(s)://` and `s3://` (with `LOAD httpfs`) all work on one code path.
+    - **Native + wasm** — built for every community-extensions platform, DuckDB-WASM
+      included: the same reader for native and browser DuckDB.
 
     ### Functions
 
@@ -82,15 +83,12 @@ docs:
     | `ags_headings(path)` | `(group, heading, unit, ags_type, sql_type, status, is_key, ordinal)` — the per-heading schema, enriched with the dictionary's KEY status. |
     | `ags_dictionary()` | the embedded standard AGS dictionary as a table (`group`, `heading`, `status`, `ags_type`, `unit`, `description`, …). |
     | `ags_relationships()` | `(child, parent, shared_keys)` — the spec parent→child graph that `_parent_id` follows. |
-    | `validate_ags(path[, dict_version := '4.2'][, warnings := true][, fyi := true])` | `(rule, line, group, severity, desc)` — a clean-room AGS4 rule check; the edition auto-detects from `TRAN_AGS` unless forced, and only `error`-severity findings show unless the `warnings` / `fyi` tiers are opted in. |
-    | `certify_ags(path[, dict_version := '4.2'])` | validate, then mint a sibling `.ags.idx` certificate; returns a one-row status (`certified`, `groups`/`errors`/`warnings`/`fyi` counts, `dict_version`, `message`). |
-    | `validate_ags_text(content[, dict_version := '4.2'][, warnings := true][, fyi := true])` | the same rule check as `validate_ags`, over an **inline AGS4 string** (no filesystem) — the twin of `read_ags_text`. |
-    | `certify_ags_text(content[, dict_version := '4.2'])` | validate an inline AGS4 string and, when clean, return the `.ags.idx` certificate **JSON in a `cert` column** (nothing written to disk) — the in-memory analog of `certify_ags`. |
-    | `load_ags_script(path)` | `(seq, stmt)` — CREATE-TABLE DDL to materialise every group into an indexed, repeat-/remote-queryable store. |
+    | `load_ags(path)` | `(seq, stmt)` — CREATE-TABLE DDL to materialise every group into an indexed, repeat-/remote-queryable store. |
 
     Readers stream lazily (≈2048-row vector chunks); a non-conforming numeric cell becomes
     `NULL`, never an error (the born-typed behaviour). Optional arguments are **named**
-    (`dict_version := '4.2'`, `warnings := true`), the rest positional. The path verbs
+    (`edition := '4.2'`, `encoding := 'windows-1252'`), the rest positional. The path verbs
     take an `encoding` named param (e.g. `encoding := 'windows-1252'`) for non-UTF-8
-    sources; the `_text` variants are UTF-8 (their input is already a `VARCHAR`). There
-    is no repair surface — mutation stays in the `lat-check` CLI / the `laterite` library.
+    sources; the `_text` variant is UTF-8 (its input is already a `VARCHAR`). This is a
+    **read-only SQL surface** — validation, certification and repair stay in the `lat`
+    CLI / the `laterite` library.

--- a/extensions/laterite_ags4/docs/function_descriptions.csv
+++ b/extensions/laterite_ags4/docs/function_descriptions.csv
@@ -1,0 +1,8 @@
+function,description,comment,example
+read_ags,"Read one AGS4 group as a typed table — born-typed columns plus content-addressed _id/_parent_id keys","Local / http(s):// / s3:// (with LOAD httpfs); consumes a sibling .ags.idx for a fast single-group slice","SELECT loca_id, loca_gl FROM read_ags('site.ags', 'LOCA');"
+read_ags_text,"Read one AGS4 group as a typed table from an inline AGS4 string","No filesystem — the input is a VARCHAR (already UTF-8)","SELECT * FROM read_ags_text(ags_string, 'LOCA');"
+ags_groups,"List the groups in an AGS4 file with row and heading counts","Returns (group, n_rows, n_headings, parent)","SELECT * FROM ags_groups('site.ags');"
+ags_headings,"The per-heading schema of an AGS4 file, enriched with dictionary KEY status","Returns (group, heading, unit, ags_type, sql_type, status, is_key, ordinal)","SELECT * FROM ags_headings('site.ags') LIMIT 5;"
+ags_dictionary,"The embedded standard AGS dictionary as a table","Returns (group, heading, status, ags_type, unit, description)","SELECT * FROM ags_dictionary() LIMIT 5;"
+ags_relationships,"The AGS group parent-child (KEY) graph that _parent_id follows","Returns (child, parent, shared_keys)","SELECT * FROM ags_relationships();"
+load_ags,"Emit CREATE-TABLE DDL to materialise every AGS4 group into an indexed, queryable store","Returns (seq, stmt) — run the statements to get keyed tables","SELECT stmt FROM load_ags('site.ags') ORDER BY seq;"


### PR DESCRIPTION
Updates the `laterite_ags4` community extension to 0.7.0, pinned to release commit `18643a40d10e39de57527a7867c6a23c427175e9`.