### PR TITLE
ducklink: update to v4.2.0

### DIFF
--- a/extensions/ducklink/description.yml
+++ b/extensions/ducklink/description.yml
@@ -3,7 +3,7 @@
 extension:
   name: ducklink
   description: Load portable WebAssembly extension modules into DuckDB from SQL
-  version: 4.0.0
+  version: 4.2.0
   language: Rust
   build: cargo
   license: MIT
@@ -19,7 +19,7 @@ extension:
 
 repo:
   github: tegmentum/ducklink-extension
-  ref: v4.0.0
+  ref: v4.2.0
 
 docs:
   hello_world: |
@@ -49,11 +49,25 @@ docs:
 
     A set of system views makes everything introspectable:
 
-      * ducklink.modules      — the full catalog, with a `loaded` flag
-      * ducklink.functions    — every function with its full SQL signature
-      * ducklink.capabilities — what this host build supports
-      * ducklink.cache        — the local component cache
-      * ducklink.versions     — module generations and compatibility
+      * ducklink.modules               — the full catalog, with a `loaded` flag
+      * ducklink.functions             — every function with its full SQL signature
+      * ducklink.docs                  — searchable per-function documentation
+      * ducklink.host_capabilities     — capability kinds this host build satisfies
+      * ducklink.host                  — this host's WIT contract version + DuckDB build info
+      * ducklink.cache                 — the local component cache
+      * ducklink.module_compatibility  — per module × generation: runnable, selected, lifecycle
+
+    Two companion helpers make the doc surface interactive:
+    `ducklink_search('query')` returns ranked function matches across name,
+    tags, summary, and description; `ducklink_help('name')` renders the
+    markdown block for a single function or every function in a module —
+    so the catalog is discoverable from SQL without leaving the session.
+
+    Components can also ship their own docs bundled in the `.wasm` binary
+    via a `duckdb.docs` custom section (JSON per function). Ducklink reads
+    the section at load and merges it with the catalog docs — component
+    summary/description/example override the catalog, tags union — so
+    third-party modules can keep their own docs authoritative.
 
     On Linux and macOS an advanced tier also enables a `LOAD WASM '<name>'`
     statement — an explicit, sandbox-aware alternative to `ducklink_load` that


### PR DESCRIPTION
Six perf batches + a cold-start UX fix + an optional binary-size feature since v4.1.1. No API breaks, no WIT contract changes — additive minor bump.

## User-visible wins

Measured on darwin/aarch64 with lto=true, strip=true:

| Metric | Before | After | Δ |
|---|---:|---:|---:|
| Aggregate 1M rows (`sample_sum(v) FROM range(1M)`) | 82 ms | 38 ms | **-54%** |
| Parallel scalar (2-thread cross-extension) | 12.9 ms | 5.75 ms | **-55%** |
| Serial scalar dispatch | 42 ms | 11.2 ms | **-73%** |
| Cold-start on offline / bad-DNS | 15 s | 3 s | **-80%** |
| Binary size (offline build variant) | 25.9 MB | 21.7 MB | **-4 MB** |

## What's new architecturally

**Dispatch (F/G/H/I/L batches)**
- Column-native aggregate UPDATE: `AggState` is per-column typed accumulators picked at `agg_init`. Ungrouped chunks bulk-copy the whole input via `extend_from_slice`. Eliminates ~10M outer Vec allocs + boxed enum variants per 10M-row aggregate.
- `CallbackRegistry` `Mutex → RwLock`; `Weak<Instance>` on `CallbackEntry` so dispatch prologue is one atomic upgrade instead of `HashMap<name, _>::get` + `Arc` clone.
- Per-thread `SCALAR_ARGS_SCRATCH`: `refill_colvec` reuses Colvec buffers across chunks; TEXT/BLOB reuse via `String::clear + push_str`.
- `write_colvec` skips a redundant 2048-byte null-mask scan.

**Discovery / docs (F1, F2, G4)**
- `Arc<CachedDocs>` with generation-counter invalidation for the docs pipeline. `render_help`, `ducklink.docs`, and `ducklink_search` no longer rebuild ~639 DocRows per query.
- `flat_vector` handles hoisted out of every discovery TF's row loop.

**Load-time (H4, J3)**
- Base component-linker template cached per Engine: ~25 `add_to_linker` calls run ONCE per process instead of once per component load.
- Wasm bytes read ONCE per load and shared between `Component::from_binary` and `parse_docs_from_bytes`.
- `wasmtime::Config::memory_may_move(false)` (K1): 1-2% real per-row gain via base-pointer LICM.

## Cold-start UX (J1)

The single most user-visible slow path in the codebase: opening DuckDB on hotel-WiFi / offline, running `SELECT * FROM ducklink.modules`, and staring at a black cursor for 15 seconds while a network fetch times out before the bundled snapshot loads.

- Catalog HTTP fetch timeout: **15 s → 3 s**. The graceful fallback (bundled snapshot) is already in the binary.
- Async prewarm: `Engine2::new` spawns a background thread that populates the catalog `OnceLock` while DuckDB is still finishing extension setup. By the time the first user query arrives the catalog is usually already resolved. Best-effort; races are resolved via `OnceLock::get_or_init`'s barrier.

## Optional binary-size feature (J2)

New default-enabled `network` feature gates `reqwest + rustls + webpki-roots + sha2`:

```
cargo build --release                                     # 25.9 MB (with network)
cargo build --release --no-default-features \
            --features loadable,advanced                  # 21.7 MB (offline)
```

The offline variant is for air-gapped / minimum-size deployments; it serves only names in the bundled snapshot and refuses to download uncached blobs.

**Community-extensions CI runs `cargo build --release` (default features)** so this PR's distributed artifact keeps full network support — no change for end users of the CI-built extension.

## Retracted design docs

`docs/perf-ceiling-measurement.md`, `docs/wit-streaming-scalar-dispatch.md` (RETRACTED), `docs/wit-shared-memory-result.md` (CANCELLED), and `docs/guest-simd-investigation.md` capture the measurement work behind this release and the reasoning behind rejecting several proposed architectural changes (~30% streaming projection turned out to be ~1.3%; ~27% zero-copy projection turned out to be <1%). New benches (`streaming_validation`, `memcpy_floor`) let anyone reproduce the findings.

## PR history

Supersedes v4.1.1 (merged as #2201). All changes are on top of `v4.1.1`.