### PR TITLE
miint: bump to v1.0.0-rc.3

### DIFF
--- a/extensions/miint/description.yml
+++ b/extensions/miint/description.yml
@@ -14,7 +14,7 @@ extension:
 
 repo:
   github: the-miint/duckdb-miint
-  ref: e4b2620d4a4b23750550446f6da6204ca9a98dd7
+  ref: c2e8d972724afd82fbbe542f6abf5c7a984f375d
 
 docs:
   hello_world: |

--- a/extensions/miint/description.yml
+++ b/extensions/miint/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: miint
   description: Bioinformatics extension for microbiome research - read/write FASTQ, SAM/BAM, BIOM, GFF, Newick trees, query NCBI, and more.
-  version: '1.0.0-rc.4'
+  version: '1.0.0-rc.3'
   language: C++
   build: cmake
   license: BSD-3-Clause
@@ -14,7 +14,7 @@ extension:
 
 repo:
   github: the-miint/duckdb-miint
-  ref: 1f5b77301c6d4130bb2660c5f9684d1d6afd2a4f
+  ref: e4b2620d4a4b23750550446f6da6204ca9a98dd7
 
 docs:
   hello_world: |


### PR DESCRIPTION
Updates the `miint` extension entry to **v1.0.0-rc.3**.

- `version`: `1.0.0-rc.3`
- `ref`: `c2e8d972724afd82fbbe542f6abf5c7a984f375d` (current `v1.5-variegata` tip of [the-miint/duckdb-miint](https://github.com/the-miint/duckdb-miint))

### Why this ref (and not the matching git tag)
The `v1.0.0-rc.3` git tag points at an earlier commit whose `ena_upload_reads.cpp` used POSIX `mkdtemp(3)` — which MinGW's libc omits, breaking the `windows_amd64_mingw` build. `c2e8d97` carries the fix (portable staging-directory creation via DuckDB's `FileSystem` instead of `mkdtemp`) plus a regression test, and the `windows_amd64_mingw` lane is **green** on the source repo's CI. The `ref` deliberately tracks the fixed commit rather than the tag.

The previous entry carried a `1.0.0-rc.4` label that never had a corresponding tag or release in the source repo; this realigns the version with the source repo's own tagging convention (`v1.0.0-rc.2` → `v1.0.0-rc.3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
