### PR TITLE
Bump erpl_idoc to v2026.07.24

### DIFF
--- a/extensions/erpl_idoc/description.yml
+++ b/extensions/erpl_idoc/description.yml
@@ -10,4 +10,4 @@ extension:
     - jrosskopf
 repo:
   github: DataZooDE/erpl-idoc
-  ref: f96c92a39be25b4df77928cc029e76a25c21718b
+  ref: 932869fb8cc0a0d3612d428c19b0d05aa9cf9e72


### PR DESCRIPTION
Bumps `erpl_idoc` to `v2026.07.24`, built against **DuckDB v1.5.5** (stable) while retaining the **v1.4 LTS** build.

Source: [`DataZooDE/erpl-idoc@932869fb8c`](https://github.com/DataZooDE/erpl-idoc/releases/tag/v2026.07.24) (release v2026.07.24).
Previous ref: `f96c92a39b`.