### PR TITLE
ducklink: update to v4.5.0

### DIFF
--- a/extensions/ducklink/description.yml
+++ b/extensions/ducklink/description.yml
@@ -3,7 +3,7 @@
 extension:
   name: ducklink
   description: Load portable WebAssembly extension modules into DuckDB from SQL
-  version: 4.3.0
+  version: 4.5.0
   language: Rust
   build: cargo
   license: MIT
@@ -19,7 +19,7 @@ extension:
 
 repo:
   github: tegmentum/ducklink-extension
-  ref: v4.3.0
+  ref: v4.5.0
 
 docs:
   hello_world: |
@@ -35,9 +35,13 @@ docs:
     --   FROM ducklink_load('aba');
     --   SELECT aba_validate('021000021');   -- true
   extended_description: |
-    ducklink turns DuckDB into a host for portable WebAssembly extension
-    modules. A module is built once against the `duckdb:extension` WIT world
-    and runs on any supported platform — no per-platform native build.
+    ducklink is a uniform extension interface for DuckDB: users ask for a
+    capability by name, and ducklink picks the best backing — a portable
+    WebAssembly component, a ducklink-hosted native `.duckdb_extension`, or
+    a matching entry in `duckdb/community-extensions` — without changing
+    the SQL you write. A module is built once against the
+    `duckdb:extension` WIT world and runs on any supported platform in
+    its WASM form; native equivalents are opted-in for hot paths.
 
     The interface is SQL-native and catalog-backed. `ducklink_load('<name>')`
     resolves a name against a curated online catalog, downloads the component
@@ -74,14 +78,24 @@ docs:
     naturally in DDL:
 
         DUCKLINK LOAD 'aba';                    -- WASM (default)
-        DUCKLINK LOAD 'aba' NATIVE;             -- force the native build
+        DUCKLINK LOAD 'aba' NATIVE;             -- prefer the native backing
 
-    Modules also come in a `NATIVE` build (curated set, per-platform
-    `.duckdb_extension` files) that skips the WebAssembly sandbox for ~20x
-    the throughput on tight-loop workloads. Native loads require DuckDB
-    started with `-unsigned`; a matching entry appears in
-    `ducklink.modules.native_available` when a native build exists for
-    the running host.
+    `NATIVE` is the routing layer. When the catalog advertises a
+    community-extensions entry for the same capability, ducklink dispatches
+    `INSTALL <name> FROM community; LOAD <name>;` on your behalf — signed by
+    the community-extensions key, no `-unsigned` needed. Otherwise it falls
+    back to a ducklink-hosted per-platform `.duckdb_extension` file (curated
+    set, `-unsigned` required at DuckDB startup), which skips the
+    WebAssembly sandbox for ~20x the throughput on tight-loop workloads.
+    `ducklink.modules.native_available` is `true` whenever ANY native backing
+    resolves for the running host.
+
+    When a native backing is a community extension, ducklink can re-expose its functions
+    under its own chosen names via community-native aliases, keeping downstream SQL stable
+    across backing swaps. On the advanced tier the aliases are real catalog entries, so
+    DISTINCT, FILTER, ORDER BY, and window OVER clauses all propagate transparently through
+    aggregate aliases. On the loadable-only community-extensions build they are CREATE OR
+    REPLACE MACRO shapes: scalar and table zero-overhead, aggregate limited to plain GROUP BY.
 
     A built-in `ducklink_version()` scalar is always available, so the
     extension is usable and testable before any module is loaded. For


### PR DESCRIPTION
Update ducklink from v4.3.0 (currently on `main`) to v4.5.0.

## Summary of changes since v4.3.0

**v4.4.0** — WIT contract generation-4 (`duckdb:extension@4.0.0`); PLAN-prefix module namespacing on the ducklink side; per-generation compatibility view; overlap audit against the community-extensions catalog.

**v4.5.0** — community-native provider becomes a full routing layer:
- `community_prefix` / `function_mapping` catalog knobs let ducklink expose a community extension's functions under ducklink's chosen names.
- On the advanced tier, aliases are real `CatalogEntry` copies (via a small C++ shim), so aggregate DISTINCT / FILTER / ORDER BY / OVER all propagate transparently through aliased aggregates.
- On the loadable-only community-extensions build, aliases are `CREATE OR REPLACE MACRO` shapes — scalar and table zero-overhead (planner-inlined), aggregate limited to plain GROUP BY with `list_aggregate`.
- Test-skip infrastructure so `cargo test` is green on checkouts without the wasm corpus.

## Supersedes #2238

#2238 targets v4.4.0. This PR bundles v4.4.0 + v4.5.0 into a single manifest bump. Once this is merged, I'll close #2238.

## Test plan
- [x] `cargo build --release --no-default-features --features loadable,advanced`
- [x] `cargo test --release --no-default-features --features bundled,advanced --lib` (55 passing, 0 failing)
- [x] Both integration test binaries compile under `have_corpus`