### PR TITLE
Bump anofox_similarity to v2026.07.24

### DIFF
--- a/extensions/anofox_similarity/description.yml
+++ b/extensions/anofox_similarity/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: DataZooDE/anofox-similarity
-  ref: 52e9a7b9b3fb4045b77d23b8aaf31a1e007346a1
+  ref: 17ece448ca4a2d3a7d73c30dd8e53055478249bc
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps `anofox_similarity` to `v2026.07.24`, built against **DuckDB v1.5.5** (stable) while retaining the **v1.4 LTS** build.

Source: [`DataZooDE/anofox-similarity@17ece448ca`](https://github.com/DataZooDE/anofox-similarity/releases/tag/v2026.07.24) (release v2026.07.24).
Previous ref: `52e9a7b9b3`.