### PR TITLE
Bump anofox_forecast to v0.5.2

### DIFF
--- a/extensions/anofox_forecast/description.yml
+++ b/extensions/anofox_forecast/description.yml
@@ -10,4 +10,4 @@ extension:
     - sipemu
 repo:
   github: DataZooDE/anofox-forecast
-  ref: f44228b6a88e0b25915aae08fadf1b192ebe7fe2
+  ref: f43004a0fe746588ea143c89967623fcc0a3111c


### PR DESCRIPTION
Bumps `anofox_forecast` to `v0.5.2`, built against **DuckDB v1.5.5** (stable) while retaining the **v1.4 LTS** build.

Source: [`DataZooDE/anofox-forecast@f43004a0fe`](https://github.com/DataZooDE/anofox-forecast/releases/tag/v0.5.2) (release v0.5.2).
Previous ref: `f44228b6a8`.