### PR TITLE
Add luajit: JIT-compiled Lua UDFs for DuckDB

### DIFF
--- a/extensions/luajit/description.yml
+++ b/extensions/luajit/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: luajit
-  description: "In-process LuaJIT UDFs for DuckDB — 12 functions, JIT-compiled, GROUP BY, batch mode @1.0x native speed"
-  version: 1.0.0
+  description: "In-process LuaJIT UDFs for DuckDB — 12 functions, JIT-compiled, GROUP BY, batch mode ~3.6x native (single-thread)"
+  version: 0.17
   language: C
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: alitrack/duckdb-luajit
-  ref: refs/tags/v1.0.0
+  ref: refs/tags/v0.17
 
 docs:
   hello_world: |
@@ -30,11 +30,12 @@ docs:
     ## luajit — JIT-compiled Lua UDFs for DuckDB
 
     Write and run Lua functions directly in SQL. LuaJIT compiles them to native machine code
-    with trace-based JIT, achieving **near-native performance** (1.0× native SQL in batch mode).
+    with trace-based JIT, **near-native performance** (batch mode ~3.6× native SQL single-threaded,
+    ~2500× faster than Python UDF).
 
     **12 Functions:**
     - `luajit_i` / `luajit_f` / `luajit_b` — typed scalar UDFs (BIGINT, DOUBLE, BOOLEAN)
-    - `luajit_v` — **chunk-batched scalar** (1 Lua call per chunk, 1.0× native speed)
+    - `luajit_v` — **chunk-batched scalar** (1 Lua call per chunk, ~3.6× native single-thread)
     - `luajit_m` — mixed-type auto-cast
     - `luajit_l` / `luajit_s` / `luajit_map` — LIST/STRUCT/MAP type bridges
     - `luajit_agg` — aggregate UDFs with GROUP BY support
@@ -49,10 +50,11 @@ docs:
     - Lua→DuckDB callback (`_duckdb_call`) for SQL execution from Lua
     - LIST, STRUCT, MAP type bridges between DuckDB and Lua
 
-    **Performance (50K rows):**
-    - `luajit_v` (batch): 3.8ms (1.0× native SQL)
-    - `luajit_f` (row-by-row): 6.2ms (1.7× native)
-    - Python UDF: ~9400ms (~2500× native)
+    **Performance (500K rows, single-threaded):**
+    - `luajit_v` (batch): 4.9ms (~3.6× native SQL)
+    - `luajit_i` (row-by-row): 24.3ms (~18× native)
+    - Python UDF: >160s (~200,000× native)
+    - Note: shared Lua state serializes under parallel execution; single-thread only
 
     **Design:**
     - LuaJIT 2.1 self-contained (~700KB binary)
@@ -60,5 +62,5 @@ docs:
     - MIT licensed
     - ~1050 lines of C
 
-    **Platforms:** Linux x64/arm64, macOS x64/arm64. Windows and WASM excluded 
+    **Platforms:** Linux x64/arm64, macOS x64/arm64, Windows (MSVC). WASM excluded
     (LuaJIT requires GNU Make + GCC).

--- a/extensions/luajit/description.yml
+++ b/extensions/luajit/description.yml
@@ -1,0 +1,64 @@
+extension:
+  name: luajit
+  description: "In-process LuaJIT UDFs for DuckDB — 12 functions, JIT-compiled, GROUP BY, batch mode @1.0x native speed"
+  version: 1.0.0
+  language: C
+  build: cmake
+  license: MIT
+  maintainers:
+    - alitrack
+  excluded_platforms: "linux_arm64;wasm_eh;wasm_mvp;wasm_threads;windows_amd64_mingw;windows_amd64_rtools"
+
+repo:
+  github: alitrack/duckdb-luajit
+  ref: refs/tags/v1.0.0
+
+docs:
+  hello_world: |
+    -- Load and compile a UDF in one shot
+    LOAD luajit;
+    SELECT message FROM luajit_module(
+        mode := 'quick_compile',
+        source := 'return function(x) return x * 2 + 1 end',
+        sql_name := 'x2p1'
+    );
+    -- Use it immediately (auto-macro generated)
+    SELECT x2p1(5);
+    -- → 11
+
+  extended_description: |
+    ## luajit — JIT-compiled Lua UDFs for DuckDB
+
+    Write and run Lua functions directly in SQL. LuaJIT compiles them to native machine code
+    with trace-based JIT, achieving **near-native performance** (1.0× native SQL in batch mode).
+
+    **12 Functions:**
+    - `luajit_i` / `luajit_f` / `luajit_b` — typed scalar UDFs (BIGINT, DOUBLE, BOOLEAN)
+    - `luajit_v` — **chunk-batched scalar** (1 Lua call per chunk, 1.0× native speed)
+    - `luajit_m` — mixed-type auto-cast
+    - `luajit_l` / `luajit_s` / `luajit_map` — LIST/STRUCT/MAP type bridges
+    - `luajit_agg` — aggregate UDFs with GROUP BY support
+    - `luajit_table` — table-generating UDFs
+    - `luajit_module` — module management (10 modes)
+
+    **Features:**
+    - Compile + auto-type + auto-macro in one call (`quick_compile`)
+    - Aggregate UDFs receive FULL value table, enabling median, stddev, percentile, etc.
+    - GROUP BY support with per-group Lua invocation
+    - File-based persistence (`save`/`load`) with auto-restore on `LOAD`
+    - Lua→DuckDB callback (`_duckdb_call`) for SQL execution from Lua
+    - LIST, STRUCT, MAP type bridges between DuckDB and Lua
+
+    **Performance (50K rows):**
+    - `luajit_v` (batch): 3.8ms (1.0× native SQL)
+    - `luajit_f` (row-by-row): 6.2ms (1.7× native)
+    - Python UDF: ~9400ms (~2500× native)
+
+    **Design:**
+    - LuaJIT 2.1 self-contained (~700KB binary)
+    - Zero external dependencies at runtime
+    - MIT licensed
+    - ~1050 lines of C
+
+    **Platforms:** Linux x64/arm64, macOS x64/arm64. Windows and WASM excluded 
+    (LuaJIT requires GNU Make + GCC).


### PR DESCRIPTION
## luajit — LuaJIT UDFs for DuckDB

In-process LuaJIT 2.1 embedded in DuckDB. JIT-compiled native code, batch mode, GROUP BY.

**12 functions:** luajit_i, luajit_f, luajit_b, luajit_v, luajit_m, luajit_l, luajit_s, luajit_map, luajit_agg, luajit_table, luajit_module

**Platforms:** Linux x64/arm64, macOS x64/arm64

- **CI passing:** [Main Distribution Pipeline](https://github.com/alitrack/duckdb-luajit/actions) ✅
- **Repo:** https://github.com/alitrack/duckdb-luajit
- **Tag:** v1.0.0