### PR TITLE
Bump anofox_scenario to v2026.07.24

### DIFF
--- a/extensions/anofox_scenario/description.yml
+++ b/extensions/anofox_scenario/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: DataZooDE/anofox-scenario
-  ref: 484a9ce530cd61d7f9fd562543b46055bfc48d83
+  ref: ef43c760b1ea297d21b14b693044d29828a07ab6
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps `anofox_scenario` to [v2026.07.24](https://github.com/DataZooDE/anofox-scenario/releases/tag/v2026.07.24) (`ef43c76`).

The only change since the currently pinned `484a9ce` is the DuckDB submodule and CI target moving from v1.5.4 to v1.5.5, matching the sibling bumps in #2314-#2320.

Verified locally against a v1.5.5 build: full suite passes (1149 assertions, 27 test cases), and the `hello_world` example in `description.yml` runs as documented.