### PR TITLE
ducklake_cdc: v0.6.2

### DIFF
--- a/extensions/ducklake_cdc/description.yml
+++ b/extensions/ducklake_cdc/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: ducklake_cdc
   description: "Stream changes from your DuckLake — durable consumer cursors, single-reader windows, typed DDL events."
-  version: "0.6.1"
+  version: "0.6.2"
   language: C++
   build: cmake
   license: Apache-2.0
@@ -13,4 +13,4 @@ extension:
 
 repo:
   github: "ekkuleivonen/ducklake-cdc-extension"
-  ref: "50eb8ac4b35f85a98f432c62511c1a1a95000a9b"
+  ref: "db3a5b17b63be5316a93ce7fce32dedf97abd186"


### PR DESCRIPTION
Automated descriptor update for [ekkuleivonen/ducklake-cdc-extension@v0.6.2](https://github.com/ekkuleivonen/ducklake-cdc-extension/releases/tag/v0.6.2).

Release SHA: `db3a5b17b63be5316a93ce7fce32dedf97abd186`

Generated by [.github/workflows/release.yml](https://github.com/ekkuleivonen/ducklake-cdc-extension/blob/db3a5b17b63be5316a93ce7fce32dedf97abd186/.github/workflows/release.yml).
