### PR TITLE
ducklake_cdc: v0.6.1

### DIFF
--- a/extensions/ducklake_cdc/description.yml
+++ b/extensions/ducklake_cdc/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: ducklake_cdc
   description: "Stream changes from your DuckLake — durable consumer cursors, single-reader windows, typed DDL events."
-  version: "0.5.4"
+  version: "0.6.1"
   language: C++
   build: cmake
   license: Apache-2.0
@@ -13,4 +13,4 @@ extension:
 
 repo:
   github: "ekkuleivonen/ducklake-cdc-extension"
-  ref: "2e85b6a2df0a9a560308ad62c0c21d1fc67888aa"
+  ref: "50eb8ac4b35f85a98f432c62511c1a1a95000a9b"


### PR DESCRIPTION
Automated descriptor update for [ekkuleivonen/ducklake-cdc-extension@v0.6.1](https://github.com/ekkuleivonen/ducklake-cdc-extension/releases/tag/v0.6.1).

Release SHA: `50eb8ac4b35f85a98f432c62511c1a1a95000a9b`

Generated by [.github/workflows/release.yml](https://github.com/ekkuleivonen/ducklake-cdc-extension/blob/50eb8ac4b35f85a98f432c62511c1a1a95000a9b/.github/workflows/release.yml).
