### PR TITLE
ducklink: update to v4.1.1

### DIFF
--- a/extensions/ducklink/description.yml
+++ b/extensions/ducklink/description.yml
@@ -3,7 +3,7 @@
 extension:
   name: ducklink
   description: Load portable WebAssembly extension modules into DuckDB from SQL
-  version: 4.0.0
+  version: 4.1.1
   language: Rust
   build: cargo
   license: MIT
@@ -19,7 +19,7 @@ extension:
 
 repo:
   github: tegmentum/ducklink-extension
-  ref: v4.0.0
+  ref: v4.1.1
 
 docs:
   hello_world: |
@@ -49,11 +49,25 @@ docs:
 
     A set of system views makes everything introspectable:
 
-      * ducklink.modules      — the full catalog, with a `loaded` flag
-      * ducklink.functions    — every function with its full SQL signature
-      * ducklink.capabilities — what this host build supports
-      * ducklink.cache        — the local component cache
-      * ducklink.versions     — module generations and compatibility
+      * ducklink.modules               — the full catalog, with a `loaded` flag
+      * ducklink.functions             — every function with its full SQL signature
+      * ducklink.docs                  — searchable per-function documentation
+      * ducklink.host_capabilities     — capability kinds this host build satisfies
+      * ducklink.host                  — this host's WIT contract version + DuckDB build info
+      * ducklink.cache                 — the local component cache
+      * ducklink.module_compatibility  — per module × generation: runnable, selected, lifecycle
+
+    Two companion helpers make the doc surface interactive:
+    `ducklink_search('query')` returns ranked function matches across name,
+    tags, summary, and description; `ducklink_help('name')` renders the
+    markdown block for a single function or every function in a module —
+    so the catalog is discoverable from SQL without leaving the session.
+
+    Components can also ship their own docs bundled in the `.wasm` binary
+    via a `duckdb.docs` custom section (JSON per function). Ducklink reads
+    the section at load and merges it with the catalog docs — component
+    summary/description/example override the catalog, tags union — so
+    third-party modules can keep their own docs authoritative.
 
     On Linux and macOS an advanced tier also enables a `LOAD WASM '<name>'`
     statement — an explicit, sandbox-aware alternative to `ducklink_load` that


### PR DESCRIPTION
Additive follow-up to v4.1.0 (currently open as [#2199](https://github.com/duckdb/community-extensions/pull/2199)). v4.1.1 lands the **wasm custom-section docs bridge**: components can ship their own `summary` / `description` / `example` / `tags` inside the `.wasm` binary via a `duckdb.docs` custom section, and ducklink merges them with the catalog docs at query time.

### Merge semantics

Per-function, per-field:
- Component `summary` / `description` / `example` **replace** the catalog value when present.
- `tags` **union** with the catalog set (catalog order preserved, component-only tags appended).
- Modules without a section render pure catalog data — no behaviour change for existing components.

### Why it exists

Catalog authoring lag is a real thing. This lets third-party component authors keep their own docs authoritative without waiting on a catalog PR to land, while still respecting the catalog as source-of-truth for anything the component doesn't override.

### Safety

Non-fatal at every step: missing file / malformed envelope / missing section / invalid JSON / wrong shape all return silently. A broken section can never break `LOAD WASM 'name'`. Diagnostics go through `verbose_log!`; no user-facing noise on the happy path.

### Implementation

- New module `src/docs_section.rs` (~260 lines, unit-tested).
- Hand-rolled uleb128 wasm scanner — no new dependencies. Walks top-level custom sections plus one level into component-nested core modules.
- Wired through `Engine2::load` + `build_doc_rows`, so the override flows through `ducklink.docs`, `ducklink_search`, and `ducklink_help` uniformly.
- 32 lib tests pass; release build clean.

### PR history

Supersedes:
- [#2199](https://github.com/duckdb/community-extensions/pull/2199) (v4.1.0, still open) — same code plus the wasm-section reader.
- [#2195](https://github.com/duckdb/community-extensions/pull/2195) (v4.0.2, closed).
- [#2192](https://github.com/duckdb/community-extensions/pull/2192) (v4.0.1, closed; transient CI failure on osx_arm64).

Closing #2199 alongside this PR with a supersedes comment.