### PR TITLE
agent_data: update to 0.3.0 (DuckDB v1.5.5, adds Cursor support)

### DIFF
--- a/extensions/agent_data/description.yml
+++ b/extensions/agent_data/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: axsaucedo/agent_data_duckdb
-  ref: 1b9b232056763204c12046beacd5c99a6672442e
+  ref: 134e48d47d5a901bc923f258ad1cd29b82d3a2ff
 
 docs:
   hello_world: |

--- a/extensions/agent_data/description.yml
+++ b/extensions/agent_data/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: agent_data
   description: A DuckDB extension written in Rust for querying, analysing and inspecting AI coding agents history. Read conversations, plans, todos, history, and usage stats directly from your local agent data directories.
-  version: 0.2.0
+  version: 0.3.0
   language: Rust
   build: cargo
   license: MIT


### PR DESCRIPTION
## What's new in 0.3.0

I'm excited about this release, as we are adding support for a third agent: **Cursor**! 🎉

- New `source='cursor'` provider: query your Cursor sessions with `read_conversations(path='~/.cursor')`, including token usage stats
- Windows mingw builds are enabled again (`windows_amd64_mingw` is no longer excluded)

## Summary

- bumps `extensions/agent_data/description.yml` `repo.ref` to `134e48d47d5a901bc923f258ad1cd29b82d3a2ff` and `version` to `0.3.0`
- targets DuckDB `v1.5.5`, `duckdb`/`libduckdb-sys` crate `1.10505.0`, and `extension-ci-tools` `v1.5-variegata`
- restores latest-stable community binaries so `agent_data` is installable again via `INSTALL agent_data FROM community`

## Validation in source repo

Source PR: https://github.com/axsaucedo/agent_data_duckdb/pull/18

- full release validation against DuckDB v1.5.5, covering the Rust test suite, the example app suite, and smoke queries against the built extension
- all-platform builds green in the source repo's distribution pipeline