### PR TITLE
scalarfs: 1.4.1 -> 1.5.0

### DIFF
--- a/extensions/scalarfs/description.yml
+++ b/extensions/scalarfs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: scalarfs
   description: A collection of virtual filesystems for working with scalars
-  version: 1.4.1
+  version: 1.5.0
   language: C++
   build: cmake
   license: MIT
@@ -12,9 +12,9 @@ extension:
     - teaguesterling
 repo:
   github: teaguesterling/duckdb_scalarfs
-  andium: 62ca2530e273ab9daa7d563519e1f22569e71741
-  ref: 62ca2530e273ab9daa7d563519e1f22569e71741
-  ref_next: 62ca2530e273ab9daa7d563519e1f22569e71741
+  andium: 68faa6c72054123a6c6521dd41c12f929431da50
+  ref: 68faa6c72054123a6c6521dd41c12f929431da50
+  ref_next: 68faa6c72054123a6c6521dd41c12f929431da50
 docs:
   hello_world: |
     LOAD scalarfs;
@@ -43,6 +43,16 @@ docs:
     COPY (SELECT path FROM files WHERE active) TO 'variable:paths' (FORMAT variable);
     SELECT * FROM read_csv('pathvariable:paths');  -- Read all files from the list
 
+    -- Select which files to read via a catalog macro (pathmacro:)
+    CREATE TABLE reports AS
+      SELECT * FROM (VALUES ('west', '/data/west.csv'), ('east', '/data/east.csv')) t(region, path);
+    CREATE MACRO region_files(p) AS (SELECT list(path) FROM reports WHERE region = p['region']);
+    SET allowed_pathmacro_macros = 'region_files';
+    SELECT * FROM read_csv('pathmacro:region_files?region=east');  -- reads only the east file
+
+    -- Build pathmacro: URLs safely (keys/values URL-encoded)
+    SELECT to_pathmacro_url('region_files', {region: 'west'});  -- pathmacro:region_files?region=west
+
   extended_description: |
     DuckDB's file functions (read_csv, read_json, COPY TO, etc.) expect file paths. scalarfs bridges the gap
     when your content is already in memory, allowing the same functions to work with:
@@ -50,18 +60,22 @@ docs:
     Variables — Store data in DuckDB variables and read/write them as files
     Path Variables — Use file paths stored in variables for dynamic file resolution
     Inline literals — Embed content directly in your queries without temporary files
+    Catalog macros — Select which files to read from an index/catalog via a macro (pathmacro:)
 
-    | Protocol         | Purpose                                |   Mode      |
-    |------------------|----------------------------------------|-------------|
-    | variable:        | DuckDB variable as file                | Read/Write  |
-    | pathvariable:    | File path(s) stored in variable        | Read/Write* |
-    | data:            | RFC 2397 data URI (base64/url-encoded) | Read        |
-    | data+varchar:    | Raw VARCHAR content as file            | Read        |
-    | data+blob:       | Escaped BLOB content as file           | Read        |
-    | decompress+gz:   | Gzip decompression wrapper             | Read        |
-    | decompress+zstd: | Zstd decompression wrapper             | Read        |
+    | Protocol         | Purpose                                 |   Mode      |
+    |------------------|-----------------------------------------|-------------|
+    | variable:        | DuckDB variable as file                 | Read/Write  |
+    | pathvariable:    | File path(s) stored in variable         | Read/Write* |
+    | data:            | RFC 2397 data URI (base64/url-encoded)  | Read        |
+    | data+varchar:    | Raw VARCHAR content as file             | Read        |
+    | data+blob:       | Escaped BLOB content as file            | Read        |
+    | decompress+gz:   | Gzip decompression wrapper              | Read        |
+    | decompress+zstd: | Zstd decompression wrapper              | Read        |
+    | pathmacro:        | Paths resolved by an allow-listed macro | Read/Write |
 
     * Can only write to a `pathvariable:` that's a scalar path (not lists).
+
+    Helper functions `to_pathmacro_url()` / `from_pathmacro_url()` build and parse `pathmacro:` URLs.
 
     For full documentation, see: https://scalarfs.readthedocs.io/
 


### PR DESCRIPTION
Bumps **scalarfs** to `v1.5.0` (built against DuckDB v1.5).

### New: `pathmacro:` protocol (read + write)
A resolver filesystem that turns a catalog into a file-selection layer. `read_csv('pathmacro:<macro>?k=v')` calls an **allow-listed** scalar macro that returns a path (or `VARCHAR[]` of paths), so a globbing reader touches only the files the macro selects — inter-file pruning driven by SQL.

- Opt-in via the `allowed_pathmacros` setting (empty by default).
- Macro name is identifier-validated; query-string values are passed as escaped **data**, never interpolated as SQL (injection-safe).
- Returned paths may themselves be globs / other protocols (re-dispatched), including recursive `**`.
- **Writable**: `COPY ... TO 'pathmacro:<macro>?...'` when the macro resolves to a single path; overwrite is atomic (temp write + rename).

### New: URL helpers
- `to_pathmacro_url(macro[, params STRUCT|MAP])` — build a `pathmacro:` URL, URL-encoding each key/value.
- `from_pathmacro_url(url)` → `STRUCT(macro, params MAP(VARCHAR,VARCHAR))` — the inverse.

### Also
- Consolidated URL/blob encode-decode into a shared internal module (no behavior change).
- Built and tested against **DuckDB v1.5** (`v1.5-variegata`).

Release commit: `teaguesterling/duckdb_scalarfs@68faa6c` (tag `v1.5.0`).