### PR TITLE
erpl_web: bump ref to a86f4ce (posthog-telemetry Error Tracking fix)

### DIFF
--- a/extensions/erpl_web/description.yml
+++ b/extensions/erpl_web/description.yml
@@ -10,4 +10,4 @@ extension:
     - jrosskopf
 repo:
   github: DataZooDE/erpl-web
-  ref: 65ef2a2dd6f49c4b353e305df21dc354b5519a64
+  ref: a86f4ceefe3718b6bc2a21f47f9468b3180f5e5c


### PR DESCRIPTION
Bumps `erpl_web`'s pinned commit to pick up the posthog-telemetry submodule update (DataZooDE/posthog-telemetry#10): `CaptureError()` now stamps `$exception_list` and a product-scoped `$exception_fingerprint`, so PostHog Error Tracking actually creates issues from captured errors instead of every event being rejected at ingestion. Telemetry-only change — no functional/API changes to the extension itself.