### PR TITLE
Add motorsport_telemetry extension

### DIFF
--- a/extensions/motorsport_telemetry/description.yml
+++ b/extensions/motorsport_telemetry/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: motorsport_telemetry
   description: Query Cosworth PDS, MoTeC LD, and Racelogic VBOX telemetry directly in DuckDB
-  version: 0.6.0
+  version: 0.6.1
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: tobi/duckdb_motorsport_telemetry
-  ref: b0a16ce6f79af7672a031524132414b848de8ff8
+  ref: 8cc06a597e33e7558be759cbffa44f2a2e1baa49
 
 docs:
   hello_world: |

--- a/extensions/motorsport_telemetry/description.yml
+++ b/extensions/motorsport_telemetry/description.yml
@@ -1,0 +1,34 @@
+extension:
+  name: motorsport_telemetry
+  description: Query Cosworth PDS, MoTeC LD, and Racelogic VBOX telemetry directly in DuckDB
+  version: 0.6.0
+  language: Rust
+  build: cargo
+  license: MIT
+  requires_toolchains: "rust;python3"
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;linux_amd64_musl;linux_arm64_musl;windows_amd64_mingw;windows_amd64_rtools"
+  maintainers:
+    - tobi
+
+repo:
+  github: tobi/duckdb_motorsport_telemetry
+  ref: b0a16ce6f79af7672a031524132414b848de8ff8
+
+docs:
+  hello_world: |
+    SELECT name, unit, frequency_hz, sample_count
+    FROM telemetry_metadata('run.ld')
+    WHERE sample_count > 0;
+
+    SELECT *
+    FROM read_telemetry('run.ld',
+      rate := 100,
+      channels := 'Ground Speed,Throttle Pos,Brake Pedal Pos');
+  extended_description: |
+    `motorsport_telemetry` reads Pi Research/Cosworth PDS, MoTeC i2 LD, and
+    Racelogic VBOX VBO telemetry without an export step. It provides exact
+    channel metadata, native-rate long-form samples, and projected wide readers
+    with time/channel pruning and type-aware interpolation. Integer and event
+    channels always use previous-value semantics; only floating-point channels
+    can interpolate linearly. The parsers memory-map native files and table
+    functions produce vectorized DuckDB output.


### PR DESCRIPTION
Adds `motorsport_telemetry`, a Rust extension that queries motorsport data-logger files directly in DuckDB:

- Pi Research / Cosworth **PDS** (`.pds`)
- MoTeC i2 **LD** (`.ld`)
- Racelogic VBOX **VBO** (`.vbo`)

The model is two relations per file — channel metadata and native-rate samples — plus an interpolated wide reader. Files are memory-mapped, values decode straight into DuckDB vectors, scans are parallel, and projection pushdown skips channels a query does not touch. Integer and event channels always use previous-value semantics; only floating-point channels interpolate linearly.

```sql
SELECT name, unit, frequency_hz, sample_count
FROM telemetry_metadata('run.ld')
WHERE sample_count > 0;

SELECT *
FROM read_telemetry('run.ld',
  rate := 100,
  channels := 'Ground Speed,Throttle Pos,Brake Pedal Pos');
```

Notes for reviewers:

- Uses only the stable public C extension API; built with `extension-ci-tools` (`make configure/release/test_release`).
- Repository CI builds through the Community Extension toolchain against DuckDB 1.5.4 and runs parser, integration, and registration tests on Linux, macOS, and Windows.
- All test fixtures are generated at runtime, so no telemetry data is shipped.
- `excluded_platforms` skips DuckDB-Wasm, musl, MinGW, and RTools for the initial submission; a separate WASM build is published from the project's own repository.
- Pinned ref `b0a16ce6f79af7672a031524132414b848de8ff8` is tag `v0.6.0`.

Source: https://github.com/tobi/duckdb_motorsport_telemetry