### PR TITLE
qvd: update to v1.0.3 (DuckDB 1.5.5)

### DIFF
--- a/extensions/qvd/description.yml
+++ b/extensions/qvd/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: qvd
   description: Read (streaming) and write Qlik QVD files
-  version: 1.0.2
+  version: 1.0.3
   language: Rust
   build: cmake          # community label; the actual build goes through the Rust C-API Makefile
   license: Apache-2.0
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: snouhaud/DuckDB-QVD-Extension
-  ref: 4f5cc8fd39b9ef336887c72103a451e5468a6af2
+  ref: f9870d64292f5a065e67b636ff714e966ea46536
 
 docs:
   hello_world: |


### PR DESCRIPTION
Updates the `qvd` community extension to **v1.0.3**, rebuilt against **DuckDB v1.5.5**.

- `version`: 1.0.2 → 1.0.3
- `repo.ref`: pinned to the `v1.0.3` release tag commit (`f9870d6`)

No source/API changes vs 1.0.2 — this is a version bump to track the current community DuckDB (v1.5.5). Reading (streaming, projected) and writing (`COPY ... TO/FROM (FORMAT qvd)`) verified on DuckDB 1.5.5: `cargo test`, loadable-extension build stamped `v1.5.5`, and SQLLogicTest suite all pass.