### PR TITLE
Add LDBC data generator

### DIFF
--- a/extensions/ldbc_data_gen/description.yml
+++ b/extensions/ldbc_data_gen/description.yml
@@ -1,0 +1,48 @@
+extension:
+  name: ldbc_data_gen
+  description: Generate LDBC SNB BI datasets directly from DuckDB
+  version: 0.1.0
+  language: C++
+  build: cmake
+  license: MIT
+  maintainers:
+    - Dtenwolde
+
+repo:
+  github: Dtenwolde/ldbc-data-gen
+  ref: v1.5-variegata
+
+docs:
+  hello_world: |
+    INSTALL ldbc_data_gen FROM community;
+    LOAD ldbc_data_gen;
+
+    -- Generate the LDBC SNB BI dataset as DuckDB tables.
+    CALL ldbcgen(sf := 0.003, schema := 'ldbc');
+
+    -- Inspect generated relation counts.
+    FROM ldbcgen(sf := 0.003, schema := 'ldbc_counts');
+
+    -- Generate Spark-compatible BI Parquet files.
+    CALL ldbcgen(
+      sf := 0.003,
+      target := 'files',
+      output_dir := 'out/sf0.003',
+      format := 'parquet',
+      overwrite := true
+    );
+
+    -- Inspect the generated schema metadata.
+    FROM ldbcgen_schema(format := 'parquet')
+    LIMIT 10;
+
+    -- Run one bundled LDBC BI query against generated tables.
+    PRAGMA ldbc_bi(1, schema = 'ldbc');
+
+  extended_description: >
+    The ldbc_data_gen extension generates deterministic LDBC Social Network Benchmark Business Intelligence (SNB BI) datasets directly inside DuckDB.
+    It can materialize the generated graph as DuckDB tables or write Spark-compatible BI files in the composite-merged-fk layout, including the initial snapshot, inserts, and deletes. Parquet and CSV file output are supported.
+
+    The extension also includes helpers for inspecting the generated schema, configuration values, deterministic Java-compatible random sequences, and bundled LDBC BI query execution through `PRAGMA ldbc_bi`.
+
+    The generator is designed for reproducible benchmark data generation and local validation workflows without requiring Spark.


### PR DESCRIPTION
The `ldbc_data_gen` extension generated the LDBC Social Network Benchmark Business Intelligence (SNB BI) datasets directly in DuckDB. Similar to the `tpch` and `tpcds` extensions. It can generate either as DuckDB tables or Spark-compatible BI output files in the `composite-merged-fk` layout (if there's interest I'll add a way to do `composite-projected-fk` as well)

The generated file layout includes:
  - initial snapshot relations
  - dynamic insert batches
  - dynamic delete batches
  - Parquet and CSV output support

The extension also includes helpers for inspecting generated schema/configuration metadata and exposes bundled LDBC BI query execution through `PRAGMA ldbc_bi`.