### PR TITLE
Add petgraph_ext: Graph algorithms for DuckDB

### DIFF
--- a/extensions/petgraph_ext/description.yml
+++ b/extensions/petgraph_ext/description.yml
@@ -5,7 +5,7 @@ extension:
   language: Rust
   build: cargo
   license: MIT
-  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;linux_amd64_musl;windows_amd64_rtools;windows_amd64_mingw"
+  excluded_platforms: "linux_arm64;wasm_mvp;wasm_eh;wasm_threads;linux_amd64_musl;windows_amd64_rtools;windows_amd64_mingw"
   requires_toolchains: "rust;python3"
   maintainers:
     - alitrack

--- a/extensions/petgraph_ext/description.yml
+++ b/extensions/petgraph_ext/description.yml
@@ -1,0 +1,21 @@
+extension:
+  name: petgraph_ext
+  description: "Graph algorithms for DuckDB — PageRank, shortest path, SCC, MST, and more via petgraph"
+  version: 0.5.0
+  language: Rust
+  build: cargo
+  license: MIT
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;linux_amd64_musl;windows_amd64_rtools;windows_amd64_mingw"
+  requires_toolchains: "rust;python3"
+  maintainers:
+    - alitrack
+repo:
+  github: alitrack/duckdb_petgraph
+  ref: 1f74c220f43fbee437604944c1def299764f0e44
+docs:
+  hello_world: |
+    LOAD petgraph_ext;
+    SELECT * FROM petgraph_shortest_path('[(0,1,1.0),(1,2,1.0)]', 0, 2);
+  extended_description: |
+    17 algorithms: PageRank, betweenness/closeness/eigenvector centrality,
+    SCC, MST, shortest path, connected components, Louvain, toposort.


### PR DESCRIPTION
## petgraph_ext — Graph algorithms powered by petgraph

- Repo: alitrack/duckdb_petgraph (v0.5.0)
- 17 functions: PageRank, Betweenness centrality, SCC, MST, shortest path, Louvain, and more
- Named graph cache for zero-reparse repeated queries
- Platforms: Linux x64, macOS arm64/x64
- Excluded: WASM, Windows MinGW/Rtools, linux_musl
- CI: extension-ci-tools @v1.5-variegata, SQLLogicTest suite