### PR TITLE
stats_duck: lift the windows_amd64 exclusion

### DIFF
--- a/extensions/stats_duck/description.yml
+++ b/extensions/stats_duck/description.yml
@@ -7,7 +7,6 @@ extension:
   license: Apache-2.0
   maintainers:
     - caerbannogwhite
-  excluded_platforms: "windows_amd64;"
 
 repo:
   github: KoliStat/the-stats-duck


### PR DESCRIPTION
One-line change: remove `excluded_platforms: "windows_amd64;"` from `extensions/stats_duck/description.yml`.

The exclusion was carried over from the extension's own CI, where it works around a `vcvars64.bat` path issue in extension-ci-tools **v1.4.3** (duckdb/extension-ci-tools#371), a constraint that doesn't apply to this repo's build infrastructure (other C++/cmake extensions, e.g. `anofox_statistics`, build and serve `windows_amd64` fine).

Without it, users of the standard (MSVC) Windows CLI currently get a 404 on `INSTALL stats_duck FROM community`:

```
Failed to download extension "stats_duck" at URL
"http://community-extensions.duckdb.org/v1.5.4/windows_amd64/stats_duck.duckdb_extension.gz" (HTTP 404)
```

No other changes, same `ref` (v0.7.0), the platform just gets built. This PR's CI should demonstrate the `windows_amd64` build directly.
