### PR TITLE
anofox_statistics: bump ref to 33a9eca (posthog-telemetry Error Tracking fix)

### DIFF
--- a/extensions/anofox_statistics/description.yml
+++ b/extensions/anofox_statistics/description.yml
@@ -9,4 +9,4 @@ extension:
   requires_toolchains: rust
 repo:
   github: DataZooDE/anofox-statistics
-  ref: 5f9ab25c4dc263178cb50197b480892d5f2dcd4e
+  ref: 33a9eca4d8e7ff9638370470c5ee993e338b5669


### PR DESCRIPTION
Bumps `anofox_statistics`'s pinned commit to pick up the posthog-telemetry submodule update (DataZooDE/posthog-telemetry#10): `CaptureError()` now stamps `$exception_list` and a product-scoped `$exception_fingerprint`, so PostHog Error Tracking actually creates issues from captured errors instead of every event being rejected at ingestion. Telemetry-only change — no functional/API changes to the extension itself.