### PR TITLE
yaml: 1.6.6 -> 1.7.0 (DoS guards, WASM fix, yaml_to_json key escaping)

### DIFF
--- a/extensions/yaml/description.yml
+++ b/extensions/yaml/description.yml
@@ -17,8 +17,8 @@ extension:
   
 repo:
   github: teaguesterling/duckdb_yaml
-  andium: 9449d983fafdaff0be9aa8d0082cd526b5e95be4
-  ref: 9449d983fafdaff0be9aa8d0082cd526b5e95be4
+  andium: 4523b13794d366d727d598dd137f957c0e96caa4
+  ref: 4523b13794d366d727d598dd137f957c0e96caa4
 
 docs:
   hello_world: |

--- a/extensions/yaml/description.yml
+++ b/extensions/yaml/description.yml
@@ -2,10 +2,12 @@ extension:
   name: yaml
   description: Read YAML files into DuckDB with native YAML type support, comprehensive extraction functions, and seamless JSON interoperability
   version: 1.7.0
-  # Windows is built (no excluded_platforms): the earlier exclusion (DuckDB-vendored
-  # fmt vs the community MSVC STL) no longer reproduces on the v1.5.4 toolchain -- the
-  # extension compiles and passes the full test suite on windows_amd64 via the
-  # v1.5-variegata CI (a ~24-min real build+test run, no COPY-TO hang).
+  # windows_amd64 (MSVC) is built: the earlier "fmt fails to compile vs the community
+  # MSVC STL" exclusion no longer reproduces on the v1.5.4 toolchain -- the extension
+  # compiles and passes the full suite on windows_amd64 via v1.5-variegata CI (a ~24-min
+  # real build+test run, no COPY-TO hang). windows_amd64_mingw stays excluded: the mingw
+  # (libstdc++) toolchain + yaml-cpp is not yet validated here.
+  excluded_platforms: windows_amd64_mingw
   language: C++
   build: cmake
   license: MIT

--- a/extensions/yaml/description.yml
+++ b/extensions/yaml/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: yaml
   description: Read YAML files into DuckDB with native YAML type support, comprehensive extraction functions, and seamless JSON interoperability
-  version: 1.6.6
+  version: 1.7.0
   # Windows excluded: DuckDB's vendored fmt fails to compile against the community
   # runner's current MSVC STL (stdext::checked_array_iterator removed); not fixable
   # from the extension.
@@ -17,8 +17,8 @@ extension:
   
 repo:
   github: teaguesterling/duckdb_yaml
-  andium: 8a1d8444af06682a3cb2933068a6a35af0fec3b2
-  ref: 8a1d8444af06682a3cb2933068a6a35af0fec3b2
+  andium: 9449d983fafdaff0be9aa8d0082cd526b5e95be4
+  ref: 9449d983fafdaff0be9aa8d0082cd526b5e95be4
 
 docs:
   hello_world: |

--- a/extensions/yaml/description.yml
+++ b/extensions/yaml/description.yml
@@ -2,17 +2,17 @@ extension:
   name: yaml
   description: Read YAML files into DuckDB with native YAML type support, comprehensive extraction functions, and seamless JSON interoperability
   version: 1.7.0
-  # Windows excluded: DuckDB's vendored fmt fails to compile against the community
-  # runner's current MSVC STL (stdext::checked_array_iterator removed); not fixable
-  # from the extension.
-  excluded_platforms: windows_amd64;windows_amd64_mingw
+  # Windows is built (no excluded_platforms): the earlier exclusion (DuckDB-vendored
+  # fmt vs the community MSVC STL) no longer reproduces on the v1.5.4 toolchain -- the
+  # extension compiles and passes the full test suite on windows_amd64 via the
+  # v1.5-variegata CI (a ~24-min real build+test run, no COPY-TO hang).
   language: C++
   build: cmake
   license: MIT
   maintainers:
     - teaguesterling
 
-  # yaml package issues for windows in previous vcpkg
+  # Pinned vcpkg for Windows yaml-cpp compatibility (older vcpkg had Windows build issues).
   vcpkg_commit: "656be05781442d5c4cb14978f6c7bf47b6e12b32"
   
 repo:


### PR DESCRIPTION
Bumps **yaml** from v1.6.6 to **v1.7.0** (`9449d983`). First release since 1.6.6.

- **YAML DoS guards** — bounded nesting depth + alias/anchor expansion (cumulative node budget), extended to the extraction/unnest node walks (GHSA advisory). Tunable via `yaml_set_max_*`.
- **WASM now loads (#40)** — `yaml-cpp` added to `LINKED_LIBS` so the SIDE_MODULE link embeds it instead of leaving stub imports that threw at load; includes a live duckdb-wasm load test.
- **`yaml_to_json` escapes map keys (#42)** — keys were inserted raw while values were escaped, so a key with `"`/`\` produced invalid JSON from a function declared `LogicalType::JSON()`. Unified into one escaper for values and keys.
- Removed dead `yaml_reader_column_bind_old.cpp`.

**Build:** shippable artifacts target the **DuckDB v1.5.4** release tag (submodules track `v1.5-variegata`). Linux / macOS / WASM green. Windows stays excluded pending a `yaml_copy_to.test` hang (tracked follow-up).

Release: https://github.com/teaguesterling/duckdb_yaml/releases/tag/v1.7.0
