### PR TITLE
Bump anofox_tabular to v2026.07.24

### DIFF
--- a/extensions/anofox_tabular/description.yml
+++ b/extensions/anofox_tabular/description.yml
@@ -9,4 +9,4 @@ extension:
     - jrosskopf
 repo:
   github: DataZooDE/anofox-tabular
-  ref: 6d34a7d9c7bb1e2cc1312cca64be52ad0d61f6ad
+  ref: a9d45d1c6a0f0878fcf92c4aca1f2d51fa8b8979


### PR DESCRIPTION
Bumps `anofox_tabular` to `v2026.07.24`, built against **DuckDB v1.5.5** (stable) while retaining the **v1.4 LTS** build.

Source: [`DataZooDE/anofox-tabular@a9d45d1c6a`](https://github.com/DataZooDE/anofox-tabular/releases/tag/v2026.07.24) (release v2026.07.24).
Previous ref: `6d34a7d9c7`.