### PR TITLE
ducklink: update to v4.3.0

### DIFF
--- a/extensions/ducklink/description.yml
+++ b/extensions/ducklink/description.yml
@@ -3,7 +3,7 @@
 extension:
   name: ducklink
   description: Load portable WebAssembly extension modules into DuckDB from SQL
-  version: 4.0.0
+  version: 4.3.0
   language: Rust
   build: cargo
   license: MIT
@@ -19,7 +19,7 @@ extension:
 
 repo:
   github: tegmentum/ducklink-extension
-  ref: v4.0.0
+  ref: v4.3.0
 
 docs:
   hello_world: |
@@ -49,15 +49,39 @@ docs:
 
     A set of system views makes everything introspectable:
 
-      * ducklink.modules      — the full catalog, with a `loaded` flag
-      * ducklink.functions    — every function with its full SQL signature
-      * ducklink.capabilities — what this host build supports
-      * ducklink.cache        — the local component cache
-      * ducklink.versions     — module generations and compatibility
+      * ducklink.modules               — the full catalog, with a `loaded` flag
+      * ducklink.functions             — every function with its full SQL signature
+      * ducklink.docs                  — searchable per-function documentation
+      * ducklink.host_capabilities     — capability kinds this host build satisfies
+      * ducklink.host                  — this host's WIT contract version + DuckDB build info
+      * ducklink.cache                 — the local component cache
+      * ducklink.module_compatibility  — per module × generation: runnable, selected, lifecycle
 
-    On Linux and macOS an advanced tier also enables a `LOAD WASM '<name>'`
-    statement — an explicit, sandbox-aware alternative to `ducklink_load` that
-    signals you are entering the WebAssembly module boundary.
+    Two companion helpers make the doc surface interactive:
+    `ducklink_search('query')` returns ranked function matches across name,
+    tags, summary, and description; `ducklink_help('name')` renders the
+    markdown block for a single function or every function in a module —
+    so the catalog is discoverable from SQL without leaving the session.
+
+    Components can also ship their own docs bundled in the `.wasm` binary
+    via a `duckdb.docs` custom section (JSON per function). Ducklink reads
+    the section at load and merges it with the catalog docs — component
+    summary/description/example override the catalog, tags union — so
+    third-party modules can keep their own docs authoritative.
+
+    On Linux and macOS an advanced tier also enables a `DUCKLINK LOAD '<name>'`
+    SQL statement — an explicit alternative to `ducklink_load()` that reads
+    naturally in DDL:
+
+        DUCKLINK LOAD 'aba';                    -- WASM (default)
+        DUCKLINK LOAD 'aba' NATIVE;             -- force the native build
+
+    Modules also come in a `NATIVE` build (curated set, per-platform
+    `.duckdb_extension` files) that skips the WebAssembly sandbox for ~20x
+    the throughput on tight-loop workloads. Native loads require DuckDB
+    started with `-unsigned`; a matching entry appears in
+    `ducklink.modules.native_available` when a native build exists for
+    the running host.
 
     A built-in `ducklink_version()` scalar is always available, so the
     extension is usable and testable before any module is loaded. For


### PR DESCRIPTION
Additive minor since v4.2.0. No API breaks, no WIT contract changes.

## What's new

**Native distribution end-to-end.** A new `native` provider kind on ducklink catalog entries (platform + duckdb_version + content_digest). Entries with a matching native provider are fetched from ducklink infrastructure, sha256-verified, cached under `~/.cache/ducklink/native/…`, and LOADed via DuckDB's own extension mechanism. The extension does **not** flip `allow_unsigned_extensions` — that's an explicit user choice at DuckDB startup (`-unsigned`).

**New SQL surface.** `DUCKLINK LOAD '<name>' [WASM|NATIVE];` — default WASM. Retires the previous `LOAD WASM 'aba'` / `LOAD NATIVE 'aba'` pseudo-LOAD verbs (which borrowed DuckDB's LOAD keyword; the new form is unambiguously ducklink).

**Function form.** `FROM ducklink_load('aba', kind => 'wasm' | 'native')` — same choice via the existing table function.

**Discovery.** New `native_available` BOOLEAN column on `ducklink.modules` — TRUE when the entry has a native provider matching this host's platform + DuckDB version.

## Design docs shipped alongside

Two upstream discussion drafts are in the repo, both ready to file at duckdb/duckdb:

- `docs/duckdb-upstream-custom-trusted-keys.md` — minimal-viable subset of [#23388](https://github.com/duckdb/duckdb/discussions/23388); a `custom_trusted_extension_keys` setting so third-party extension distributors can be trusted without global `allow_unsigned_extensions`.
- `docs/duckdb-upstream-function-autoload.md` — an `ExtensionHelper::RegisterFunctionEntry` API so extensions like ducklink can extend DuckDB's function → extension autoload map at runtime. Would enable transparent autoload (`SELECT aba_validate(...)` with no prior LOAD).

## Supersedes

[#2207](https://github.com/duckdb/community-extensions/pull/2207) (v4.2.0). Closing that with a supersedes comment.

## PR history

- #2207 v4.2.0
- #2201 v4.1.1
- #2199 v4.1.0
- #2195 v4.0.2
- #2192 v4.0.1