### PR TITLE
quack_oauth: bump ref to d0141da (posthog-telemetry Error Tracking fix)

### DIFF
--- a/extensions/quack_oauth/description.yml
+++ b/extensions/quack_oauth/description.yml
@@ -10,4 +10,4 @@ extension:
     - jrosskopf
 repo:
   github: DataZooDE/quack-oauth
-  ref: 0b39e72efe1e85adce0dfe61bfb75ef4037692ff
+  ref: d0141da21a84b167f1f6f01fcbeafb30482173d5


### PR DESCRIPTION
Bumps `quack_oauth`'s pinned commit to pick up the posthog-telemetry submodule update (DataZooDE/posthog-telemetry#10): `CaptureError()` now stamps `$exception_list` and a product-scoped `$exception_fingerprint`, so PostHog Error Tracking actually creates issues from captured errors instead of every event being rejected at ingestion. Telemetry-only change — no functional/API changes to the extension itself.