### PR TITLE
Add duckdb_api extension

### DIFF
--- a/extensions/duckdb_api/description.yml
+++ b/extensions/duckdb_api/description.yml
@@ -1,0 +1,12 @@
+extension:
+  name: duckdb_api
+  description: Exposes a typed example relation through DuckDB's duckdb_api_scan table function.
+  version: 0.2.0
+  language: C++
+  build: cmake
+  license: MIT
+  maintainers:
+    - ngalluzzo
+repo:
+  github: ngalluzzo/duckdb-fdw
+  ref: 47dc6169ae820f70beb0c2722b8a8f5288cd1469


### PR DESCRIPTION
Adds the duckdb_api Community Extension at version 0.2.0.

Source and release inputs:
- Repository: https://github.com/ngalluzzo/duckdb-fdw
- Immutable source commit: 47dc6169ae820f70beb0c2722b8a8f5288cd1469
- License: MIT
- Maintainer: ngalluzzo

Pre-submission evidence:
- The exact source commit builds through the pinned DuckDB Community Extension template for DuckDB v1.5.4.
- The extension test target passes 20 SQLLogicTest assertions and five focused C++ contract suites.
- A clean stock DuckDB v1.5.4 host loads the locally built artifact and returns the accepted typed relation.
- The exact descriptor is accepted by the current upstream scripts/build.py parser.

The descriptor intentionally carries no platform exclusions or compatibility claims. Community CI is the authority for eligible build rows; complete stock-host install and restart evidence remains a post-publication release gate.