### PR TITLE
anofox_tabfm: bump to v2026.07.15 (0.2.0) — multiple foundation models

### DIFF
--- a/extensions/anofox_tabfm/description.yml
+++ b/extensions/anofox_tabfm/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: anofox_tabfm
-  description: Zero-shot tabular machine learning inside DuckDB — classification and regression via Google's TabFM foundation model on ONNX Runtime, no training loop
-  version: 0.1.0
+  description: Zero-shot tabular machine learning inside DuckDB — classification and regression with real tabular foundation models (Mitra, TabPFN v2, TabICL, TabFM) on ONNX Runtime, no training loop
+  version: 0.2.0
   language: C++
   build: cmake
   license: MIT
@@ -11,53 +11,81 @@ extension:
 
 repo:
   github: DataZooDE/anofox-tabfm
-  ref: ee2c97599510f03c1221483899fa804b4d57d633
+  ref: 1b4ecaf5b05489451e12ac330cb52886537ac2fe
 
 docs:
   hello_world: |
-    -- Enable Google's license gate and download the weight-free model once.
-    -- The extension ships only the computation graph; you fetch the weights
-    -- yourself from Hugging Face under Google's non-commercial license.
-    INSTALL httpfs; LOAD httpfs;                    -- weights are fetched over HTTPS
-    SET anofox_tabfm_accept_hf_license = true;      -- non-commercial, no redistribution
-    CALL tabfm_download('classification');          -- ~6.6 GB, cached under ~/.cache/anofox-tabfm
+    -- Fetch a real tabular foundation model once (Mitra, Apache-2.0, ~300 MB,
+    -- no license gate). Cached under ~/.cache/anofox-tabfm and reused after.
+    INSTALL httpfs; LOAD httpfs;                       -- weights are fetched over HTTPS
+    CALL tabfm_download('classification', model := 'mitra');
 
-    -- Zero-shot classification: the model reads labelled rows as in-context
-    -- examples and predicts the unlabelled ones — no training step.
-    CREATE TABLE history  AS SELECT * FROM VALUES
-      (25, 40000, true), (52, 90000, false), (31, 55000, true), (44, 62000, false)
-      AS t(age, income, churned);
-    CREATE TABLE prospects AS SELECT * FROM VALUES
-      (29, 48000), (60, 120000) AS t(age, income);
+    -- Label a few rows; leave the ones you want scored as NULL. The model reads
+    -- the labelled rows as in-context examples and predicts the rest — no training.
+    CREATE TABLE iris AS SELECT * FROM VALUES
+      (5.1, 3.5, 1.4, 0.2, 'setosa'),
+      (4.9, 3.0, 1.4, 0.2, 'setosa'),
+      (7.0, 3.2, 4.7, 1.4, 'versicolor'),
+      (6.4, 3.2, 4.5, 1.5, 'versicolor'),
+      (6.3, 3.3, 6.0, 2.5, 'virginica'),
+      (5.8, 2.7, 5.1, 1.9, 'virginica'),
+      (5.0, 3.6, 1.4, 0.2, NULL),                      -- predict me
+      (6.5, 3.0, 5.8, 2.2, NULL)                       -- and me
+      AS t(sepal_len, sepal_wid, petal_len, petal_wid, species);
 
-    SELECT * FROM tabfm_classify('history', 'churned', test := 'prospects');
+    SELECT petal_len, petal_wid, yhat AS predicted_species, yhat_score
+    FROM tabfm_classify('iris', 'species', model := 'mitra')
+    WHERE species IS NULL;
 
   extended_description: |
-    **anofox_tabfm** embeds Google's [TabFM](https://github.com/google-research/tabfm)
-    tabular foundation model — a TabPFN-style in-context learner — into DuckDB, so
-    tabular classification and regression become a single SQL statement. There is no
-    training loop, no Python, and no MLOps: the model reads your labelled rows as
-    context and predicts the rest.
+    **anofox_tabfm** embeds real tabular foundation models — TabPFN-style
+    in-context learners — into DuckDB, so tabular classification and regression
+    become a single SQL statement. There is no training loop, no Python, and no
+    MLOps: the model reads your labelled rows as context and predicts the rest.
 
-    Inference runs on [ONNX Runtime](https://onnxruntime.ai/), statically linked into
-    the extension (CPU execution provider). CUDA and ROCm/MIGraphX flavors exist in
+    ### Built-in models
+    Four models ship in the extension and are selected with `model :=` (or a
+    `SET anofox_tabfm_default_model` once per session):
+
+    - **mitra** — AWS AutoGluon (Apache-2.0), no license gate, ~300 MB. A great default.
+    - **tabpfn-v2** — Prior Labs (Apache-2.0, attribution).
+    - **tabicl-v2** — Inria (BSD-3-Clause).
+    - **tabfm-v1** — Google TabFM (non-commercial, gated; ~6.6 GB).
+
+    Only weight-free computation graphs are bundled — **no model weights are
+    distributed with the extension**. You download the weights yourself from
+    Hugging Face into a local cache (`~/.cache/anofox-tabfm`), and for the gated
+    Google model you first accept its license
+    (`SET anofox_tabfm_accept_hf_license = true`).
+
+    ### Bring your own model
+    Register any compatible model entirely from SQL — no external JSON manifest.
+    Weights can be `.safetensors` or a native PyTorch `.ckpt` (read without Python):
+
+    ```sql
+    CALL tabfm_register_model(
+      id := 'my-model',
+      classification_graph   := 'model.onnx',
+      classification_weights := 'model.safetensors',
+      license := 'apache-2.0');
+    ```
+
+    ### Inference
+    Runs on [ONNX Runtime](https://onnxruntime.ai/), statically linked into the
+    extension (CPU execution provider). CUDA and ROCm/MIGraphX flavors exist in
     the source tree for self-builds; this community build ships the portable CPU
     flavor.
 
-    ### License / weights
-    No Google model weights are distributed with this extension — it bundles only a
-    **weight-free** computation graph. You download the weights yourself from Hugging
-    Face after accepting Google's license
-    (`SET anofox_tabfm_accept_hf_license = true; CALL tabfm_download(...)`). The
-    weights (~6.6 GB for classification) are cached locally under
-    `~/.cache/anofox-tabfm` and reused across sessions.
-
     ### Surface
-    - `tabfm_classify` / `tabfm_regress` — zero-shot predict over a test set
+    - `tabfm_classify` / `tabfm_regress` — zero-shot predict (a single table with
+      NULL targets, or a separate `test :=` set)
     - `tabfm_predict`, `tabfm_predict_by`, `tabfm_predict_agg`, `tabfm_predict_win`
-    - `tabfm_download` / `tabfm_models` / `tabfm_load` / `tabfm_unload` / `tabfm_remove`
+    - `tabfm_register_model` / `tabfm_unregister_model` — pure-SQL model registration
+    - `tabfm_download` / `tabfm_models` / `tabfm_list_models` / `tabfm_load` /
+      `tabfm_unload` / `tabfm_remove` — all accept `model :=`
     - `tabfm_devices` — discover CPU/GPU execution providers
-    - `SET anofox_tabfm_*` settings (license gate, cache dir, threads, device, tracing)
+    - `SET anofox_tabfm_*` settings (default model, license gate, cache dir,
+      threads, device, tracing)
 
     Full function names are `anofox_tabfm_*` with short `tabfm_*` aliases. See the
     [project repository](https://github.com/DataZooDE/anofox-tabfm) for the full


### PR DESCRIPTION
Updates the `anofox_tabfm` descriptor to the latest release, **v2026.07.15**.

### What changed in the extension since the initial submission
The extension grew from a single Google-TabFM wrapper into a multi-model
foundation-model runtime:

- **Four built-in models**, selected with `model :=` (or `SET anofox_tabfm_default_model`):
  - **mitra** — AWS AutoGluon (Apache-2.0), no license gate, ~300 MB — the new default
  - **tabpfn-v2** — Prior Labs (Apache-2.0, attribution)
  - **tabicl-v2** — Inria (BSD-3-Clause)
  - **tabfm-v1** — Google TabFM (non-commercial, gated; ~6.6 GB)
- **Pure-SQL model registration** via `tabfm_register_model` — no external JSON
  manifest. Weights can be `.safetensors` or a native PyTorch `.ckpt`
  (read without Python).
- `model :=` on all lifecycle functions (`tabfm_download`/`load`/`unload`/`remove`).

### Descriptor changes
- `ref` → `1b4ecaf` (release tag `v2026.07.15`)
- `version` → `0.2.0`
- `description`, `hello_world` (now a self-contained Mitra example, no license
  gate needed), and `extended_description` refreshed for the multi-model surface.

### License wall (unchanged)
No model weights are distributed with the extension — only weight-free
computation graphs are bundled. Weights are downloaded by the user from Hugging
Face into a local cache; the gated Google model still requires
`SET anofox_tabfm_accept_hf_license = true`.

Still ships the portable CPU flavor; `excluded_platforms` unchanged.