### PR TITLE
Add python_udf: Embedded CPython UDFs for DuckDB

### DIFF
--- a/extensions/python_udf/description.yml
+++ b/extensions/python_udf/description.yml
@@ -8,7 +8,7 @@ extension:
   requires_toolchains: "rust;python3"
   maintainers:
     - alitrack
-  excluded_platforms: "wasm_eh;wasm_mvp;wasm_threads;windows_amd64"
+  excluded_platforms: "linux_arm64;wasm_eh;wasm_mvp;wasm_threads;windows_amd64"
 repo:
   github: alitrack/duckdb-python
   ref: 83c9dbb96101c37a860de013ed9619cb15d02116

--- a/extensions/python_udf/description.yml
+++ b/extensions/python_udf/description.yml
@@ -8,7 +8,7 @@ extension:
   requires_toolchains: "rust;python3"
   maintainers:
     - alitrack
-  excluded_platforms: "linux_arm64;wasm_eh;wasm_mvp;wasm_threads;windows_amd64_mingw;windows_amd64"
+  excluded_platforms: "wasm_eh;wasm_mvp;wasm_threads;windows_amd64_mingw;windows_amd64_rtools"
 repo:
   github: alitrack/duckdb-python
   ref: e51470893752257417ed395e5dfe227f9ee93233

--- a/extensions/python_udf/description.yml
+++ b/extensions/python_udf/description.yml
@@ -8,7 +8,7 @@ extension:
   requires_toolchains: "rust;python3"
   maintainers:
     - alitrack
-  excluded_platforms: "wasm_eh;wasm_mvp;wasm_threads;windows_amd64_mingw;windows_amd64_rtools"
+  excluded_platforms: "wasm_eh;wasm_mvp;wasm_threads;windows_amd64;windows_amd64_mingw;windows_amd64_rtools"
 repo:
   github: alitrack/duckdb-python
   ref: e51470893752257417ed395e5dfe227f9ee93233

--- a/extensions/python_udf/description.yml
+++ b/extensions/python_udf/description.yml
@@ -8,7 +8,7 @@ extension:
   requires_toolchains: "rust;python3"
   maintainers:
     - alitrack
-  excluded_platforms: "linux_arm64;wasm_eh;wasm_mvp;wasm_threads;windows_amd64"
+  excluded_platforms: "linux_arm64;wasm_eh;wasm_mvp;wasm_threads;windows_amd64_mingw;windows_amd64"
 repo:
   github: alitrack/duckdb-python
   ref: e51470893752257417ed395e5dfe227f9ee93233
@@ -20,4 +20,4 @@ docs:
     SELECT py_call('double_it', '21');
   extended_description: |
     CPython UDFs via PyO3: py_eval, py_agg, py_scan, py_register, py_call,
-    py_map, py_list. Python 3.11/3.12/3.13. Linux x64/arm64, macOS.
+    py_map, py_list. Python 3.12. Linux x64, macOS x64/arm64.

--- a/extensions/python_udf/description.yml
+++ b/extensions/python_udf/description.yml
@@ -1,0 +1,23 @@
+extension:
+  name: python_udf
+  description: "Embedded CPython UDFs — py_eval, py_agg, py_scan, py_register, py_call, py_map, py_list"
+  version: 0.2.0
+  language: Rust
+  build: cargo
+  license: MIT
+  requires_toolchains: "rust;python3"
+  maintainers:
+    - alitrack
+  excluded_platforms: "wasm_eh;wasm_mvp;wasm_threads;windows_amd64"
+repo:
+  github: alitrack/duckdb-python
+  ref: 83c9dbb96101c37a860de013ed9619cb15d02116
+docs:
+  hello_world: |
+    LOAD python_udf;
+    SELECT py_eval('x.upper()', 'hello');
+    SELECT py_register('double_it', 'str(int(x)*2)', 1);
+    SELECT py_call('double_it', '21');
+  extended_description: |
+    CPython UDFs via PyO3: py_eval, py_agg, py_scan, py_register, py_call,
+    py_map, py_list. Python 3.11/3.12/3.13. Linux x64/arm64, macOS.

--- a/extensions/python_udf/description.yml
+++ b/extensions/python_udf/description.yml
@@ -11,7 +11,7 @@ extension:
   excluded_platforms: "linux_arm64;wasm_eh;wasm_mvp;wasm_threads;windows_amd64"
 repo:
   github: alitrack/duckdb-python
-  ref: 83c9dbb96101c37a860de013ed9619cb15d02116
+  ref: e51470893752257417ed395e5dfe227f9ee93233
 docs:
   hello_world: |
     LOAD python_udf;


### PR DESCRIPTION
## python_udf — CPython UDFs embedded in DuckDB

- Repo: alitrack/duckdb-python (v0.2.0)
- 7 functions: py_eval, py_agg, py_scan, py_register, py_call, py_map, py_list
- CPython via PyO3 (Rust FFI), supports Python 3.11/3.12/3.13
- Scalar, aggregate, and table function UDFs
- Platforms: Linux x64, macOS arm64/x64
- Excluded: linux_arm64, WASM, Windows
- CI: extension-ci-tools @v1.5-variegata, multi-platform smoke + Docker embed