### PR TITLE
anofox_forecast: bump ref to f44228b (posthog-telemetry Error Tracking fix)

### DIFF
--- a/extensions/anofox_forecast/description.yml
+++ b/extensions/anofox_forecast/description.yml
@@ -10,4 +10,4 @@ extension:
     - sipemu
 repo:
   github: DataZooDE/anofox-forecast
-  ref: b64d99eadd17b688ccd80b42269d3a7e8dddd0ec
+  ref: f44228b6a88e0b25915aae08fadf1b192ebe7fe2


### PR DESCRIPTION
Bumps `anofox_forecast`'s pinned commit to pick up the posthog-telemetry submodule update (DataZooDE/posthog-telemetry#10): `CaptureError()` now stamps `$exception_list` and a product-scoped `$exception_fingerprint`, so PostHog Error Tracking actually creates issues from captured errors instead of every event being rejected at ingestion. Telemetry-only change — no functional/API changes to the extension itself.