### PR TITLE
Update firebird extension to v1.0.1

### DIFF
--- a/extensions/firebird/description.yml
+++ b/extensions/firebird/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: firebird
   description: Federated read-only access to Firebird (3.0/4.0/5.0) databases from DuckDB, with projection + filter pushdown, INT128 / DECIMAL(38) / TIMESTAMP_TZ support, native ATTACH, and CHARACTER SET NONE handling (default win1252; strict / iso8859_1 / blob also available) with filter-pushdown correctness on transcoded columns.
-  version: 0.6.1
+  version: 1.0.1
   language: C++
   build: cmake
   license: MIT
@@ -21,7 +21,7 @@ extension:
 
 repo:
   github: flozer/duckdb-firebird
-  ref: v0.6.1
+  ref: v1.0.1
 
 docs:
   hello_world: |
@@ -166,4 +166,4 @@ docs:
     - Firebird 3.0 (apt `firebird3.0-server`, CI fixture)
     - Firebird 4.0.x (`firebirdsql/firebird:4-noble`)
     - Firebird 5.0.4 (Windows local + `firebirdsql/firebird:5-noble`)
-    - DuckDB v1.5.3 (`StorageExtension::Register` API)
+    - DuckDB v1.5.3 - v1.5.5 (`StorageExtension::Register` API)


### PR DESCRIPTION
Atualiza firebird para v1.0.1.

- Release upstream: https://github.com/flozer/duckdb-firebird/releases/tag/v1.0.1
- Compatibilidade validada no repo upstream contra DuckDB v1.5.5.
- CI upstream verde.
- Sem mudança em outras extensões.