### PR TITLE
feat: Update CityJSON extension version to 0.2.0 and enhance documentation

### DIFF
--- a/extensions/cityjson/description.yml
+++ b/extensions/cityjson/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: cityjson
   description: Read, write, and query CityJSON, CityJSONSeq, and FlatCityBuf 3D city model files.
-  version: 0.1.0
+  version: 0.2.0
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: cityjson/duckdb-cityjson
-  ref: 0df88f9fb023e272b0fd3208e0f55445714b278c
+  ref: d511bdba26392bab7d4b789f294065a3fbed58d6
 
 docs:
   hello_world: |
@@ -46,7 +46,10 @@ docs:
 
     Additional features:
     - Automatic schema inference from CityJSON attributes
+    - Wide columnar layout: one WKB geometry column per Level of Detail, plus a per-object `bbox` extent
     - LOD-based geometry extraction as WKB blobs via the `lod` parameter
+    - Filter pushdown on `id`, `feature_id`, and `object_type`
+    - Streaming reads of large CityJSONSeq files and remote files over HTTP/S3/GCS
     - Support for CityJSON v2.0 and CityJSONSeq formats
 
     For more information on the CityJSON format, see https://www.cityjson.org/.


### PR DESCRIPTION
Updates the `cityjson` community extension to v0.2.0 (DuckDB v1.5.4).

Since 0.1.0 the extension has gained:
- Write support via `COPY ... TO` (cityjson, cityjsonseq, flatcitybuf)
- Wide columnar layout: one WKB geometry column per LOD, plus a per-object `bbox`
- Filter pushdown on `id`, `feature_id`, `object_type`
- Streaming reads of large CityJSONSeq and remote (HTTP/S3/GCS) files
- FlatCityBuf (`.fcb`) read/write

Bumps `version` to 0.2.0 and `ref` to the latest release commit.