### PR TITLE
erpl_idoc: bump ref to f96c92a (posthog-telemetry Error Tracking fix)

### DIFF
--- a/extensions/erpl_idoc/description.yml
+++ b/extensions/erpl_idoc/description.yml
@@ -10,4 +10,4 @@ extension:
     - jrosskopf
 repo:
   github: DataZooDE/erpl-idoc
-  ref: ff10f42ef48cc14688b6fd408b527eeeefdc7eba
+  ref: f96c92a39be25b4df77928cc029e76a25c21718b


### PR DESCRIPTION
Bumps `erpl_idoc`'s pinned commit to pick up the posthog-telemetry submodule update (DataZooDE/posthog-telemetry#10): `CaptureError()` now stamps `$exception_list` and a product-scoped `$exception_fingerprint`, so PostHog Error Tracking actually creates issues from captured errors instead of every event being rejected at ingestion. Telemetry-only change — no functional/API changes to the extension itself.