### PR TITLE
Bump erpl_web to v2026.07.24

### DIFF
--- a/extensions/erpl_web/description.yml
+++ b/extensions/erpl_web/description.yml
@@ -10,4 +10,4 @@ extension:
     - jrosskopf
 repo:
   github: DataZooDE/erpl-web
-  ref: a86f4ceefe3718b6bc2a21f47f9468b3180f5e5c
+  ref: cdecc5e716bf91ad19b9c11f0e3ab6d0c5fc84a0


### PR DESCRIPTION
Bumps `erpl_web` to `v2026.07.24`, built against **DuckDB v1.5.5** (stable) while retaining the **v1.4 LTS** build.

Source: [`DataZooDE/erpl-web@cdecc5e716`](https://github.com/DataZooDE/erpl-web/releases/tag/v2026.07.24) (release v2026.07.24).
Previous ref: `a86f4ceefe`.