### PR TITLE
Bump sitting_duck to v1.10.1

### DIFF
--- a/extensions/sitting_duck/description.yml
+++ b/extensions/sitting_duck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: sitting_duck
   description: Parse and analyze source code ASTs from 27 programming languages with tree-sitter grammars, pattern matching, and structural search
-  version: 1.9.0
+  version: 1.10.0
   language: C++
   build: cmake
   license: MIT
@@ -9,7 +9,7 @@ extension:
     - teaguesterling
 repo:
   github: teaguesterling/sitting_duck
-  ref: 1da43741d781e630f42ed09e362b2040b30432b6
+  ref: aee6656de323c80bd3840043a780765586b0ea49
 docs:
   hello_world: |
     -- Parse Python code and find function definitions
@@ -86,6 +86,11 @@ docs:
     Supports type selectors, `#name`, `.semantic` (~80 aliases), combinators, `:has()`, `:not()`,
     `:match()` / `:contains()` structural patterns, scope/call-graph pseudo-classes, and pseudo-element navigation.
     Bare type matching: `if` matches `if` + `if_statement` + `if_clause`.
+
+    v1.10.0 adds runtime-loadable tree-sitter grammars (`register_language()`, off by
+    default behind `sitting_duck_enable_runtime_grammars`), `ast_to_blocks` (render code
+    structure as duck_blocks documents), and `ast_patch`/`ast_replace` (AST-anchored
+    source patching and selector-driven rewriting in SQL).
 
     v1.9.0 hardens the selector engine: no more silent-empty results (selectors the engine
     can't honor now raise a clear error instead of returning 0 rows), `#name` on call nodes

--- a/extensions/sitting_duck/description.yml
+++ b/extensions/sitting_duck/description.yml
@@ -1,15 +1,15 @@
 extension:
   name: sitting_duck
   description: Parse and analyze source code ASTs from 27 programming languages with tree-sitter grammars, pattern matching, and structural search
-  version: 1.10.0
+  version: 1.10.1
   language: C++
   build: cmake
-  license: MIT
+  license: Apache-2.0
   maintainers:
     - teaguesterling
 repo:
   github: teaguesterling/sitting_duck
-  ref: aee6656de323c80bd3840043a780765586b0ea49
+  ref: b1489034c5c299a03bb3477acd878158c7ed1811
 docs:
   hello_world: |
     -- Parse Python code and find function definitions


### PR DESCRIPTION
Updates sitting_duck 1.9.0 → 1.10.1 (`b1489034`). Supersedes the v1.10.0 run of this PR: v1.10.1 fixes the `windows_amd64` test failure (glob-expanded path separators in `duck_blocks.test` — test-only change) and corrects the license field to Apache-2.0, matching the extension's relicense.

**v1.10.x — render, patch, extend:**
- **Runtime-loadable tree-sitter grammars** (`register_language()`): load a grammar `.so` at runtime with optional JSON semantic config — ABI-checked, smoke-parsed, plugged into the same registry as built-ins. Off by default (`SET sitting_duck_enable_runtime_grammars = true`), and the library path honors `allowed_directories` before dlopen.
- **`ast_to_blocks`**: render code structure as duck_blocks documents (definitions → headings, bodies → code blocks) with style/tuning parameters — composes with duck_block_utils for TOCs and terminal rendering.
- **`ast_patch` / `ast_replace`**: AST-anchored source patching and CSS-selector-driven rewriting in SQL, with loud errors on overlapping/stale/out-of-range edits.

Full notes: https://github.com/teaguesterling/sitting_duck/releases/tag/v1.10.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B32kWhs96dz7VnR9dYYAJy