### PR TITLE
ducklink: update to v4.4.0

### DIFF
--- a/extensions/ducklink/description.yml
+++ b/extensions/ducklink/description.yml
@@ -3,7 +3,7 @@
 extension:
   name: ducklink
   description: Load portable WebAssembly extension modules into DuckDB from SQL
-  version: 4.3.0
+  version: 4.4.0
   language: Rust
   build: cargo
   license: MIT
@@ -19,7 +19,7 @@ extension:
 
 repo:
   github: tegmentum/ducklink-extension
-  ref: v4.3.0
+  ref: v4.4.0
 
 docs:
   hello_world: |
@@ -35,9 +35,13 @@ docs:
     --   FROM ducklink_load('aba');
     --   SELECT aba_validate('021000021');   -- true
   extended_description: |
-    ducklink turns DuckDB into a host for portable WebAssembly extension
-    modules. A module is built once against the `duckdb:extension` WIT world
-    and runs on any supported platform — no per-platform native build.
+    ducklink is a uniform extension interface for DuckDB: users ask for a
+    capability by name, and ducklink picks the best backing — a portable
+    WebAssembly component, a ducklink-hosted native `.duckdb_extension`, or
+    a matching entry in `duckdb/community-extensions` — without changing
+    the SQL you write. A module is built once against the
+    `duckdb:extension` WIT world and runs on any supported platform in
+    its WASM form; native equivalents are opted-in for hot paths.
 
     The interface is SQL-native and catalog-backed. `ducklink_load('<name>')`
     resolves a name against a curated online catalog, downloads the component
@@ -74,14 +78,17 @@ docs:
     naturally in DDL:
 
         DUCKLINK LOAD 'aba';                    -- WASM (default)
-        DUCKLINK LOAD 'aba' NATIVE;             -- force the native build
+        DUCKLINK LOAD 'aba' NATIVE;             -- prefer the native backing
 
-    Modules also come in a `NATIVE` build (curated set, per-platform
-    `.duckdb_extension` files) that skips the WebAssembly sandbox for ~20x
-    the throughput on tight-loop workloads. Native loads require DuckDB
-    started with `-unsigned`; a matching entry appears in
-    `ducklink.modules.native_available` when a native build exists for
-    the running host.
+    `NATIVE` is the routing layer. When the catalog advertises a
+    community-extensions entry for the same capability, ducklink dispatches
+    `INSTALL <name> FROM community; LOAD <name>;` on your behalf — signed by
+    the community-extensions key, no `-unsigned` needed. Otherwise it falls
+    back to a ducklink-hosted per-platform `.duckdb_extension` file (curated
+    set, `-unsigned` required at DuckDB startup), which skips the
+    WebAssembly sandbox for ~20x the throughput on tight-loop workloads.
+    `ducklink.modules.native_available` is `true` whenever ANY native backing
+    resolves for the running host.
 
     A built-in `ducklink_version()` scalar is always available, so the
     extension is usable and testable before any module is loaded. For


### PR DESCRIPTION
Additive minor since v4.3.0 (merged in #2214).

Highlights:

- New `community-native` provider kind on catalog entries: records that
  a capability already exists as a `duckdb/community-extensions` entry.
  `DUCKLINK LOAD '<name>' NATIVE` (and `ducklink_load(kind => 'native')`)
  now prefers this backing when present — signed by the
  community-extensions key, no `-unsigned` needed. Falls back to a
  ducklink-hosted native `.duckdb_extension`.

- `ducklink.modules.native_available` is now truthful about ANY native
  backing (community-native OR ducklink-native), matching what users
  expect from the `NATIVE` load path.

- Reframes ducklink as a uniform extension interface: users ask for a
  capability by name; ducklink picks the best backing (community-native
  -> ducklink-native -> WASM). Same SQL either way.

Schema for the new provider kind: `docs/catalog-authoring.md` §3b in
the ducklink repo. No API breaks; no WIT contract changes.