### PR TITLE
ducklink: update to v4.6.1

### DIFF
--- a/extensions/ducklink/description.yml
+++ b/extensions/ducklink/description.yml
@@ -3,7 +3,7 @@
 extension:
   name: ducklink
   description: Load portable WebAssembly extension modules into DuckDB from SQL
-  version: 4.6.0
+  version: 4.6.1
   language: Rust
   build: cargo
   license: MIT
@@ -19,7 +19,7 @@ extension:
 
 repo:
   github: tegmentum/ducklink-extension
-  ref: v4.6.0
+  ref: v4.6.1
 
 docs:
   hello_world: |


### PR DESCRIPTION
Patch release fixing Linux community-CI binary load failure.

## What v4.6.0 broke on Linux

The Linux community binary from v4.6.0 fails at LOAD with:

\`\`\`
IO Error: Extension "…/ducklink.duckdb_extension" could not be loaded:
…: undefined symbol: _ZTIN6duckdb12FunctionDataE
\`\`\`

(That mangled name demangles to \`typeinfo for duckdb::FunctionData\`.)

Root cause is a fundamental Mach-O vs ELF divergence for extensions
that link against DuckDB's internal C++ ABI:

- **macOS (Mach-O)**: \`-undefined dynamic_lookup\` searches the whole
  process image at \`dlopen\` time, so internal typeinfo resolves
  regardless of visibility. v4.6.0 works on macOS.
- **Linux (ELF)**: \`dlopen\` can only resolve against the host process's
  \`.dynsym\` table. DuckDB's Linux binary compiles with default
  \`-fvisibility=hidden\`, so internal typeinfo is in memory but not
  exported. \`dlopen\` rejects the load.

Ducklink's "advanced tier" (parser hook, catalog-alias shim, DUCKLINK
PREFIX statement, colon-syntax sugar, filter pushdown) is a small C++
translation unit compiled against DuckDB's internal headers. Every
symbol it references is expected to resolve at load — but on Linux
the internal typeinfo isn't in the export table.

## Fix

Skip the advanced tier's C++ shim on \`target_os == "linux"\` in
\`build.rs\`, mirroring the pre-existing Windows skip. Linux community
users now get the **common tier**: scalar/table/aggregate function
registration via the stable C Extension API, plus community-native
routing with the \`CREATE OR REPLACE MACRO\` fallback (which was
always the intended loadable-only shape).

Users who want the advanced tier on Linux can build locally against
a DuckDB they trust and control the visibility flags of.

## Test plan

- [x] \`cargo build --release --no-default-features --features loadable\` (simulates the loadable-only path that Linux community-CI takes) — builds clean.
- [x] \`cargo test --release --no-default-features --features bundled,advanced --lib\` on macOS — 80 tests still pass. The advanced tier is untouched on Mac.