### PR TITLE
Bump anofox_statistics to v0.7.3

### DIFF
--- a/extensions/anofox_statistics/description.yml
+++ b/extensions/anofox_statistics/description.yml
@@ -9,4 +9,4 @@ extension:
   requires_toolchains: rust
 repo:
   github: DataZooDE/anofox-statistics
-  ref: 33a9eca4d8e7ff9638370470c5ee993e338b5669
+  ref: 6521cd9ec146456407f607af204555ece8011dd8


### PR DESCRIPTION
Bumps `anofox_statistics` to `v0.7.3`, built against **DuckDB v1.5.5** (stable) while retaining the **v1.4 LTS** build.

Source: [`DataZooDE/anofox-statistics@6521cd9ec1`](https://github.com/DataZooDE/anofox-statistics/releases/tag/v0.7.3) (release v0.7.3).
Previous ref: `33a9eca4d8`.