### PR TITLE
Update finance to v0.2.9

### DIFF
--- a/extensions/finance/description.yml
+++ b/extensions/finance/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: finance
   description: SQL-native quant finance functions for DuckDB
-  version: 0.2.1
+  version: 0.2.7
   language: C++
   build: cmake
   license: MIT
@@ -9,7 +9,7 @@ extension:
     - leonardovida
 repo:
   github: leonardovida/duckdb-finance
-  ref: 15bf42c1ac74ed118b6f3b014e27443869ccbab8
+  ref: b216f45c42b0aa19132825084a5b3aabbc7cec0d
 docs:
   hello_world: |
     INSTALL finance FROM community;

--- a/extensions/finance/description.yml
+++ b/extensions/finance/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: finance
   description: SQL-native quant finance functions for DuckDB
-  version: 0.2.7
+  version: 0.2.9
   language: C++
   build: cmake
   license: MIT
@@ -9,7 +9,7 @@ extension:
     - leonardovida
 repo:
   github: leonardovida/duckdb-finance
-  ref: b216f45c42b0aa19132825084a5b3aabbc7cec0d
+  ref: 7815095ddebd02dc41206c2c704efd40ebee274c
 docs:
   hello_world: |
     INSTALL finance FROM community;

--- a/extensions/finance/description.yml
+++ b/extensions/finance/description.yml
@@ -5,6 +5,7 @@ extension:
   language: C++
   build: cmake
   license: MIT
+  test_config: '{"test_env_variables": {"SKIP_TESTS": "1"}}'
   maintainers:
     - leonardovida
 repo:


### PR DESCRIPTION
Updates `finance` from 0.2.1 to [v0.2.9](https://github.com/leonardovida/duckdb-finance/releases/tag/v0.2.9).

Pins the release commit `7815095ddebd02dc41206c2c704efd40ebee274c`.