### PR TITLE
Bump plinking_duck to v0.7.1

### DIFF
--- a/extensions/plinking_duck/description.yml
+++ b/extensions/plinking_duck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: plinking_duck
   description: Read PLINK 2 genomics file formats and run common genetic analyses directly in SQL
-  version: 0.5.0
+  version: 0.7.0
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: teaguesterling/plinking_duck
-  ref: ce446b086c88df40f5447ab7ce04cc867e2fe3db
+  ref: 9e08a545513bf15a3903d2dc40abc2b71464497c
 
 docs:
   hello_world: |
@@ -39,10 +39,10 @@ docs:
     standard SQL instead of format-specific command-line tools.
 
     **File readers:**
-    - `read_pvar(path)` — variant metadata (.pvar/.bim)
+    - `read_pvar(path | [paths])` — variant metadata (.pvar/.bim); a list row-concatenates multiple files
     - `read_psam(path)` — sample metadata (.psam/.fam)
     - `read_pgen(path)` — binary genotypes (.pgen)
-    - `read_pfile(prefix)` — unified fileset reader with orient modes (variant/genotype/sample), sample subsetting, region and variant filtering
+    - `read_pfile(prefix | [prefixes])` — unified fileset reader with orient modes (variant/genotype/sample), sample subsetting, region and variant filtering; accepts a list of prefixes to read a variant-sharded fileset (identical samples) as one table
     - `read_plink_vcf(path)` — fast biallelic genotype extraction from VCF/VCF.gz (~3x faster than htslib)
 
     **Analysis functions:**
@@ -62,7 +62,9 @@ docs:
     **Flexible inputs:**
     - Unified `variants` parameter: indices, rsids, CPRA strings/structs, ranges
     - Parquet/CSV/table companions for variant and sample metadata
-    - `af_range` / `ac_range` / `genotype_range` filter pushdown
+    - `af_range` / `ac_range` filter pushdown, and `include_genotypes` (hardcall
+      category) / `genotype_range` for fast carrier lookups — in `orient := 'sample'`
+      only the matching subjects are materialized
 
     All functions support projection pushdown (skip genotype decompression for
     metadata-only queries), parallel scanning, sample subsetting, and region

--- a/extensions/plinking_duck/description.yml
+++ b/extensions/plinking_duck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: plinking_duck
   description: Read PLINK 2 genomics file formats and run common genetic analyses directly in SQL
-  version: 0.7.0
+  version: 0.7.1
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: teaguesterling/plinking_duck
-  ref: 9e08a545513bf15a3903d2dc40abc2b71464497c
+  ref: b2d6b8b23388c422bdf539b97a2997f8643d7a1b
 
 docs:
   hello_world: |


### PR DESCRIPTION
Updates `plinking_duck` to [v0.7.0](https://github.com/teaguesterling/plinking_duck/releases/tag/v0.6.1) (bundles v0.6.0 + v0.6.1 + v0.7.0; v0.6.0/v0.6.1 was not yet merged here).

**Features & fixes:**
- `include_genotypes := ['het','hom_alt']` — named hardcall-category genotype filter (`genotype_range` retained as the numeric alias).
- Fast carrier lookups: in `orient := 'sample'` a genotype filter materializes only matching subjects; `.psam.parquet` companions are preferred and read **projection-aware** (only the psam columns a query selects are loaded), so wide biobank psam files stay fast.
- Correctness: sample-orient `counts`/`stats` no longer miscount out-of-range hardcalls as missing; genotype-orient filtering applies regardless of projection; typed (INTEGER/DOUBLE) and `columns`-mode psam values read correctly from parquet companions.

CI green across Linux amd64/arm64 and macOS amd64/arm64 on the source repo.