### PR TITLE
webbed: 2.4.0 -> 2.6.0 (security hardening + multi-file parallelism + schema inference)

### DIFF
--- a/extensions/webbed/description.yml
+++ b/extensions/webbed/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: webbed
   description: Comprehensive processing extension for web markup languages (XML and HTML) with SAX streaming for large files, intelligent schema inference, XPath-based data extraction, and HTML table parsing.
-  version: 2.5.0
+  version: 2.6.0
   language: C++
   build: cmake
   license: MIT
@@ -15,7 +15,7 @@ extension:
 repo:
   github: teaguesterling/duckdb_webbed
   andium: ddda30f11352138b2451657419640370d1612137
-  ref: ffafd3d8380657fce911159d207b988bf29c020e
+  ref: a8c75aa6853069436a25c71d05bff3ab66f5e1e7
 docs:
   docs_url: https://duckdb-webbed.readthedocs.io
   hello_world: |
@@ -88,4 +88,4 @@ docs:
 
     See https://duckdb-webbed.readthedocs.io for comprehensive documentation and examples.
 
-    Built on libxml2 for robust, standards-compliant parsing with comprehensive error handling and memory-safe RAII implementation. 89 test suites with 2925 assertions, including DOM/SAX equivalence and adversarial/security testing. The extension supports mixed file systems, configurable schema inference, and efficient processing of large document collections.
+    Built on libxml2 for robust, standards-compliant parsing with comprehensive error handling and memory-safe RAII implementation. 91 test suites with 3011 assertions, including DOM/SAX equivalence, adversarial/security, and multi-file parallelism testing. The extension supports mixed file systems, configurable schema inference, and efficient processing of large document collections.

--- a/extensions/webbed/description.yml
+++ b/extensions/webbed/description.yml
@@ -1,20 +1,21 @@
 extension:
   name: webbed
   description: Comprehensive processing extension for web markup languages (XML and HTML) with SAX streaming for large files, intelligent schema inference, XPath-based data extraction, and HTML table parsing.
-  version: 2.4.0
+  version: 2.5.0
   language: C++
   build: cmake
   license: MIT
   requires_toolchains: vcpkg
-  # Windows re-included for v2.4.0: DuckDB v1.5.4's vendored fmt no longer uses the removed
-  # MSVC STL API (the old compile blocker), and the extension builds on Windows in CI.
+  # Windows included since v2.4.0: DuckDB v1.5.4's vendored fmt no longer uses the removed
+  # MSVC STL API (the old compile blocker), and the extension builds and passes tests on the
+  # windows_amd64 MSVC runner in CI.
   maintainers:
     - teaguesterling
   vcpkg_commit: 68a1c387f660632f2f65cdb7e8cd093a08840e5d
 repo:
   github: teaguesterling/duckdb_webbed
   andium: ddda30f11352138b2451657419640370d1612137
-  ref: ad2a912d1758a9380a3f9759b78987dd374565ed
+  ref: ffafd3d8380657fce911159d207b988bf29c020e
 docs:
   docs_url: https://duckdb-webbed.readthedocs.io
   hello_world: |
@@ -87,4 +88,4 @@ docs:
 
     See https://duckdb-webbed.readthedocs.io for comprehensive documentation and examples.
 
-    Built on libxml2 for robust, standards-compliant parsing with comprehensive error handling and memory-safe RAII implementation. 68 test suites with 2511 assertions, including DOM/SAX equivalence testing. The extension supports mixed file systems, configurable schema inference, and efficient processing of large document collections.
+    Built on libxml2 for robust, standards-compliant parsing with comprehensive error handling and memory-safe RAII implementation. 89 test suites with 2925 assertions, including DOM/SAX equivalence and adversarial/security testing. The extension supports mixed file systems, configurable schema inference, and efficient processing of large document collections.


### PR DESCRIPTION
Bumps **webbed** to **v2.6.0** (ref `a8c75aa6853069436a25c71d05bff3ab66f5e1e7`).

This PR was originally the v2.5.0 security bump; since it hadn't merged yet, it's been **rolled forward to v2.6.0**, which already contains the v2.5.0 hardening plus two multi-file features. One PR ships everything.

**Security (from v2.5.0)**
- **XXE-safe by default**: external `SYSTEM`/`PUBLIC` entities are no longer resolved and no network access is attempted (`XML_PARSE_NONET`/`HTML_PARSE_NONET` + a fail-closed external-entity loader).
- Completes the >2 GiB whole-document fix for the remaining HTML parse sites.
- Per-context libxml2 error handling (thread-safe).

**New in v2.6.0**
- **Multi-file parallelism** for `read_xml`/`read_html`(+`_objects`): one worker per file, order-preserving via DuckDB batch-index reassembly. Single-file reads unchanged.
- **Multi-file schema inference** (`sample_files`, default 8): the default read now samples several files instead of only the first, so later-file columns/wider types aren't missed. Glob matches are sorted for deterministic order. `sample_files := 1` restores the old first-file-only behavior.

**Build**: shippable artifacts target the **DuckDB v1.5.4** release tag (submodules track `v1.5-variegata` for dev only). Windows stays included (builds + passes tests on the `windows_amd64` MSVC runner).

Release: https://github.com/teaguesterling/duckdb_webbed/releases/tag/v2.6.0
Tests: 91 test cases / 3011 assertions green on all platforms.
