### PR TITLE
duck_block_utils: 1.3.0 (terminal rendering + DuckDB v1.5.5)

### DIFF
--- a/extensions/duck_block_utils/description.yml
+++ b/extensions/duck_block_utils/description.yml
@@ -143,6 +143,32 @@ docs:
     | `pandoc_inlines_to_db_inlines(json)` | Parse Pandoc inline AST |
     | `db_inlines_to_pandoc(blocks)` | Convert to Pandoc inline AST |
 
+    ## Terminal Rendering
+
+    Render documents — or any query result — as styled ANSI terminal output
+    (`PRAGMA duck_block_render`), and compose pages that embed live query
+    results:
+
+    ```sql
+    PRAGMA duck_block_render;
+
+    -- Any query as a pretty ANSI table
+    SELECT rendered FROM db_render_query('SELECT * FROM my_table LIMIT 10');
+
+    -- A page that embeds live query results as rendered tables
+    SELECT db_render_blocks(db_page('Sales Report', [
+        db_paragraph('Top rows:'),
+        db_query_table('SELECT * FROM t ORDER BY id')
+    ]));
+    ```
+
+    | Function | Description |
+    |----------|-------------|
+    | `db_blocks_render_ansi(blocks[, width])` | Width-aware ANSI document renderer |
+    | `db_render_query(sql)` | Render a query's results as an ANSI table |
+    | `db_page(title, blocks)` | Assemble a titled page from block-lists |
+    | `db_query_table(sql)` / `db_table(json)` | Query/JSON results as an embeddable table block |
+
     ## Ecosystem Integration
 
     Duck Block Utils works seamlessly with other DuckDB document extensions:

--- a/extensions/duck_block_utils/description.yml
+++ b/extensions/duck_block_utils/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duck_block_utils
   description: Build, transform, validate, and extract content from structured documents using the duck_block type
-  version: 1.2.1
+  version: 1.3.0
   language: C++
   build: cmake
   license: MIT
@@ -9,8 +9,11 @@ extension:
     - teaguesterling
 repo:
   github: teaguesterling/duckdb_duck_block_utils
+  # andium (DuckDB v1.4.5 track) intentionally left at the v1.2.1 commit:
+  # v1.3.0 retargets to a DuckDB v1.5.5 tree (dropped v1.4.x support) and is not
+  # built-verified against v1.4.5. v1.4.5 users should move to the v1.5.x track.
   andium: 125662df9e5450105dc9b7957ad955cb53d7beec
-  ref: 125662df9e5450105dc9b7957ad955cb53d7beec
+  ref: refs/tags/v1.3.0
 docs:
   hello_world: |
     -- Build a document programmatically


### PR DESCRIPTION
Bumps `duck_block_utils` to **1.3.0**, `ref: refs/tags/v1.3.0`.

## What's new
- **ANSI terminal rendering** — `PRAGMA duck_block_render`, width-aware C++ `db_blocks_render_ansi`, and `db_render_blocks` / `db_render_block` / `db_render_query`.
- **Page composition macros** — `db_table`, `db_query_table` (embed query results), `db_page`.
- **Pandoc-AST** recursion-depth cap + fidelity improvements.
- **Retargeted** the stable build to the **DuckDB v1.5.5** release tag (v1.5-variegata line).

Upstream CI is green across Linux amd64/arm64, macOS amd64/arm64, and all Wasm legs; full test suite passes (538 assertions).

## andium (v1.4.5 track)
Intentionally left at the v1.2.1 commit: v1.3.0 is a DuckDB v1.5.5 tree that dropped v1.4.x support and is not built-verified against v1.4.5 — same pattern as `func_apply`. v1.4.5 users stay on the existing track; v1.5.x users get 1.3.0 via `ref`.