### PR TITLE
zim: 0.5.0 → 0.6.0 (security cap + fixes)

### DIFF
--- a/extensions/zim/description.yml
+++ b/extensions/zim/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: zim
   description: Read .zim (Kiwix / openZIM) archives directly in DuckDB via libzim, from local files or remote S3/HTTP — offline Wikipedia, WikiMed, Stack Exchange, iFixit, and more, with a zim:// filesystem and full-text search.
-  version: 0.5.0
+  version: 0.6.0
   language: C++
   build: cmake
   license: GPL-2.0-or-later
@@ -12,7 +12,7 @@ extension:
   vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
 repo:
   github: teaguesterling/duckdb_zim
-  ref: 87d627e8b0b8f923bad1bfbb9e55dd85412632a5
+  ref: 1faa9a3502bf174edcbac5e3eeac1840afd83561
 docs:
   hello_world: |
     -- Load the extension


### PR DESCRIPTION
Bumps the `zim` extension **0.5.0 → 0.6.0**. Minor bump: a new named parameter and a new protective size cap (generous default keeps normal use compatible).

### Highlights
- **Security — decompression-bomb cap (GHSA-rxpc-2q4f-gch6, MED).** A crafted ZIM cluster could declare a huge uncompressed size and force unbounded allocation on read. A configurable `zim_max_content_size` (default 2 GiB, `0` disables) now rejects oversize entries before materializing, at every read path. *This fix has been on `main` since v0.5.1 work but never shipped to users — 0.6.0 is its first release.*
- **`ignore_errors` for federated search (#14).** `zim_search`/`zim_suggest` over a glob/LIST no longer abort the whole query when one archive can't be opened — with `ignore_errors := true`, un-openable archives are skipped as long as at least one succeeds (a lone/all-failed call still errors).
- **Remote-index cache-key fix (#16).** The `zim_remote_search_max_local_index` cap is now part of the archive cache key, so a raised setting takes effect even if a non-search query opened the archive first.
- **No more stdout pollution (#21).** libzim printed `No stemming for language 'X'` to stdout for languages Xapian can't stem (e.g. Chinese); a local libzim overlay patch drops it. Search behavior unchanged.

### Validation
- All four changes merged to `main` via CI-green PRs (#20, #23/#14, #24/#16, #25/#21), each building across Linux + macOS (arm+amd) + WASM.
- New tests: federated `ignore_errors` (sqllogictest), decompression cap (all read paths), and a Chinese-fixture stdout-cleanliness CLI test wired into CI.

Ref: `teaguesterling/duckdb_zim@v0.6.0` (`1faa9a3`). `excluded_platforms` and `vcpkg_commit` unchanged; the libzim patch rides the repo's existing `vcpkg_ports` overlay.