### PR TITLE
Update dicom extension version

### DIFF
--- a/extensions/dicom/description.yml
+++ b/extensions/dicom/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: nmontesg/duck-dicom
-  ref: v0.5.0
+  ref: v0.6.0
 
 docs:
   hello_world: |
@@ -25,8 +25,7 @@ docs:
     Communication in Medicine) directly into DuckDB. It uses the powerful DCMTK C++ library to read DICOM files and
     convert them into JSON format.
 
-    For full documentation and examples, see the project
-    [`README`](https://github.com/nmontesg/duck-dicom/blob/main/README.md).
+    For full documentation and examples, see the project [`documentation`](https://nmontesg.github.io/duck-dicom/).
     
     **Key functionality:**
 


### PR DESCRIPTION
This dicom extension version changes the backend reading of DICOM files for `read_dicom`. It now uses a custom `DcmProducer` and `DcmInputStream`, allowing to read DICOM files in a streaming manner and stop early when encountering the pixel data. Improvement in reading speeds are most notable when reading from remote storage.