### PR TITLE
Update dplyr extension to v0.5.1

### DIFF
--- a/extensions/dplyr/description.yml
+++ b/extensions/dplyr/description.yml
@@ -8,7 +8,7 @@
 extension:
   name: dplyr
   description: R dplyr pipeline syntax support for DuckDB - transpiles dplyr verbs to SQL
-  version: 0.4.0
+  version: 0.5.1
   language: Rust & C++
   build: cmake
   license: MIT
@@ -19,7 +19,7 @@ extension:
 
 repo:
   github: mrchypark/libdplyr
-  ref: 405e38282970f5079f925549d2f574060c10313a
+  ref: adc1c5420a477d33c57a496f292df28d83dec1bc
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary

- update the dplyr community extension from v0.4.0 to v0.5.1
- pin the source to the exact v0.5.1 release commit

## Validation

- confirmed `v0.5.1^{}` resolves to `adc1c5420a477d33c57a496f292df28d83dec1bc`
- parsed the descriptor and ran `scripts/build.py` for DuckDB v1.5.4
- verified the change is limited to the version and source ref