### PR TITLE
anofox_tabfm: bump ref to 8c99c62 (posthog-telemetry Error Tracking fix)

### DIFF
--- a/extensions/anofox_tabfm/description.yml
+++ b/extensions/anofox_tabfm/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: DataZooDE/anofox-tabfm
-  ref: 1b4ecaf5b05489451e12ac330cb52886537ac2fe
+  ref: 8c99c624847163c68c34db8d51aa00af3201cc15
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps `anofox_tabfm`'s pinned commit to pick up the posthog-telemetry submodule update (DataZooDE/posthog-telemetry#10): `CaptureError()` now stamps `$exception_list` and a product-scoped `$exception_fingerprint`, so PostHog Error Tracking actually creates issues from captured errors instead of every event being rejected at ingestion. Telemetry-only change — no functional/API changes to the extension itself.