### PR TITLE
Add erpl_idoc community extension

### DIFF
--- a/extensions/erpl_idoc/description.yml
+++ b/extensions/erpl_idoc/description.yml
@@ -10,4 +10,4 @@ extension:
     - jrosskopf
 repo:
   github: DataZooDE/erpl-idoc
-  ref: bd2bb580d3d1a83c8c2689b62b09d96d8fdc4f12
+  ref: 62c2249ab561fe78c0e3a03afe178fbf2d8cb9d9

--- a/extensions/erpl_idoc/description.yml
+++ b/extensions/erpl_idoc/description.yml
@@ -10,4 +10,4 @@ extension:
     - jrosskopf
 repo:
   github: DataZooDE/erpl-idoc
-  ref: 62c2249ab561fe78c0e3a03afe178fbf2d8cb9d9
+  ref: ff10f42ef48cc14688b6fd408b527eeeefdc7eba

--- a/extensions/erpl_idoc/description.yml
+++ b/extensions/erpl_idoc/description.yml
@@ -1,0 +1,13 @@
+extension:
+  name: erpl_idoc
+  description: Read & write SAP IDoc files (flat + IDoc-XML) as SQL in DuckDB — a community extension in the erpl family.
+  language: C++
+  build: cmake
+  excluded_platforms: "windows_amd64_rtools;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads;"
+  license: BSL 1.1
+  requires_toolchains: "cmake, openssl"
+  maintainers:
+    - jrosskopf
+repo:
+  github: DataZooDE/erpl-idoc
+  ref: bd2bb580d3d1a83c8c2689b62b09d96d8fdc4f12


### PR DESCRIPTION
This adds **erpl_idoc**, a DuckDB extension to read & write SAP IDoc files (flat + IDoc-XML) directly as SQL. It is part of the ERPL family and sits alongside the already-published `erpl_web`.

- **Repo:** https://github.com/DataZooDE/erpl-idoc
- **License:** BSL 1.1 (same as `erpl_web` / `anofox_*`)
- **Maintainer:** @jrosskopf
- **Build:** cmake; vcpkg deps `tinyxml2` + `openssl` (`requires_toolchains: cmake, openssl`)
- **Platforms:** excludes windows mingw/rtools and wasm (native SAP file parsing), matching `erpl_web`

### Notes
- Builds against the registry's current DuckDB **v1.5.4** / vcpkg toolchain — the extension's own CI already targets the same versions.
- The pinned commit commits a `-fno-gnu-unique` GCC guard into `extension_config.cmake` (needed for the v1.5-variegata GCC image link step).
- SQL tests (`test/sql/*.test`) are fully **offline** — typed read/write is driven by committed CSV dictionaries and fixtures; no live SAP system or extra extension is required at build/test 