### PR TITLE
webbed: 2.6.1 (structured nested inlines)

### DIFF
--- a/extensions/webbed/description.yml
+++ b/extensions/webbed/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: webbed
   description: Comprehensive processing extension for web markup languages (XML and HTML) with SAX streaming for large files, intelligent schema inference, XPath-based data extraction, and HTML table parsing.
-  version: 2.6.0
+  version: 2.6.1
   language: C++
   build: cmake
   license: MIT
@@ -15,7 +15,9 @@ extension:
 repo:
   github: teaguesterling/duckdb_webbed
   andium: ddda30f11352138b2451657419640370d1612137
-  ref: a8c75aa6853069436a25c71d05bff3ab66f5e1e7
+  # andium (DuckDB v1.4.5 track) left at its prior commit; the v2.6.1
+  # structured-inline fix ships on the v1.5.x track via ref.
+  ref: refs/tags/v2.6.1
 docs:
   docs_url: https://duckdb-webbed.readthedocs.io
   hello_world: |


### PR DESCRIPTION
Bumps `webbed` to **2.6.1**, `ref: refs/tags/v2.6.1`.

`html_to_duck_blocks` now preserves **nested inline formatting** (was flattened — `<b>x <i>y</i></b>` dropped the inner `<i>`), emits **NULL** for empty container content, and uses the shared level convention (top-level block 1 / inline 2 / nested+1). Aligns webbed's structured duck_blocks output with `duckdb_markdown` and `duck_block_utils`.

andium (v1.4.5 track) left at its prior commit; fix ships on the v1.5.x track via `ref`.