### PR TITLE
Bump plinking_duck to v0.7.2

### DIFF
--- a/extensions/plinking_duck/description.yml
+++ b/extensions/plinking_duck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: plinking_duck
   description: Read PLINK 2 genomics file formats and run common genetic analyses directly in SQL
-  version: 0.7.1
+  version: 0.7.2
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: teaguesterling/plinking_duck
-  ref: b2d6b8b23388c422bdf539b97a2997f8643d7a1b
+  ref: 0a37fccb3009d1b0d59216cf6556d912a2f4bc4b
 
 docs:
   hello_world: |


### PR DESCRIPTION
Updates plinking_duck to v0.7.2 (ref 0a37fcc).

Highlights since v0.7.1:
- read_pfile honors `file_search_path` and expands globs / `pathmacro:` URLs to local shard paths
- multi-file `orient := 'sample'` + new `combine_samples` parameter (implicit/identical)
- shared `psam` override allowed with a multi-file list
- streaming per-sample `genotypes := 'counts'|'stats'` (O(samples) memory, not the variants×samples matrix) + optional sparse (pgen difflist) path for rare-variant carrier finding (`plinking_sample_counts_sparse`, ~4-6x)
- fix: crash on a region matching zero variants via parquet pushdown

Full suite green (74 cases / 4189 assertions).