### PR TITLE
ai: bump to v0.4.14

### DIFF
--- a/extensions/ai/description.yml
+++ b/extensions/ai/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: ai
   description: AI functions for SQL — completions, classification, extraction, embeddings, and read-only SQL generation across local and hosted model providers
-  version: 0.4.0
+  version: 0.4.14
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: leonardovida/duckdb-ai
-  ref: 42139d114b5513b18a6e674a9bc689b2e2762c04
+  ref: 9b7b16a5d5bfa97180b8be48d69bd9a4a4106419
 
 docs:
   hello_world: |


### PR DESCRIPTION
Updates `ai` to [v0.4.14](https://github.com/leonardovida/duckdb-ai/releases/tag/v0.4.14).

Pins the release commit `9b7b16a5d5bfa97180b8be48d69bd9a4a4106419`.
