### PR TITLE
cog: target DuckDB v1.5.5

### DIFF
--- a/extensions/cog/description.yml
+++ b/extensions/cog/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: st-layer/duckdb-cog
-  ref: 631d256698dc84f6ccd1ac645e85f9e1156a2fc7
+  ref: 1d210fd7719ae44fef0ac908f4b3f6386677da52
 
 docs:
   hello_world: |


### PR DESCRIPTION
Follow-up to #2274: the initially pinned ref predates the DuckDB v1.5.5 release, so the post-merge deploy failed its load check ("built specifically for v1.5.4 … this version is v1.5.5" — run 30093265930).

This bumps the ref to the commit where the extension targets v1.5.5 across the board (Makefile TARGET_DUCKDB_VERSION, min-version stamp, and test toolchain). Our own CI runs the same extension-ci-tools distribution pipeline at `duckdb_version: v1.5.5` / `ci_tools_version: v1.5-variegata` and is green on all included platforms (incl. wasm) at this commit.

Sorry for the churn — the 1.5.5 release landed mid-review. Thanks!