### PR TITLE
urlpattern: 0.4.1 (DuckDB v1.5.x compatibility)

### DIFF
--- a/extensions/urlpattern/description.yml
+++ b/extensions/urlpattern/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: urlpattern
   description: WHATWG URLPattern API for matching and extracting components from URLs using pattern syntax
-  version: 0.4.0
+  version: 0.4.1
   language: C++
   build: cmake
   license: MIT
@@ -13,7 +13,9 @@ extension:
 repo:
   github: teaguesterling/duckdb_urlpattern
   andium: bc9864b9fad37bffe15f7499fc5b9021e970eaf8
-  ref: bc9864b9fad37bffe15f7499fc5b9021e970eaf8
+  # andium (DuckDB v1.4.5 track) left at the pre-v1.5-variegata commit;
+  # v0.4.1 targets the v1.5.x line and ships on that track via ref.
+  ref: refs/tags/v0.4.1
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps `urlpattern` to **0.4.1**, `ref: refs/tags/v0.4.1`.

The current listing pins a pre-compatibility commit (0.4.0) that builds for DuckDB v1.5.4 but **404s for v1.5.5**. v0.4.1 includes the `BaseExpression::GetAlias()` accessor fix and v1.5-variegata bump, so the community build produces v1.5.5 artifacts. Test suite green (162 assertions).

andium (v1.4.5 track) left at the prior commit; the fix ships on the v1.5.x track via `ref`.