### PR TITLE
ducklink: update to v4.1.0

### DIFF
--- a/extensions/ducklink/description.yml
+++ b/extensions/ducklink/description.yml
@@ -3,7 +3,7 @@
 extension:
   name: ducklink
   description: Load portable WebAssembly extension modules into DuckDB from SQL
-  version: 4.0.0
+  version: 4.1.0
   language: Rust
   build: cargo
   license: MIT
@@ -19,7 +19,7 @@ extension:
 
 repo:
   github: tegmentum/ducklink-extension
-  ref: v4.0.0
+  ref: v4.1.0
 
 docs:
   hello_world: |
@@ -49,11 +49,19 @@ docs:
 
     A set of system views makes everything introspectable:
 
-      * ducklink.modules      — the full catalog, with a `loaded` flag
-      * ducklink.functions    — every function with its full SQL signature
-      * ducklink.capabilities — what this host build supports
-      * ducklink.cache        — the local component cache
-      * ducklink.versions     — module generations and compatibility
+      * ducklink.modules               — the full catalog, with a `loaded` flag
+      * ducklink.functions             — every function with its full SQL signature
+      * ducklink.docs                  — searchable per-function documentation
+      * ducklink.host_capabilities     — capability kinds this host build satisfies
+      * ducklink.host                  — this host's WIT contract version + DuckDB build info
+      * ducklink.cache                 — the local component cache
+      * ducklink.module_compatibility  — per module × generation: runnable, selected, lifecycle
+
+    Two companion helpers make the doc surface interactive:
+    `ducklink_search('query')` returns ranked function matches across name,
+    tags, summary, and description; `ducklink_help('name')` renders the
+    markdown block for a single function or every function in a module —
+    so the catalog is discoverable from SQL without leaving the session.
 
     On Linux and macOS an advanced tier also enables a `LOAD WASM '<name>'`
     statement — an explicit, sandbox-aware alternative to `ducklink_load` that


### PR DESCRIPTION
Updates `ducklink` from v4.0.0 (upstream) to v4.1.0. Supersedes [#2195](https://github.com/duckdb/community-extensions/pull/2195) (v4.0.2), which never merged; v4.1.0 rolls the intervening in-database documentation surface + catalog authoring guide into a single fresh submission alongside all of the v4.0.2 perf and discovery-view work.

## In-database documentation (new in v4.1.0)

Users of the extension shouldn't need to leave DuckDB to know what a WebAssembly module in the catalog does. v4.1.0 lands the doc / search / help surface — three coordinated tools plus the catalog schema they share:

- `ducklink.docs` (view over `ducklink_docs()` TF) — flat one-row-per-function surface, columned as (module, function, kind, signature, summary, description, example, tags, loaded). For plain WHERE-clause discovery: `SELECT * FROM ducklink.docs WHERE description ILIKE '%routing%';`
- `ducklink_search('query')` — ranked matches. Tokenizes on whitespace (case-insensitive substring per token) and scores 10x name + 5x tags + 3x summary + 1x description, filters `score > 0`, orders stable by (score DESC, module, function).
- `ducklink_help('name')` — pretty-printed markdown for a single function OR every function in a module; a not-found hint points at `ducklink_search`.

The underlying `CatalogEntry.functions[]` gains four optional serde-default fields — summary, description, example, tags — so unenriched catalog JSON parses unchanged. The bundled snapshot's `aba` and `sample_extension` entries ship enriched so the pipeline demos end-to-end.

A companion `docs/catalog-authoring.md` guide walks catalog authors through enriching `functions[]` for the doc surface, including the 10x/5x/3x/1x ranking weights and how to preview edits locally.

## Perf pass (from v4.0.2, still not merged upstream)

Measured medians on aarch64-darwin, v4.0.1 baseline -> v4.0.2:

- `aggregate_query/sample_sum_1M`: 76.2 ms -> 73.3 ms (**-3.7%**)
- `scalar_dispatch/plus_one_i64_2048`: 139.8 us -> 134.3 us (**-5.3%**)
- new `scalar_dispatch/plus_one_col_i64_2048`: 86.4 us — the col-native path is **~35% faster** than the row-major sibling
- `parallel_scalar/parallel_cross_ext`: flat within CI after cache-line-padding the callback registry

Highlights: column-native scalar and aggregate dispatch (skip the runtime's row-major pivot on both sides of the WIT crossing), per-instance locking so cross-extension parallelism doesn't serialize on one mutex, and the advanced-tier pushdown scan now writes column-hoisted.

## Discovery-view renames (from v4.0.2, still not merged upstream)

SQL surface change, no wasm ABI impact — a v4.1.x host still loads every v4.0.x guest:

- `ducklink.versions` -> `ducklink.module_compatibility`
- `ducklink.capabilities` -> `ducklink.host_capabilities`
- new `ducklink.host` view — this host's WIT contract version + DuckDB build info
- `ducklink.modules.language` dropped (source language isn't useful — everything is wasm at runtime)
- `ducklink.modules.requires` -> `capabilities` (pairs with `host_capabilities`: host provides, module uses)

Manifest `extended_description` updated to match.