### PR TITLE
hex9: update to libhex9 v2.1.0 (deterministic addressing), fix license metadata

### DIFF
--- a/extensions/hex9/description.yml
+++ b/extensions/hex9/description.yml
@@ -1,16 +1,16 @@
 extension:
   name: hex9
   description: Hex9 hierarchical hexagonal DGGS — point encoding, layer binning, cell geometry as WKB, labels, k-rings, Hamiltonian-curve ordering, and grid enumeration
-  version: 2.0.0
+  version: 2.1.0
   language: C++
   build: cmake
-  license: GPL-2.0-or-later
+  license: Apache-2.0
   maintainers:
     - MrBenGriffin
 
 repo:
   github: MrBenGriffin/duckdb-hex9
-  ref: 12fd29a8de207a5a6d9339b1c8f4e0cd967b2729
+  ref: bf3b954b4d91bc6e2ff834dad494e409e0570ab3
 
 docs:
   hello_world: |
@@ -27,3 +27,6 @@ docs:
     k-rings, labels, Hamiltonian-curve locality ordering with HUGEINT
     indexes) plus table functions (h9_grid, h9_curve_cells, h9_owned_cells).
     Geometry is emitted as WKB, consumed directly by the spatial extension.
+    Since libhex9 2.1.0 the encode chain is deterministic: the same lon/lat
+    yields the bit-identical uuid on every platform, enforced by in-repo
+    universality pin tests.


### PR DESCRIPTION
Updates the hex9 extension to libhex9 **v2.1.0** and corrects the descriptor metadata.

- **ref**: `MrBenGriffin/duckdb-hex9@bf3b954` — libhex9 submodule at v2.1.0. The headline change is a **deterministic encode chain**: the same lon/lat yields the bit-identical cell uuid on every platform (vendored deterministic math kernels + pinned FP contraction). The extension's test suite now includes universality pin tests (`test/sql/h9_universality.test`) asserting frozen full-depth goldens, so each platform build re-proves bit-exact addressing.
- **version**: 2.0.0 → 2.1.0.
- **license**: `GPL-2.0-or-later` → `Apache-2.0` — the previous value was an error on our part; libhex9 and this extension are and have always been Apache-2.0 (LICENSE file now included in the extension repo).

Note: the extension was merged on 2026-07-21 (#2283) but no binaries appear to have been deployed to the CDN (`INSTALL hex9 FROM community` returns 404 for v1.5.4/v1.5.5 at least on osx_arm64/linux_amd64/windows_amd64) and the docs page 404s — if there is a build/deploy log from that window showing hex9 failing, happy to fix whatever it shows on our side.

Built and tested locally against DuckDB v1.5.4 (macOS arm64): all 63 assertions in 5 test files pass, including the new universality pins.