### PR TITLE
ducklake_cdc: v0.5.2

### DIFF
--- a/extensions/ducklake_cdc/description.yml
+++ b/extensions/ducklake_cdc/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: ducklake_cdc
   description: "Stream changes from your DuckLake — durable consumer cursors, single-reader windows, typed DDL events."
-  version: "0.5.1"
+  version: "0.5.2"
   language: C++
   build: cmake
   license: Apache-2.0
@@ -13,4 +13,4 @@ extension:
 
 repo:
   github: "ekkuleivonen/ducklake-cdc-extension"
-  ref: "723dcf85f6051215689e4f07b08a4bc6017c165e"
+  ref: "9c1371e37362b229184e6592607a415cae163ba1"


### PR DESCRIPTION
Updates `ducklake_cdc` to v0.5.2, built from release commit `9c1371e37362b229184e6592607a415cae163ba1`.

This release adds DuckDB 1.5.4 compatibility and includes the catalogue-discovery/cache fixes required by the Atlas/Quack deployment topology.

Validation:

- Required CI passed on the release commit.
- Full DuckDB extension distribution matrix passed for Linux, macOS, Windows, and Wasm.
- ASan/UBSan smoke passed.

Release: https://github.com/ekkuleivonen/ducklake-cdc-extension/releases/tag/v0.5.2
