### PR TITLE
pdf: update to 0.7.0

### DIFF
--- a/extensions/pdf/description.yml
+++ b/extensions/pdf/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: pdf
   description: Read text, metadata, words, lines, tables, layout elements, and markdown from PDF files (works on scanned PDFs via Tesseract OCR word boxes); chunk for retrieval; render pages; inspect outlines, attachments, form fields, annotations, revisions, and signatures; extract embedded images; merge, split, rotate, compress, encrypt, decrypt, watermark, and Bates-stamp documents via qpdf; write PDFs natively via libharu (`write_pdf` / `COPY … TO FORMAT pdf`); and convert office documents to PDF.
-  version: 0.5.1
+  version: 0.6.0
   language: C++
   build: cmake
   license: GPL-2.0-or-later
@@ -17,7 +17,7 @@ extension:
 
 repo:
   github: asubbarao/duckdb-pdf
-  ref: 177b634edbcf7e3fdbd7068f4a72455073fba67c
+  ref: 7a092bda4d9b22689f790b892c8bfa71214ef1e7
 
 docs:
   hello_world: |

--- a/extensions/pdf/description.yml
+++ b/extensions/pdf/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: pdf
   description: Read text, metadata, words, lines, tables, layout elements, and markdown from PDF files (works on scanned PDFs via Tesseract OCR word boxes); chunk for retrieval; render pages; inspect outlines, attachments, form fields, annotations, revisions, and signatures; extract embedded images; merge, split, rotate, compress, encrypt, decrypt, watermark, and Bates-stamp documents via qpdf; write PDFs natively via libharu (`write_pdf` / `COPY … TO FORMAT pdf`); and convert office documents to PDF.
-  version: 0.6.0
+  version: 0.7.0
   language: C++
   build: cmake
   license: GPL-2.0-or-later
@@ -17,7 +17,7 @@ extension:
 
 repo:
   github: asubbarao/duckdb-pdf
-  ref: 7a092bda4d9b22689f790b892c8bfa71214ef1e7
+  ref: c5209712bc63047dd2bee07c30b54bc177841812
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps the `pdf` extension to **0.7.0**, pinning `repo.ref` to a fully green distribution-CI commit.

### What changed since 0.5.1 (`177b634` → `c520971`)

#### 0.6.0 (`177b634` → `7a092bd`)
- **`feat`: comprehensive Poppler/qpdf API surface + pluggable OCR backend** — expanded inspect/transform coverage and a cleaner OCR integration.
- **`feat`: first-class OCR surface** — isolates the Tesseract translation unit and exposes text-layer flags.
- **examples**: added a generalizable document-intelligence pipeline recipe.
- **style**: clang-format pass so `Code Quality Check / Format Check` is green.

#### 0.7.0 (`7a092bd` → `c520971`)
- **`feat(pdf_redact)`: row-mode / column-ref args** — pure table **in-out** function (same shape as `range`/`unnest`).
  - Constant-arg form remains backward-compatible: `FROM pdf_redact('in.pdf', 'out.pdf', […boxes…])`
  - Column-ref dependent joins work: `FROM docs d CROSS JOIN pdf_redact(d.path, d.out, d.boxes) r`
  - Named params `dpi`/`password` still bind on the all-constants path; row-mode uses dpi=200 and empty password defaults.
- Tests: **873 assertions green** on the extension distribution pipeline (linux/osx/windows amd64+arm as built).

### CI

Distribution pipeline on the pinned commit `c5209712bc63047dd2bee07c30b54bc177841812` is green on all built targets — `linux_amd64`, `linux_arm64`, `osx_amd64`, `osx_arm64`, and `windows_amd64` — plus the Format Check job. (Run: asubbarao/duckdb-pdf `Main Extension Distribution Pipeline` on `c520971`, re-confirmed after one flake re-run of `pdf_sign.test` on osx_arm64 only.)

Diff is limited to `extensions/pdf/description.yml`: `version` → `0.7.0` and `repo.ref` → `c520971…`.