### PR TITLE
markdown: 1.4.2 -> 1.5.0 (WASM fix, JSON escaping, md_extract_frontmatter)

### DIFF
--- a/extensions/markdown/description.yml
+++ b/extensions/markdown/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: markdown
   description: Read, analyze, and write Markdown files with block-level document representation and inline element support
-  version: 1.4.2
+  version: 1.5.0
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 repo:
   github: teaguesterling/duckdb_markdown
   andium: c9e1a4d3b98a814c86295ecb2ed760be286242ba
-  ref: refs/tags/v1.4.2
+  ref: refs/tags/v1.5.0
 docs:
   hello_world: |
     -- Load the extension
@@ -102,4 +102,4 @@ docs:
 
     Real-world benchmark: Processing 287 Markdown files (2,699 sections, 1,137 code blocks, 1,174 links) in 603ms.
 
-    Full test suite with 1108 passing assertions across 20 test files.
+    Full test suite with 1190 passing assertions across 24 test files.

--- a/extensions/markdown/description.yml
+++ b/extensions/markdown/description.yml
@@ -11,7 +11,7 @@ extension:
 repo:
   github: teaguesterling/duckdb_markdown
   andium: c9e1a4d3b98a814c86295ecb2ed760be286242ba
-  ref: refs/tags/v1.5.0
+  ref: 4ac331521f3567ae745187fa16f27e56296b432b
 docs:
   hello_world: |
     -- Load the extension


### PR DESCRIPTION
Bumps **markdown** from v1.4.2 to **v1.5.0** (`refs/tags/v1.5.0`).

Catches the extension up to the DuckDB v1.5 line and bundles:

- **WASM now loads (#19).** cmark-gfm added to `LINKED_LIBS`, so the `-sSIDE_MODULE=2` link embeds it instead of leaving stub imports that threw on first call (the failing-wasm census). Same root cause/fix as webbed#96 / yaml#40.
- **Valid JSON in table cells (#21).** The `encoding='json'` block-content escaper was unified to cover `\r`/`\t` and all control chars; the table-cell path previously escaped only `" \ \n`, producing invalid JSON for a tab/CR in a cell.
- **New `md_extract_frontmatter(md)` (#17).** Returns the raw frontmatter block as `VARCHAR` — the seam to `duckdb_yaml` for full YAML fidelity without markdown carrying a YAML parser.

**Build:** shippable artifacts target the **DuckDB v1.5.4** release tag; submodules track `v1.5-variegata` for dev. Windows (MSVC + mingw), macOS, Linux, and WASM all build and pass the test suite (24 test files / 1190 assertions).

Release: https://github.com/teaguesterling/duckdb_markdown/releases/tag/v1.5.0
