### PR TITLE
mssql: update to v0.2.2 (DuckDB v1.5.5)

### DIFF
--- a/extensions/mssql/description.yml
+++ b/extensions/mssql/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: mssql
   description: "Connect DuckDB to Microsoft SQL Server via native TDS (including TLS)."
-  version: "0.2.1"
+  version: "0.2.2"
   language: "C++"
   build: "cmake"
   licence: "MIT"
@@ -17,7 +17,7 @@ extension:
 
 repo:
   github: "hugr-lab/mssql-extension"
-  ref: "v0.2.1"
+  ref: "v0.2.2"
 
 docs:
   hello_world: |

--- a/extensions/mssql/description.yml
+++ b/extensions/mssql/description.yml
@@ -13,6 +13,9 @@ extension:
     - "wasm_mvp"
     - "wasm_eh"
     - "wasm_threads"
+  # vcpkg tag 2026.06.24 == the builtin-baseline in the extension's vcpkg.json
+  # (default CI vcpkg predates it and cannot resolve the baseline)
+  vcpkg_commit: "52c9e08cdf8580d2d9762f547d22b96fd81e82f2"
   test_config: '{"test_env_variables": {"SKIP_TESTS": "1"}}'
 
 repo:


### PR DESCRIPTION
Updates the **mssql** extension descriptor to **v0.2.2**, built and released against **DuckDB v1.5.5** ([release](https://github.com/hugr-lab/mssql-extension/releases/tag/v0.2.2)).

Highlights since v0.2.1:

- **Concurrency fixes** for parallel scans of attached tables ([hugr-lab/mssql-extension#178](https://github.com/hugr-lab/mssql-extension/issues/178)): metadata-cache mutex consolidation, invalidation epoch guard, safe connection-pool release from result streams, `VOLATILE` stability for side-effecting scalar functions
- Named SQL Server instance resolution via SQL Server Browser (UDP 1434)
- OpenSSL 3.4.1 → 3.5.4 (LTS)
- COPY/BCP fixes (VARCHAR(n) length validation, connection release on client-side COPY failure) and wide VARCHAR/CHAR/TEXT scan truncation fix
- TDS token-parser hardening (fuzzing-discovered OOB/hang fixes)

The v0.2.2 tag passed the extension's full CI: builds for linux_amd64/arm64, osx_arm64, windows_amd64 (MSVC + MinGW), unit + integration + concurrency-stress + Kerberos end-to-end tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)