### PR TITLE
Bump plinking_duck to v0.8.0

### DIFF
--- a/extensions/plinking_duck/description.yml
+++ b/extensions/plinking_duck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: plinking_duck
   description: Read PLINK 2 genomics file formats and run common genetic analyses directly in SQL
-  version: 0.7.1
+  version: 0.8.0
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: teaguesterling/plinking_duck
-  ref: b2d6b8b23388c422bdf539b97a2997f8643d7a1b
+  ref: 8c864c03a8292288e30e07dcc456b095e39a05cd
 
 docs:
   hello_world: |


### PR DESCRIPTION
Updates plinking_duck to **v0.8.0** (ref `8c864c0`). **Supersedes #2284** (v0.7.2, never merged — v0.8.0 includes all of it).

## Headline: read `.pgen` from remote / VFS storage (s3://, http, …)

plinking_duck can now read PLINK 2 genotypes **directly from any DuckDB filesystem** — `s3://`, `https://`, `pathmacro:`, globs, and `file_search_path` — not just local disk. plink2/pgenlib are local-only (raw `FILE*`); we redirect pgenlib's 3 `.pgen` `fopen` sites (a minimal, re-appliable, upstreamable patch) to a `fopencookie`/`funopen` `FILE*` backed by a DuckDB `FileHandle` opened with the query context (httpfs secrets apply). A read-ahead block cache makes **targeted/carrier queries fetch only the variant index + region records**, not the whole file — so carrier finding over a large remote `.pgen` is efficient (something plink2 can't do at all).

```sql
LOAD httpfs;
SELECT IID FROM read_pfile('s3://bucket/cohort', orient := 'sample',
    genotypes := 'counts', region := '17:43000000-43125000',
    include_genotypes := ['het','hom_alt']);   -- BRCA1 carriers, over S3
```

- All readers (`read_pgen`/`read_pfile`) and every `plink_*` analysis function.
- `plinking_pgen_io` policy (`auto` default: remote→VFS, local→native `fopen`, zero overhead).
- Also folds in v0.7.2: `file_search_path`/glob/`pathmacro:` for `.pgen`, region-zero-match crash fix, multi-file `orient:='sample'` + `combine_samples`, streaming per-sample counts/stats + optional sparse (difflist) carrier path.

Full suite green (76 cases / 4270 assertions). A configure-time guard fails the build if the pgenlib patch doesn't take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)