### PR TITLE
Add opendal extension

### DIFF
--- a/extensions/opendal/description.yml
+++ b/extensions/opendal/description.yml
@@ -16,7 +16,7 @@ extension:
 
 repo:
   github: chitralverma/duckdb-opendal
-  ref: f3d9ef2a2ab14d7a5b39ad34b07fb8d35677d226
+  ref: 7d1b9dd3130208023902bf24d18324826055d733
 
 docs:
   hello_world: |

--- a/extensions/opendal/description.yml
+++ b/extensions/opendal/description.yml
@@ -16,7 +16,7 @@ extension:
 
 repo:
   github: chitralverma/duckdb-opendal
-  ref: 92b3362ffde1bebae411bb667efb919331e839ee
+  ref: 5129c7ee7f8a70c0c66042db621a69a08aebdb16
 
 docs:
   hello_world: |

--- a/extensions/opendal/description.yml
+++ b/extensions/opendal/description.yml
@@ -15,7 +15,7 @@ extension:
 
 repo:
   github: chitralverma/duckdb-opendal
-  ref: ab8a3a29b9fdacfb0706c4039a5863c2a8d4908b
+  ref: 6e998efad81618458518fbc061f1797354f13c56
 
 docs:
   hello_world: |

--- a/extensions/opendal/description.yml
+++ b/extensions/opendal/description.yml
@@ -16,7 +16,7 @@ extension:
 
 repo:
   github: chitralverma/duckdb-opendal
-  ref: 14a12a7dfbb09f5eb543331689080ccc1617a7a8
+  ref: c05d671158d601b0b5d5cc6ef1bf64c919d8544a
 
 docs:
   hello_world: |

--- a/extensions/opendal/description.yml
+++ b/extensions/opendal/description.yml
@@ -16,7 +16,7 @@ extension:
 
 repo:
   github: chitralverma/duckdb-opendal
-  ref: 5129c7ee7f8a70c0c66042db621a69a08aebdb16
+  ref: 14a12a7dfbb09f5eb543331689080ccc1617a7a8
 
 docs:
   hello_world: |
@@ -49,6 +49,7 @@ docs:
     - **`fs://`** / **`file://`** — Local filesystem
     - **`s3://`** — Amazon S3 and S3-compatible stores (MinIO, R2, etc.)
     - **`memory://`** — In-memory storage (useful for testing)
+    - more backends coming soon
 
     ### Key Features
 

--- a/extensions/opendal/description.yml
+++ b/extensions/opendal/description.yml
@@ -16,7 +16,7 @@ extension:
 
 repo:
   github: chitralverma/duckdb-opendal
-  ref: 4aff2f23c2f485ae9c6cac6969c1501a6b9abf8c
+  ref: 0d4e1fa16db61a7a0bfa1815b804bb0fcf42a03e
 
 docs:
   hello_world: |

--- a/extensions/opendal/description.yml
+++ b/extensions/opendal/description.yml
@@ -16,7 +16,7 @@ extension:
 
 repo:
   github: chitralverma/duckdb-opendal
-  ref: c05d671158d601b0b5d5cc6ef1bf64c919d8544a
+  ref: f3d9ef2a2ab14d7a5b39ad34b07fb8d35677d226
 
 docs:
   hello_world: |

--- a/extensions/opendal/description.yml
+++ b/extensions/opendal/description.yml
@@ -7,8 +7,7 @@ extension:
   license: MIT
   maintainers:
     - chitralverma
-  requires_toolchains:
-    - rust
+  requires_toolchains: rust
   # Exclusions:
   # - WASM: extension-ci-tools pins rust-toolchain@1.86 which is below opendal's MSRV (1.91). See https://github.com/duckdb/extension-ci-tools/issues/385
   # - MinGW: Rtools MinGW is missing libgcc_eh.a which is required by rustc for the gnu target. Rely on standard MSVC instead.

--- a/extensions/opendal/description.yml
+++ b/extensions/opendal/description.yml
@@ -1,0 +1,91 @@
+extension:
+  name: opendal
+  description: Access S3, local filesystem, and other storage services through Apache OpenDAL
+  version: "0.1.0"
+  language: C++ & Rust
+  build: cmake
+  license: MIT
+  maintainers:
+    - chitralverma
+  requires_toolchains:
+    - rust
+  # extension-ci-tools pins rust-toolchain@1.86 which is below opendal's MSRV (1.91).
+  # See https://github.com/duckdb/extension-ci-tools/issues/385
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads"
+
+repo:
+  github: chitralverma/duckdb-opendal
+  ref: 79294f58df6df14872cbf96899eeb1968b6d955f
+
+docs:
+  hello_world: |
+    -- Install and load the extension
+    INSTALL opendal FROM community;
+    LOAD opendal;
+
+    -- Create a secret for local filesystem access
+    CREATE SECRET my_fs (TYPE fs, SCOPE 'fs://', config MAP{'root': '.'});
+
+    -- Write a Parquet file through OpenDAL
+    COPY (SELECT range AS id, range * 2 AS doubled FROM range(100))
+    TO 'fs:///output/data.parquet' (FORMAT parquet);
+
+    -- Read it back
+    SELECT count(*), sum(doubled) FROM read_parquet('fs:///output/data.parquet');
+
+    -- List files
+    SELECT * FROM opendal_ls('fs:///output/');
+
+    -- Stat a file
+    SELECT name, metadata.content_length FROM opendal_stat('fs:///output/data.parquet');
+  extended_description: |
+    The `opendal` extension integrates [Apache OpenDAL](https://opendal.apache.org/)
+    into DuckDB as a virtual filesystem, enabling transparent read and write access
+    to multiple storage backends through a unified SQL interface.
+
+    ### Supported Storage Services
+
+    - **`fs://`** / **`file://`** — Local filesystem
+    - **`s3://`** — Amazon S3 and S3-compatible stores (MinIO, R2, etc.)
+    - **`memory://`** — In-memory storage (useful for testing)
+
+    ### Key Features
+
+    - **Read & write** Parquet, CSV, and JSON files through any supported backend
+    - **Glob patterns** work transparently (`read_parquet('s3://bucket/**/*.parquet')`)
+    - **Table functions** for storage operations:
+      - `opendal_stat()` — file metadata
+      - `opendal_ls()` — directory listing with optional recursion
+      - `opendal_glob()` — pattern-based file discovery
+      - `opendal_du()` — disk usage summaries
+      - `opendal_copy()` — cross-service and same-service file copy
+    - **Scoped secrets** with per-service configuration via DuckDB's secret manager
+    - **Configurable layers** — retry, timeout, I/O concurrency, and caching
+      (in-memory via foyer, optional on-disk tier)
+    - **Global settings** for default I/O, retry, timeout, and cache configuration
+    - **Coexistence** with DuckDB's native `httpfs` extension via
+      `opendal_override_native_filesystems` setting
+    - **DuckDB FileSystem logging** integration for structured I/O tracing
+
+    ### Configuration Example
+
+    ```sql
+    CREATE SECRET warehouse (
+        TYPE s3,
+        SCOPE 's3://warehouse',
+        config MAP{
+            'access_key_id': '...',
+            'secret_access_key': '...',
+            'region': 'us-east-1',
+            'endpoint': 'http://localhost:9000'
+        },
+        io_config MAP{'read.concurrent': '4', 'write.chunk_size': '8 MiB'},
+        retry_config MAP{'max_times': '5', 'jitter': 'true'},
+        cache_config MAP{'memory_size': '256 MiB'}
+    );
+
+    SELECT * FROM read_parquet('s3://warehouse/data/*.parquet');
+    ```
+
+    For full documentation, see the
+    [project repository](https://github.com/chitralverma/duckdb-opendal).

--- a/extensions/opendal/description.yml
+++ b/extensions/opendal/description.yml
@@ -9,13 +9,14 @@ extension:
     - chitralverma
   requires_toolchains:
     - rust
-  # extension-ci-tools pins rust-toolchain@1.86 which is below opendal's MSRV (1.91).
-  # See https://github.com/duckdb/extension-ci-tools/issues/385
-  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads"
+  # Exclusions:
+  # - WASM: extension-ci-tools pins rust-toolchain@1.86 which is below opendal's MSRV (1.91). See https://github.com/duckdb/extension-ci-tools/issues/385
+  # - MinGW: Rtools MinGW is missing libgcc_eh.a which is required by rustc for the gnu target. Rely on standard MSVC instead.
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw"
 
 repo:
   github: chitralverma/duckdb-opendal
-  ref: 79294f58df6df14872cbf96899eeb1968b6d955f
+  ref: 92b3362ffde1bebae411bb667efb919331e839ee
 
 docs:
   hello_world: |

--- a/extensions/opendal/description.yml
+++ b/extensions/opendal/description.yml
@@ -16,7 +16,7 @@ extension:
 
 repo:
   github: chitralverma/duckdb-opendal
-  ref: 7d1b9dd3130208023902bf24d18324826055d733
+  ref: 4aff2f23c2f485ae9c6cac6969c1501a6b9abf8c
 
 docs:
   hello_world: |

--- a/extensions/opendal/description.yml
+++ b/extensions/opendal/description.yml
@@ -16,7 +16,7 @@ extension:
 
 repo:
   github: chitralverma/duckdb-opendal
-  ref: 0d4e1fa16db61a7a0bfa1815b804bb0fcf42a03e
+  ref: ab8a3a29b9fdacfb0706c4039a5863c2a8d4908b
 
 docs:
   hello_world: |
@@ -42,18 +42,18 @@ docs:
   extended_description: |
     The `opendal` extension integrates [Apache OpenDAL](https://opendal.apache.org/)
     into DuckDB as a virtual filesystem, enabling transparent read and write access
-    to multiple storage backends through a unified SQL interface.
+    to multiple storage services through a unified SQL interface.
 
     ### Supported Storage Services
 
     - **`fs://`** / **`file://`** — Local filesystem
     - **`s3://`** — Amazon S3 and S3-compatible stores (MinIO, R2, etc.)
     - **`memory://`** — In-memory storage (useful for testing)
-    - more backends coming soon
+    - more services coming soon
 
     ### Key Features
 
-    - **Read & write** Parquet, CSV, and JSON files through any supported backend
+    - **Read & write** Parquet, CSV, and JSON files through any supported service
     - **Glob patterns** work transparently (`read_parquet('s3://bucket/**/*.parquet')`)
     - **Table functions** for storage operations:
       - `opendal_stat()` — file metadata

--- a/extensions/opendal/docs/function_descriptions.csv
+++ b/extensions/opendal/docs/function_descriptions.csv
@@ -1,0 +1,8 @@
+function,function_type,description,comment,example
+opendal_version,scalar,"Returns the version of the duckdb-opendal extension and the linked opendal-core library.",,"SELECT opendal_version();"
+opendal_stat,table,"Table function that returns metadata for a single path (such as mode, content_length, last_modified, and user_metadata).",,"SELECT * FROM opendal_stat('fs:///data/file.parquet');"
+opendal_ls,table,"Table function that lists files and subdirectories at a given path. Supports recursive listing.",,"SELECT * FROM opendal_ls('fs:///data/', recursive := true);"
+opendal_glob,table,"Table function that performs glob pattern-based file listing under a path. Matches files recursively if recursive is set.",,"SELECT * FROM opendal_glob('fs:///data/**/*.parquet');"
+opendal_du,table,"Table function that calculates and aggregates disk usage, returning size rollups grouped by parent directory.",,"SELECT * FROM opendal_du('fs:///data/');"
+opendal_copy,table,"Table function that copies a file from a source URL to a destination URL. Drains OpenDAL server-side copy where supported, otherwise streams in chunks.",,"SELECT * FROM opendal_copy('fs:///data/src.csv', 'fs:///data/dest.csv');"
+opendal_is_manually_set,scalar,"Returns true if the given URL scheme has been manually overridden to map directly to the OpenDAL filesystem.",,"SELECT opendal_is_manually_set('s3://bucket/file');"


### PR DESCRIPTION
This PR adds the metadata description for the new opendal community extension. 

The opendal extension integrates [Apache OpenDAL](https://opendal.apache.org/) as a virtual filesystem in DuckDB, enabling transparent read/write access to storage backends (currently fs://, s3://, memory:// — with more backends coming soon) with custom retry/timeout/caching configurations.