### PR TITLE
ducklink: update to v5.0.0

### DIFF
--- a/extensions/ducklink/description.yml
+++ b/extensions/ducklink/description.yml
@@ -3,7 +3,7 @@
 extension:
   name: ducklink
   description: Load portable WebAssembly extension modules into DuckDB from SQL
-  version: 4.6.0
+  version: 5.0.0
   language: Rust
   build: cargo
   license: MIT
@@ -19,7 +19,7 @@ extension:
 
 repo:
   github: tegmentum/ducklink-extension
-  ref: v4.6.0
+  ref: v5.0.0
 
 docs:
   hello_world: |
@@ -73,14 +73,10 @@ docs:
     summary/description/example override the catalog, tags union — so
     third-party modules can keep their own docs authoritative.
 
-    On Linux and macOS an advanced tier also enables a `DUCKLINK LOAD '<name>'`
-    SQL statement — an explicit alternative to `ducklink_load()` that reads
-    naturally in DDL:
-
-        DUCKLINK LOAD 'aba';                    -- WASM (default)
-        DUCKLINK LOAD 'aba' NATIVE;             -- prefer the native backing
-
-    `NATIVE` is the routing layer. When the catalog advertises a
+    Loading a module by catalog name uses the table function
+    `ducklink_load('aba', kind => 'wasm')` (WASM sandbox, the default) or
+    `ducklink_load('aba', kind => 'native')` (prefer the native backing).
+    `native` is the routing layer. When the catalog advertises a
     community-extensions entry for the same capability, ducklink dispatches
     `INSTALL <name> FROM community; LOAD <name>;` on your behalf — signed by
     the community-extensions key, no `-unsigned` needed. Otherwise it falls
@@ -92,19 +88,20 @@ docs:
 
     When a native backing is a community extension, ducklink can re-expose its functions
     under its own chosen names via community-native aliases, keeping downstream SQL stable
-    across backing swaps. On the advanced tier the aliases are real catalog entries, so
-    DISTINCT, FILTER, ORDER BY, and window OVER clauses all propagate transparently through
-    aggregate aliases. On the loadable-only community-extensions build they are CREATE OR
-    REPLACE MACRO shapes: scalar and table zero-overhead, aggregate limited to plain GROUP BY.
+    across backing swaps. Scalar and table aliases are registered as CREATE OR REPLACE
+    MACRO shapes (zero overhead). Aggregate aliases are registered as real C-API
+    AggregateFunctions that delegate to the community target on a sibling connection, so
+    DISTINCT, FILTER, GROUP BY, OVER (...) window aggregates, and ORDER BY inside the
+    aggregate call all propagate transparently through the alias.
 
     Catalog entries can further declare an optional `namespace` so their functions bind
     under both DuckDB's `main` schema (bare) and a schema-qualified form (`crypto.hash(x)`
-    for `namespace: "crypto"`). Users layer session-scoped short aliases on top with
-    `DUCKLINK PREFIX c: crypto;` (persisted in `ducklink.prefixes` and replayed on the
-    next LOAD), and a parser-override hook rewrites SPARQL-flavored `c:hash(x)` to
-    `c.hash(x)` at parse time. All five forms — bare, ducklink-alias bare, namespace-
-    qualified, alias-qualified dot, alias-qualified colon — bind the same underlying
-    function set, so aggregate modifiers propagate through every one of them.
+    for `namespace: "crypto"`). Users layer session-scoped short aliases on top via
+    `ducklink_prefix('c', 'crypto')` — callable as a table function, a scalar, or through
+    the shorter `PREFIX('c','crypto')` macro (persisted in `ducklink.prefixes` and
+    replayed on the next LOAD). All four qualifier forms — bare, ducklink-alias bare,
+    namespace-qualified, and alias-qualified — bind the same underlying function set,
+    so aggregate modifiers propagate through every one of them.
 
     A built-in `ducklink_version()` scalar is always available, so the
     extension is usable and testable before any module is loaded. For


### PR DESCRIPTION
## Summary

Stabilization release. The advanced tier (parser / optimizer / filter-pushdown extensions, which relied on DuckDB's internal C++ ABI and could not be built uniformly on Linux / macOS / Windows) is removed. Ducklink is now C-API-only on every platform, and everything shipped in v5.0.0 is committed under the surfaces named in [STABILITY.md](https://github.com/tegmentum/ducklink-extension/blob/v5.0.0/STABILITY.md) for the life of v5.x.

Full changelog: https://github.com/tegmentum/ducklink-extension/blob/v5.0.0/CHANGELOG.md

### Breaking changes since v4.6

- The `DUCKLINK LOAD 'name'` and `DUCKLINK PREFIX c: crypto` SQL statement forms are removed, along with the `c:hash(x)` colon-rewrite syntax. Use the table-function forms: `FROM ducklink_load('name', kind => 'wasm'|'native')`, `FROM ducklink_prefix('c', 'crypto')`. Standard SQL `c.hash(x)` replaces the colon form.
- Seven catalog entries whose `requires:` listed capabilities no ducklink host can satisfy have been stripped (`ggsql`, `dplyr`, `prql_parser`, `sqlitewasm`, `rtreefns`, `hnswfns`, `autocomplete`). Catalog is now 193 entries, all compatible on every host.

### Added

- **Delegating aggregate wrapper.** Community-native aggregate aliases are now registered as real C-API `AggregateFunction`s that delegate to the target via a nested SQL query on a sibling connection. `DISTINCT` / `FILTER (WHERE ...)` / `GROUP BY` / `OVER (...)` frames of every shape (`ROWS`/`RANGE`, `PRECEDING`/`FOLLOWING`/`CURRENT ROW`/`UNBOUNDED`, `EXCLUDE CURRENT ROW`/`GROUP`/`TIES`) / `ORDER BY` inside the aggregate call all propagate through the alias.
- **`ducklink_prefix(alias, namespace)` scalar** and **`PREFIX(alias, namespace)` macro** alongside the existing table function. All three shapes share one implementation body.
- **[STABILITY.md](https://github.com/tegmentum/ducklink-extension/blob/v5.0.0/STABILITY.md)** committing the SQL entry points, discovery views, catalog schema, environment variables, and the `duckdb:extension@4.0.0` WIT contract as stable surfaces through v5.x.

### Deprecated (removal at next MAJOR)

The runtime's `parser` / `optimizer` / `table-stream` WIT interfaces and their worlds remain in the shipping `duckdb:extension@4.0.0` contract for backward compatibility with components built against v4.x. They are silent no-ops today; scheduled for removal at the next WIT major bump.

## Test plan

- [x] `cargo test --release --no-default-features --features bundled --lib` — 68/68 passing.
- [x] `cargo build --release --no-default-features --features loadable` — clean loadable build.
- [x] Delegating aggregate stress test covers every window frame shape, all `EXCLUDE` variants, NULL-in-partition, and `ORDER BY` inside the aggregate call — all match native output row-for-row.
- [ ] Community CI to verify the loadable-extension build across the CI platform matrix.

Supersedes #2253 (v4.6.1, closed).