### PR TITLE
Bump h5db

### DIFF
--- a/extensions/h5db/description.yml
+++ b/extensions/h5db/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: h5db
   description: Read HDF5 datasets and attributes
-  version: 1.1.6
+  version: 1.2.0
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
     - jokasimr
 repo:
   github: jokasimr/h5db
-  ref: v1.1.6
+  ref: v1.2.0
   andium: v0.3.0
 
 docs:

--- a/extensions/h5db/description.yml
+++ b/extensions/h5db/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: h5db
   description: Read HDF5 datasets and attributes
-  version: 1.2.1
+  version: 1.2.2
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
     - jokasimr
 repo:
   github: jokasimr/h5db
-  ref: v1.2.1
+  ref: v1.2.2
   andium: v0.3.0
 
 docs:

--- a/extensions/h5db/description.yml
+++ b/extensions/h5db/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: h5db
   description: Read HDF5 datasets and attributes
-  version: 1.2.0
+  version: 1.2.1
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
     - jokasimr
 repo:
   github: jokasimr/h5db
-  ref: v1.2.0
+  ref: v1.2.1
   andium: v0.3.0
 
 docs:


### PR DESCRIPTION
## Changes from v1.1.6 to v1.2.2

  ### Added

  - Scalar `h5_read(filename, path)` with a configurable limit to memory usage.
  - Scalar `h5_attributes(filename, path)`.
  - Run-end encoded columns through `h5_ree()`.
  - HDF5 float16 support.
  - Support for multidimensional attribute values.

  ### Changes

  - Added nested-list fallback for very "wide" datasets to avoid excessive vector allocations.
  - Made column ordering in `h5_attributes` lexical.

  ### Fixed

  - Corrected (disabled) prepared-statement bind caching.
  - Improved SFTP globbing and aligned it better with local-file behavior.
  - Fixed h5db_version().
  - Reimplemented `h5_tree` to prevent deadlocks when combined with scalar h5db functions. This will change the order of rows returned by `h5_tree`.
