### PR TITLE
bump protoduck to v0.1.1

### DIFF
--- a/extensions/protoduck/description.yml
+++ b/extensions/protoduck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: protoduck
   description: Deserialize Protocol Buffer messages stored in DuckDB columns
-  version: 0.1.0
+  version: 0.1.1
   language: Rust
   build: cmake
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: fcsnk/protoduck
-  ref: c5bbd3a20fea31ebf21bb9ca3ca8c0771f83a0ea
+  ref: 022babbb3baed4409a8e5e8d035a9b623d3ebfe5
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps `protoduck` to v0.1.1 that includes support for DuckDB v1.5.4.

Tested locally