### PR TITLE
keboola: bump ref to force a clean rebuild (stale ccache in deployed 0.1.7)

### DIFF
--- a/extensions/keboola/description.yml
+++ b/extensions/keboola/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: keboola/duckdb-extension
-  ref: b5a8b9fcccb4f23136942fcb2948c200ef613bba
+  ref: 7c2afb8859df41f8dd53421ceff54d9c9df5a6bf
 
 docs:
   hello_world: |

--- a/extensions/keboola/description.yml
+++ b/extensions/keboola/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: keboola/duckdb-extension
-  ref: 7c2afb8859df41f8dd53421ceff54d9c9df5a6bf
+  ref: 7c2afb8ea0136b52be3128fbb25bc9519f39f4a3
 
 docs:
   hello_world: |


### PR DESCRIPTION
Follow-up to #2196. The deployed 0.1.7 artifacts were built with a warm ccache restored from the original submission's build (`Cache hit for restore-key: ccache-...-2026-07-09T02:00` in run 29022083342), so at least the version-stamp translation unit came from the older ref — `SELECT keboola_version()` on the CDN binaries reports `c30dc2c` (the pre-0.1.7 submission ref) instead of the 0.1.7 tag commit, and it is hard to rule out other stale objects.

The ccache was cleaned by the post-deploy `clean_cache` jobs, so a rebuild now compiles fresh. This PR bumps `ref` to the current head of `keboola/duckdb-extension` `main` (`7c2afb8`), which is binary-wise identical to the `v0.1.7` tag (the delta is test-suite and CI-config only), to trigger that rebuild. `version` stays `0.1.7`.