### PR TITLE
Bump cache_prewarm to 0.2.5

### DIFF
--- a/extensions/cache_prewarm/description.yml
+++ b/extensions/cache_prewarm/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: cache_prewarm
   description: Prewarm data blocks into DuckDB's buffer pool or OS page cache for faster queries
-  version: 0.2.4
+  version: 0.2.5
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
     - dentiny
 repo:
   github: dentiny/duckdb-cache-prewarm
-  ref: d0d3601114111aea604121b88dffed281fcd23e5
+  ref: 58444ddbe81c75e59cde0027b31a9ac655118df5
 docs:
   hello_world: |
     -- Prewarm a table into the buffer pool


### PR DESCRIPTION
## Summary

- bump `cache_prewarm` from `0.2.4` to `0.2.5`
- pin the extension to the DuckDB 1.5.5 upgrade merge commit

Release: https://github.com/dentiny/duckdb-cache-prewarm/releases/tag/v0.2.5

## Validation

- parsed `extensions/cache_prewarm/description.yml` as YAML
- verified the version and repository ref values
- `git diff --check`
