### PR TITLE
Bump docs generation to DuckDB v1.5.5

### DIFF
--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Set up DuckDB
       run: |
-        wget https://github.com/duckdb/duckdb/releases/download/v1.5.4/duckdb_cli-linux-amd64.zip
+        wget https://github.com/duckdb/duckdb/releases/download/v1.5.5/duckdb_cli-linux-amd64.zip
         unzip duckdb_cli-linux-amd64.zip
         chmod +x duckdb
 


### PR DESCRIPTION
Small housekeeping bump: `generate_docs.yml` still fetches the v1.5.4 CLI, which installs extensions from the `v1.5.4` CDN directory. Extensions published since the v1.5.5 release only have binaries under `v1.5.5`, so the scheduled docs runs currently skip them — e.g. columnar, gpudb, and prometheus don't get pages generated yet.

This mirrors the previous version bumps and simply brings the pinned CLI in line with the current release. Thanks for maintaining this infra — and of course feel free to fold this into a broader bump if one is already planned.
