### PR TITLE
update h3 to c extension

### DIFF
--- a/extensions/h3/description.yml
+++ b/extensions/h3/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: h3
   description: Hierarchical hexagonal indexing for geospatial data
-  version: 1.5.4-c
+  version: 1.5.5
   language: C++
   build: cmake
   license: Apache-2.0
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: isaacbrodsky/h3-duckdb
-  ref: ec4c50ec378caad3c6fd666ec1046b3c3f1b743a
+  ref: 166e577da67067e1d488fd551dd3b6bb42b081f2
 
 docs:
   hello_world: |

--- a/extensions/h3/description.yml
+++ b/extensions/h3/description.yml
@@ -5,6 +5,7 @@ extension:
   language: C++
   build: cmake
   license: Apache-2.0
+  requires_toolchains: "python3"
   maintainers:
     - isaacbrodsky
 

--- a/extensions/h3/description.yml
+++ b/extensions/h3/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: h3
   description: Hierarchical hexagonal indexing for geospatial data
-  version: 1.5.4
+  version: 1.5.4-c
   language: C++
   build: cmake
   license: Apache-2.0
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: isaacbrodsky/h3-duckdb
-  ref: be9ee91ad4b9718c5d0cc95647c013c5d907a237
+  ref: ec4c50ec378caad3c6fd666ec1046b3c3f1b743a
 
 docs:
   hello_world: |


### PR DESCRIPTION
Edit: see newer comment, this should now be ready

Points at a branch currently, so not ready for this PR to merge. Upstream PR is https://github.com/isaacbrodsky/h3-duckdb/pull/191 This is for testing CI on duckdb/community-extensions to make sure the extension will build with the various build system changes.