### PR TITLE
Update ducklake_cdc to v0.5.4

### DIFF
--- a/extensions/ducklake_cdc/description.yml
+++ b/extensions/ducklake_cdc/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: ducklake_cdc
   description: "Stream changes from your DuckLake — durable consumer cursors, single-reader windows, typed DDL events."
-  version: "0.5.1"
+  version: "0.5.4"
   language: C++
   build: cmake
   license: Apache-2.0
@@ -13,4 +13,4 @@ extension:
 
 repo:
   github: "ekkuleivonen/ducklake-cdc-extension"
-  ref: "723dcf85f6051215689e4f07b08a4bc6017c165e"
+  ref: "2e85b6a2df0a9a560308ad62c0c21d1fc67888aa"


### PR DESCRIPTION
Updates `ducklake_cdc` from 0.5.1 to 0.5.4 for DuckDB v1.5.4.

This release adds owner-token-conditional lease release, hardens concurrent consumer bootstrap, and adds bounded mitigation for catchable H-022 deadlock surfaces.

Release: https://github.com/ekkuleivonen/ducklake-cdc-extension/releases/tag/v0.5.4
Source commit: `2e85b6a2df0a9a560308ad62c0c21d1fc67888aa`

Supersedes #2229.