### PR TITLE
anndata: update to v0.14.3

### DIFF
--- a/extensions/anndata/description.yml
+++ b/extensions/anndata/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: anndata
   description: Read AnnData (.h5ad) files for single-cell genomics data analysis, with support for local and remote (HTTP/HTTPS/S3) files
-  version: 0.14.1
+  version: 0.14.3
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: honicky/anndata-duckdb-extension
-  ref: 7cedb5abdf500434c41156878d706e58912f7406
+  ref: 82b6f746ab56e39f2c69f607c1e43917ae6f0884
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps the `anndata` extension from **0.14.1 → 0.14.3**, with `ref` pinned to the `v0.14.3` release tag (`82b6f746ab56e39f2c69f607c1e43917ae6f0884`).

Changes since 0.14.1:
- **0.14.2** — two-branch upcoming-release tracking (`main` + `main-distribution`) per the [community-extensions dev guide](https://duckdb.org/community_extensions/development); target DuckDB bumped to a newer 1.5.x patch.
- **0.14.3** — target DuckDB updated to **v1.5.4**; fix: the `X` wide table now renames duplicate `var` (gene) names with `_1`/`_2` suffixes instead of failing to bind; added a `duckdb/main` compatibility shim (gated on `__has_include`, no-op on released 1.5.x) so the extension already compiles against the upcoming `Identifier` catalog API.

Only `version` and `ref` change in the descriptor. Maintainer: @honicky.