### PR TITLE
yaml: build windows_amd64_mingw for v1.7.0 (drop platform exclusion)

### DIFF
--- a/extensions/yaml/description.yml
+++ b/extensions/yaml/description.yml
@@ -2,12 +2,12 @@ extension:
   name: yaml
   description: Read YAML files into DuckDB with native YAML type support, comprehensive extraction functions, and seamless JSON interoperability
   version: 1.7.0
-  # windows_amd64 (MSVC) is built: the earlier "fmt fails to compile vs the community
-  # MSVC STL" exclusion no longer reproduces on the v1.5.4 toolchain -- the extension
-  # compiles and passes the full suite on windows_amd64 via v1.5-variegata CI (a ~24-min
-  # real build+test run, no COPY-TO hang). windows_amd64_mingw stays excluded: the mingw
-  # (libstdc++) toolchain + yaml-cpp is not yet validated here.
-  excluded_platforms: windows_amd64_mingw
+  # Windows fully built (no excluded_platforms). windows_amd64 (MSVC) shipped in the
+  # original v1.7.0 build; windows_amd64_mingw is now validated too — it compiles and
+  # passes the full suite on the v1.5.4 / v1.5-variegata toolchain (a real ~31-min
+  # build+test run). The earlier "fmt fails to compile vs the community MSVC STL"
+  # exclusion and the COPY-TO deadlock both proved stale/non-reproducing. Source is
+  # unchanged (same ref); this backfills the mingw platform for v1.7.0.
   language: C++
   build: cmake
   license: MIT


### PR DESCRIPTION
Backfills the `windows_amd64_mingw` platform for the existing yaml **v1.7.0** release.

## Why
v1.7.0 shipped with `excluded_platforms: windows_amd64_mingw` (MSVC-only) because mingw was unvalidated at the time. It is now validated: `windows_amd64_mingw` **compiles and passes the full test suite** on the v1.5.4 / `v1.5-variegata` toolchain — a real ~31-min build+test run (not a skip), including `yaml_copy_to.test`. The earlier "vendored fmt fails to compile vs the community MSVC STL" exclusion and the COPY-TO deadlock both proved stale / non-reproducing.

Combined with the already-shipping `windows_amd64` (MSVC), Windows is fully buildable, so this drops `excluded_platforms` entirely.

## Scope
- **Descriptor-only.** Extension source is unchanged — same `ref` (`4523b13`), same `version: 1.7.0`. This only widens the build matrix to add mingw binaries for the existing release.
- The repo's own distribution pipeline builds both Windows targets too (teaguesterling/duckdb_yaml#47).

The build CI on this PR will produce+test the mingw artifact.