### PR TITLE
sitting_duck: license MIT -> Apache-2.0

### DIFF
--- a/extensions/sitting_duck/description.yml
+++ b/extensions/sitting_duck/description.yml
@@ -4,7 +4,7 @@ extension:
   version: 1.9.0
   language: C++
   build: cmake
-  license: MIT
+  license: Apache-2.0
   maintainers:
     - teaguesterling
 repo:


### PR DESCRIPTION
sitting_duck adopted **Apache-2.0** upstream ([teaguesterling/sitting_duck](https://github.com/teaguesterling/sitting_duck)) — a patent + trademark grant appropriate for a Tree-sitter code-analysis engine, and it now ships a `THIRD_PARTY_LICENSES` file covering the 27 bundled grammars (all MIT/Apache-2.0). This updates the registry `license:` metadata to match.

Descriptor-only; source/ref unchanged.