### PR TITLE
snowflake: bump to 0.5.0 for DuckDB v1.5.5

### DIFF
--- a/extensions/snowflake/description.yml
+++ b/extensions/snowflake/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: snowflake
   description: Snowflake data source extension - query Snowflake databases directly from DuckDB
-  version: 0.4.1
+  version: 0.5.0
   language: C++
   build: cmake
   license: MIT
@@ -10,25 +10,22 @@ extension:
 
 repo:
   github: iqea-ai/duckdb-snowflake
-  ref: 7a7b4cdef7fed8ffc7e59492aefd9444a1a7e80c
+  ref: 96b6243d40389c66667116398bba2bc608ea9022
 
 install_notes: |
-  **Important:** This extension requires DuckDB 1.5.3 and the Apache Arrow ADBC Snowflake driver to function properly.
-  
-  **You must install the ADBC driver separately after installing this extension.** The extension will not work without the driver.
-  
-  For complete installation instructions, platform-specific setup, and troubleshooting, please refer to the official documentation:
-  
+  **Important:** This extension requires the ADBC Snowflake driver (a separate shared library) to function.
+
+  Install it either with the [dbc](https://docs.columnar.tech/dbc/) driver manager:
+
+      dbc install snowflake
+
+  or with the repository's installer script. No environment variable is needed in either case: the
+  extension discovers the driver next to itself, through standard ADBC driver manifests, and (on
+  Windows) through the ADBC registry keys.
+
+  For platform-specific setup and troubleshooting, see the
   **[ADBC Driver Installation Guide](https://github.com/iqea-ai/duckdb-snowflake#adbc-driver-setup)**
-  
-  The documentation includes:
-  - Step-by-step installation instructions for all platforms
-  - Automated setup scripts
-  - Manual installation procedures
-  - Driver location requirements
-  - Troubleshooting common issues
-  
-  Please visit the [extension repository](https://github.com/iqea-ai/duckdb-snowflake) for installation instructions and setup options.
+  in the [extension repository](https://github.com/iqea-ai/duckdb-snowflake).
 
 docs:
   hello_world: |
@@ -64,11 +61,12 @@ docs:
     - Multiple authentication methods (Password, Key Pair, OAuth, External Browser/SSO, Okta)
     - Direct SQL passthrough via `snowflake_query()` function
     - ATTACH support for mounting Snowflake databases as DuckDB catalogs
+    - Native `GEOMETRY`/`GEOGRAPHY` support via GeoArrow
     - Predicate pushdown optimization (optional)
     - Hybrid queries: join Snowflake tables with local DuckDB tables
     - Full DML read operations: SELECT with WHERE, JOIN, aggregations, subqueries
-    
-    **Prerequisites:** The Apache Arrow ADBC Snowflake driver must be installed separately. 
+
+    **Prerequisites:** The ADBC Snowflake driver must be installed separately (`dbc install snowflake` or the repository's installer script).
     **See the [ADBC Driver Installation Guide](https://github.com/iqea-ai/duckdb-snowflake#adbc-driver-setup) 
     for complete setup instructions.** For comprehensive usage examples, authentication methods, and 
     advanced features, visit the [extension repository](https://github.com/iqea-ai/duckdb-snowflake).

--- a/extensions/snowflake/description.yml
+++ b/extensions/snowflake/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: iqea-ai/duckdb-snowflake
-  ref: 96b6243d40389c66667116398bba2bc608ea9022
+  ref: bf861da14bfa5578a02f819dc5a2aadd4bd415d6
 
 install_notes: |
   **Important:** This extension requires the ADBC Snowflake driver (a separate shared library) to function.


### PR DESCRIPTION
Bumps the Snowflake extension to 0.5.0 (ref = tag [v0.5.0](https://github.com/iqea-ai/duckdb-snowflake/releases/tag/v0.5.0), targets DuckDB v1.5.5).

Highlights: native GEOMETRY/GEOGRAPHY via GeoArrow, a connection pool fixing concurrent-scan crashes, projected SHOW/DESC fixes, and ADBC driver discovery via standard driver manifests (file manifests everywhere, registry keys on Windows) so `dbc install snowflake` needs no environment variable. Install notes updated to match; the driver now comes from the ADBC Driver Foundry rather than the deprecated apache/arrow-adbc wheels.

Full release notes: https://github.com/iqea-ai/duckdb-snowflake/releases/tag/v0.5.0
CI on the pinned ref is green across the full build matrix plus a live-Snowflake test suite.