### PR TITLE
Bump quack_oauth to v2026.07.24

### DIFF
--- a/extensions/quack_oauth/description.yml
+++ b/extensions/quack_oauth/description.yml
@@ -10,4 +10,4 @@ extension:
     - jrosskopf
 repo:
   github: DataZooDE/quack-oauth
-  ref: d0141da21a84b167f1f6f01fcbeafb30482173d5
+  ref: 8e6621f53a9c39b8f30844d11a1c5c481528985e


### PR DESCRIPTION
Bumps `quack_oauth` to `v2026.07.24`, built against **DuckDB v1.5.5** (stable) while retaining the **v1.4 LTS** build.

Source: [`DataZooDE/quack-oauth@8e6621f53a`](https://github.com/DataZooDE/quack-oauth/releases/tag/v2026.07.24) (release v2026.07.24).
Previous ref: `d0141da21a`.