### PR TITLE
duck_block_utils: 1.4.0 (format-agnostic renderer)

### DIFF
--- a/extensions/duck_block_utils/description.yml
+++ b/extensions/duck_block_utils/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duck_block_utils
   description: Build, transform, validate, and extract content from structured documents using the duck_block type
-  version: 1.2.1
+  version: 1.4.0
   language: C++
   build: cmake
   license: MIT
@@ -9,8 +9,11 @@ extension:
     - teaguesterling
 repo:
   github: teaguesterling/duckdb_duck_block_utils
+  # andium (DuckDB v1.4.5 track) intentionally left at the v1.2.1 commit:
+  # v1.4.0 targets a v1.5.x tree (dropped v1.4.x support) and is not built-verified
+  # against v1.4.5. v1.4.5 users should move to the v1.5.x track.
   andium: 125662df9e5450105dc9b7957ad955cb53d7beec
-  ref: 125662df9e5450105dc9b7957ad955cb53d7beec
+  ref: refs/tags/v1.4.0
 docs:
   hello_world: |
     -- Build a document programmatically


### PR DESCRIPTION
Bumps `duck_block_utils` to **1.4.0**, `ref: refs/tags/v1.4.0`.

## What's new
The ANSI renderer is now **format-agnostic**: it styles structured `kind='inline'` elements (bold/italic/code/link) by element_type and treats `content` as literal text, instead of re-parsing Markdown syntax out of `content`. This restores duck_blocks spec conformance (rich text is structural; `content` is literal per `encoding`).

Pairs with `duckdb_markdown` 1.5.1, whose `read_markdown_blocks` / `parse_markdown_to_duck_blocks` now emit structured inlines.

## andium (v1.4.5 track)
Intentionally left at the v1.2.1 commit — v1.4.0 targets a v1.5.x tree (dropped v1.4.x) and isn't built-verified against v1.4.5.