### PR TITLE
anofox_tabular: bump ref to 6d34a7d (posthog-telemetry Error Tracking fix)

### DIFF
--- a/extensions/anofox_tabular/description.yml
+++ b/extensions/anofox_tabular/description.yml
@@ -9,4 +9,4 @@ extension:
     - jrosskopf
 repo:
   github: DataZooDE/anofox-tabular
-  ref: 1afde321c83d27e5c26ab6b309cefed1aa4893d5
+  ref: 6d34a7d9c7bb1e2cc1312cca64be52ad0d61f6ad


### PR DESCRIPTION
Bumps `anofox_tabular`'s pinned commit to pick up the posthog-telemetry submodule update (DataZooDE/posthog-telemetry#10): `CaptureError()` now stamps `$exception_list` and a product-scoped `$exception_fingerprint`, so PostHog Error Tracking actually creates issues from captured errors instead of every event being rejected at ingestion. Telemetry-only change — no functional/API changes to the extension itself.