### PR TITLE
func_apply: bump to v0.2.0 (security fix)

### DIFF
--- a/extensions/func_apply/description.yml
+++ b/extensions/func_apply/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: func_apply
   description: Dynamic function invocation - call any scalar function or macro by name at runtime
-  version: 0.1.0
+  version: 0.2.0
   language: C++
   build: cmake
   license: MIT
@@ -9,8 +9,12 @@ extension:
     - teaguesterling
 repo:
   github: teaguesterling/duckdb_func_apply
+  # andium (DuckDB v1.4.5 track) intentionally left at the pre-v0.2.0 commit:
+  # v0.2.0 is a DuckDB v1.5.4 tree and is not built-verified against v1.4.5.
+  # The v0.2.0 security fix (GHSA-55g5-vp25-phpg) is delivered on the v1.5.4
+  # track via `ref`; v1.4.5 users should move to the v1.5.4 track.
   andium: 2013ac345d6f19e61ee78cacae161eb272cf1837
-  ref: 2013ac345d6f19e61ee78cacae161eb272cf1837
+  ref: refs/tags/v0.2.0
 docs:
   hello_world: |
     -- Load the extension
@@ -82,3 +86,25 @@ docs:
     - Macros (e.g., `list_sum`, `list_reverse`)
 
     Aggregate and table functions are not supported.
+
+    ## Security Model
+
+    `apply` and `apply_table` run on the **caller's own context** — they add no
+    privilege beyond the SQL the caller could already execute directly. They are
+    a dynamic-dispatch convenience, **not a sandbox**.
+
+    For scenarios that embed func_apply and want to restrict which functions can
+    be invoked (e.g. accepting a function name from less-trusted input), an
+    optional, opt-in policy is available. It is **per session** and defaults to
+    `none` (no restriction):
+
+    | Function | Description |
+    |----------|-------------|
+    | `func_apply_set_security_mode(mode)` | `'none'`, `'blacklist'`, `'whitelist'`, or `'validator'` |
+    | `func_apply_set_whitelist([...])` / `func_apply_set_blacklist([...])` | Set the allowed/denied function names |
+    | `func_apply_lock_security()` | Irreversibly lock the current session's policy |
+
+    The policy lives on the session's `ClientContext` and does not leak across
+    connections. Versions before 0.2.0 stored it process-globally and could
+    quote-escape injected identifiers — see security advisory
+    GHSA-55g5-vp25-phpg; upgrade to 0.2.0 (DuckDB v1.5.4 track).


### PR DESCRIPTION
Updates `func_apply` from 0.1.0 to [v0.2.0](https://github.com/teaguesterling/duckdb_func_apply/releases/tag/v0.2.0).

## Security fix — GHSA-55g5-vp25-phpg

- **Identifier injection in `apply_table_with`**: a crafted struct/kwargs field name could break out of the reparsed table-function SQL and bypass the extension's *own* whitelist/blacklist. Injected identifiers are now quoted via `KeywordHelper::WriteQuoted`. This is **not** a privilege escalation against DuckDB — `apply` runs on the caller's own context — but it defeated the opt-in guardrail used in embedding scenarios.
- **Per-session security config**: the mode and whitelist/blacklist now live on the session `ClientContext` (`registered_state`) instead of a process-global map keyed on raw `ClientContext*`, which could alias across sessions on a recycled address.
- The security model (modes, per-session scope, "not a sandbox") is now documented in the descriptor.

Regression test `test/sql/func_apply_security_injection.test` covers the bypass; verified locally that the crafted field name is rejected by the binder rather than executing the injected function.

## Build

- `ref` → `refs/tags/v0.2.0` (DuckDB v1.5.4 track); stable CI green on all platforms.
- `andium` (v1.4.5 track) intentionally left at the pre-fix commit — v0.2.0 is a v1.5.4 tree and is not build-verified against v1.4.5. v1.4.5 users should move to the v1.5.4 track (noted in the descriptor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoeSgK1FVsbYk2FPGDyrSb