### PR TITLE
quackapi: 0.1.1 — LOC reduction; self-contained JWT (not community crypto)

### DIFF
--- a/extensions/quackapi/description.yml
+++ b/extensions/quackapi/description.yml
@@ -15,7 +15,7 @@ extension:
     FastAPI-class HTTP framework inside DuckDB — CREATE ROUTE turns SQL into
     typed, validated endpoints; one process is DB + HTTP (+ PDF/renderer via
     companion extensions).
-  version: 0.1.0
+  version: 0.1.1
   language: C++
   build: cmake
   license: MIT
@@ -31,7 +31,7 @@ extension:
 repo:
   github: asubbarao/quackapi
   # Pin to the packaging commit SHA (set by release engineer; never a branch).
-  ref: 225f812f8c49a3a5fc1040f42c3d7794260af165
+  ref: 09680f7ac665f3eeb11cf8997e562f5533eb1fac
 
 docs:
   hello_world: |
@@ -112,7 +112,9 @@ docs:
 
     - **Auth:** `CREATE AUTH … AS API_KEY | JWT (SECRET … [, ALGORITHM HS256])`,
       `REQUIRE` on routes, `quackapi_add_api_key`, `quackapi_auths`, claims as
-      `$claims_*`.
+      `$claims_*`. JWT verify is self-contained (DuckDB-bundled mbedtls +
+      `json_*` claims) — does not depend on community `crypto` (that extension
+      is hash/HMAC only, not JWT parse/exp/nbf/claims).
     - **Groups:** `CREATE GROUP … WITH (prefix=…, auth=…, tags=…)` — path prefix
       + auth inheritance (`quackapi_groups()`).
     - **Table API:** `CREATE API FOR TABLE t [AT '/path'] [KEY 'id']` → GET list
@@ -139,7 +141,8 @@ docs:
     - Serve `memory_limit` default is 256MB only when nothing is configured;
       use `memory_limit := '4GB'` / `SET quackapi_memory_limit` (never clobbers
       an operator `SET memory_limit`).
-    - Request body max 8 MiB; JWT HS256 only; table API is read-only scaffold.
+    - Request body max 8 MiB; JWT **HS256 only** (no RS256/OIDC); table API is
+      read-only scaffold.
     - Route registry is instance-scoped (re-run DDL after reopen); queue jobs
       persist in `quackapi_jobs`.
 


### PR DESCRIPTION
## Summary

Bump community **`quackapi`** to **0.1.1** (`asubbarao/quackapi@09680f7`).

**One commit** on current `main` — pin + storefront description only.

## What changed

| Area | Change |
|------|--------|
| **LOC pass 1** | JWT claims parse/serialize via DuckDB `json_*` + shared `QuackapiTrim` / `QuackapiJsonEscape` (control-byte-safe). |
| **LOC pass 2** | `enqueue` / `nack` arity collapse; DDL apply shell helpers. |
| **Auth** | JWT **HS256** verify is **self-contained** (DuckDB-bundled **mbedtls** + `json_*` claims → `$claims_*`). |

## Why not community `crypto`?

[`crypto`](https://duckdb.org/community_extensions/extensions/crypto) exposes **`crypto_hash` / `crypto_hmac` / `crypto_random_bytes` only**. It is **not** a JWT implementation:

- no compact-token parse (`header.payload.signature`)
- no `alg` allowlist (reject `none` / non-HS256)
- no `exp` / `nbf`
- no claims map for `$claims_*`

quackapi therefore implements JWT verify in-process so **`INSTALL quackapi` does not require `INSTALL crypto`**, and auth works offline in one process. (If `crypto` later gains first-class JWT verify, we can re-evaluate.)

## Reviewer notes

- Depends only on DuckDB-bundled **httplib** + **mbedtls** (no vcpkg for quackapi).
- Product tests: auth HTTP binds `$claims_*`; `quackapi_jwt_claims` covers exp/nbf/alg/control-chars; queue arity matrix.
- Platforms: wasm + all Windows legs excluded until green community windows build.

## Test plan

- [ ] Community CI green (linux/osx)
- [ ] Smoke: `CREATE AUTH j AS JWT ( SECRET 's' );` + route with `$claims_sub` without loading `crypto`