### PR TITLE
Add gorz extension

### DIFF
--- a/extensions/gorz/description.yml
+++ b/extensions/gorz/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: gorfather/duckdb-gorz
-  ref: 81f8f9c4534215671970cd8a535d9cdc84f575a7
+  ref: 1c6a247bcc9a5b76339e55fa3711d58d8ae3426b
 
 docs:
   hello_world: |

--- a/extensions/gorz/description.yml
+++ b/extensions/gorz/description.yml
@@ -5,12 +5,16 @@ extension:
   language: C++
   build: cmake
   license: MIT
+  # linux_arm64 excluded: DuckDB v1.5.4 fails to build its own plan_serializer
+  # tool on the arm64 gcc-toolset-14 image (an upstream toolchain bug, not this
+  # extension). Re-enable once the arm64 build image / DuckDB is fixed.
+  excluded_platforms: "linux_arm64"
   maintainers:
     - gorfather
 
 repo:
   github: gorfather/duckdb-gorz
-  ref: 29a6229f43ea8371fa17385cd0f040f860a3f754
+  ref: d1b6b61199af36739b5d2d78cd8c444508db609a
 
 docs:
   hello_world: |

--- a/extensions/gorz/description.yml
+++ b/extensions/gorz/description.yml
@@ -1,0 +1,49 @@
+extension:
+  name: gorz
+  description: Read and write GORpipe .gorz files and .gord dictionaries as native DuckDB tables
+  version: 0.1.0
+  language: C++
+  build: cmake
+  license: MIT
+  maintainers:
+    - gorfather
+
+repo:
+  github: gorfather/duckdb-gorz
+  ref: 13299b24c532cacaddb278db40810e4784d4ace5
+
+docs:
+  hello_world: |
+    -- Write a query result out as a GORZ file (rows must be in GOR order),
+    -- then read it back — with an optional GOR -p style range filter.
+    COPY (SELECT * FROM (VALUES ('chr1', 1000, 'A', 'G'), ('chr1', 2000, 'C', 'T'))
+            t(chrom, pos, ref, alt) ORDER BY chrom, pos)
+      TO 'variants.gorz' (FORMAT gorz);
+
+    SELECT * FROM read_gor('variants.gorz', range := 'chr1:1500-2500');
+  extended_description: |
+    The `gorz` extension reads and writes [GORpipe](https://github.com/gorpipe/gor)
+    genomic files — block-compressed `.gorz` and `.gord` dictionaries — as native
+    DuckDB tables. Files it writes are read and seeked natively by `gorpipe`, and
+    vice-versa.
+
+    ### Reading
+
+    - `read_gor(path)` — auto-detects `.gorz` vs `.gord` by extension.
+    - `read_gorz(path)` / `read_gord(path)` — force the kind.
+    - A **replacement scan**, so a bare literal works: `SELECT count(*) FROM 'variants.gord';`
+    - **Projection & parallel scan** — only selected columns are read; large files scan across threads.
+    - **`WHERE chrom/pos` → block seek** — range predicates seek into the right block instead of scanning the whole file.
+    - **`range := 'chrN:start-end'`** — GOR's `-p` semantics as a hard positional filter (also `'chrN'`, `'chrN:start-'`, `'chrN:pos'`).
+    - **Partition filters** — `read_gor(dict, f := [...], ff := [...])`, the `-f` / `-ff` GOR semantics, prune a `.gord`'s file list.
+    - **Object stores** — paths resolve through DuckDB's FileSystem, so `s3://…` works when `httpfs` is loaded.
+
+    ### Writing
+
+    ```sql
+    COPY (SELECT chrom, pos, ref, alt FROM my_variants ORDER BY chrom, pos)
+      TO 'out.gorz' (FORMAT gorz);   -- or (FORMAT gor) for plain sorted TSV
+    ```
+
+    Single-threaded, standard block-zip; validates GOR order (chromosomes ascend
+    lexicographically, positions non-decreasing) and errors out otherwise.

--- a/extensions/gorz/description.yml
+++ b/extensions/gorz/description.yml
@@ -1,6 +1,6 @@
 extension:
   name: gorz
-  description: Read and write GORpipe .gorz files and .gord dictionaries as native DuckDB tables
+  description: Read GORpipe .gorz and .gord files and write .gorz as native DuckDB tables
   version: 0.1.0
   language: C++
   build: cmake

--- a/extensions/gorz/description.yml
+++ b/extensions/gorz/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: gorfather/duckdb-gorz
-  ref: 13299b24c532cacaddb278db40810e4784d4ace5
+  ref: 29a6229f43ea8371fa17385cd0f040f860a3f754
 
 docs:
   hello_world: |

--- a/extensions/gorz/description.yml
+++ b/extensions/gorz/description.yml
@@ -5,16 +5,12 @@ extension:
   language: C++
   build: cmake
   license: MIT
-  # linux_arm64 excluded: DuckDB v1.5.4 fails to build its own plan_serializer
-  # tool on the arm64 gcc-toolset-14 image (an upstream toolchain bug, not this
-  # extension). Re-enable once the arm64 build image / DuckDB is fixed.
-  excluded_platforms: "linux_arm64"
   maintainers:
     - gorfather
 
 repo:
   github: gorfather/duckdb-gorz
-  ref: d1b6b61199af36739b5d2d78cd8c444508db609a
+  ref: 81f8f9c4534215671970cd8a535d9cdc84f575a7
 
 docs:
   hello_world: |

--- a/extensions/gorz/description.yml
+++ b/extensions/gorz/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: gorfather/duckdb-gorz
-  ref: 1c6a247bcc9a5b76339e55fa3711d58d8ae3426b
+  ref: 2e1e8327ea8ac3b2ec07d4275c7c8065051e5222
 
 docs:
   hello_world: |

--- a/extensions/gorz/description.yml
+++ b/extensions/gorz/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: gorfather/duckdb-gorz
-  ref: 2e1e8327ea8ac3b2ec07d4275c7c8065051e5222
+  ref: 6fd16aac0a69a5c85715704ea6ef7bb586cc1a35
 
 docs:
   hello_world: |


### PR DESCRIPTION
Adds **gorz** — read GORpipe `.gorz` and `.gord` files and write `.gorz` as native DuckDB tables.

GORpipe (https://github.com/gorpipe/gor) is a genomic analysis engine; `.gorz` is its block-compressed, genomically-ordered table format and `.gord` a dictionary of partition files. This extension exposes them to DuckDB:

- `read_gor` / `read_gorz` / `read_gord` table functions (projection + parallel scan, `WHERE chrom/pos` → block seek, `range := 'chrN:a-b'` GOR `-p` filter, `f`/`ff` partition-tag filters).
- Replacement scan, so `FROM 'x.gorz'` works directly.
- `COPY (…) TO 'x.gorz' (FORMAT gorz)` — write path (validates GOR order).
- Object stores via DuckDB's FileSystem (`s3://…` with httpfs).

Files written are read/seeked natively by `gorpipe` itself, and vice-versa.

- Repo: https://github.com/gorfather/duckdb-gorz @ v0.1.0
- Language: C++ · Build: cmake · License: MIT
- Built + tested against DuckDB v1.5.x (`make test`: 29/29 assertions pass).