### PR TITLE
Update ducklake_cdc to v0.5.3

### DIFF
--- a/extensions/ducklake_cdc/description.yml
+++ b/extensions/ducklake_cdc/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: ducklake_cdc
   description: "Stream changes from your DuckLake — durable consumer cursors, single-reader windows, typed DDL events."
-  version: "0.5.1"
+  version: "0.5.3"
   language: C++
   build: cmake
   license: Apache-2.0
@@ -13,4 +13,4 @@ extension:
 
 repo:
   github: "ekkuleivonen/ducklake-cdc-extension"
-  ref: "723dcf85f6051215689e4f07b08a4bc6017c165e"
+  ref: "3d41ff71517ef69da14144f991cc98686ca30e18"


### PR DESCRIPTION
Updates `ducklake_cdc` from 0.5.1 to 0.5.3 for DuckDB v1.5.4.

This release adds stable semantic version reporting, an independent build revision function, and immutable platform release assets with SHA-256 checksums.

Release: https://github.com/ekkuleivonen/ducklake-cdc-extension/releases/tag/v0.5.3
Source commit: `3d41ff71517ef69da14144f991cc98686ca30e18`

Supersedes #2228.