### PR TITLE
pdf: 0.5.1 — fix ref, 0.5.0 was pinned to a commit missing all its features

### DIFF
--- a/extensions/pdf/description.yml
+++ b/extensions/pdf/description.yml
@@ -17,7 +17,7 @@ extension:
 
 repo:
   github: asubbarao/duckdb-pdf
-  ref: d33b1f327ddca3ba963746dc2ecce6e1c804f01b
+  ref: 177b634edbcf7e3fdbd7068f4a72455073fba67c
 
 docs:
   hello_world: |

--- a/extensions/pdf/description.yml
+++ b/extensions/pdf/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: pdf
   description: Read text, metadata, words, lines, tables, layout elements, and markdown from PDF files (works on scanned PDFs via Tesseract OCR word boxes); chunk for retrieval; render pages; inspect outlines, attachments, form fields, annotations, revisions, and signatures; extract embedded images; merge, split, rotate, compress, encrypt, decrypt, watermark, and Bates-stamp documents via qpdf; write PDFs natively via libharu (`write_pdf` / `COPY … TO FORMAT pdf`); and convert office documents to PDF.
-  version: 0.5.0
+  version: 0.5.1
   language: C++
   build: cmake
   license: GPL-2.0-or-later
@@ -17,7 +17,7 @@ extension:
 
 repo:
   github: asubbarao/duckdb-pdf
-  ref: 9006e9388fa5d7c8e5e1816ac4e9a7a6e5b6e8e0
+  ref: d33b1f327ddca3ba963746dc2ecce6e1c804f01b
 
 docs:
   hello_world: |


### PR DESCRIPTION
0.5.0 (#2218) was pinned to `ref: 9006e93`, which is the batch-1 baseline — it **predates every feature the 0.5.0 description advertises**. At that commit `pdf_images`, `pdf_split_blank`, `pdf_watermark`, `pdf_bates`, `pdf_redact`, and `pdf_sign` don't exist, so a user who installs 0.5.0 and calls any of them gets `Catalog Error: function does not exist`. My apologies for the bad ref in #2218 — the description was written for the feature surface but the ref pointed at the last commit that had cleared all-platform CI at the time.

This bumps the ref to [`177b634`](https://github.com/asubbarao/duckdb-pdf/commit/177b634edbcf7e3fdbd7068f4a72455073fba67c) (duckdb-pdf `main`), where all of those functions are present and tested, plus:

- **auto-OCR is now best-effort** — a blank/scanned page encountered during a plain `read_pdf` no longer hard-errors on machines without a Tesseract model installed; it degrades to empty text for that page. Explicit `ocr := true` still raises the actionable install error. (Without this, the extension's own test suite failed on the registry's model-less Linux runner.)
- **`pdf_revisions` no longer fatally invalidates the connection** on a header-less input — an unescaped `%PDF-` in the error format string had been escalating a clean `IOException` into a fatal `InternalException`.
- **Windows-portable test assertions** — two feature tests asserted a forward-slash path (Windows glob expansion returns backslashes) and trimmed `' \\n\\f'` but not the `'\\r'` in Windows line endings; both fixed (test-only). This is what an earlier ref (d33b1f3) still tripped on the windows_amd64/MSVC leg.

Only the pinned ref changed vs the merged 0.5.0; the description already documents these functions.