### PR TITLE
laterite_ags4: bump to 0.9.0

### DIFF
--- a/extensions/laterite_ags4/description.yml
+++ b/extensions/laterite_ags4/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: laterite_ags4
   description: Read AGS4 geotechnical data files as typed, UUID-keyed tables directly from SQL — born-typed columns, deterministic content-addressed keys that join across groups by construction, and an embedded AGS dictionary. A read-only SQL surface. Local, http(s):// and s3:// (with httpfs).
-  version: 0.7.0
+  version: 0.9.0
   language: Rust
   build: cargo
   license: MIT
@@ -28,7 +28,7 @@ repo:
   github: niko86/laterite-duckdb
   # Pin to the release commit SHA once the repo is pushed + tagged (community-
   # extensions pins a SHA, not a branch). Placeholder until then:
-  ref: 1629610de77beab11ead79be36fac4324138e7e7
+  ref: 01ea351ba30e2ec1dfb75f834be2a07d287d40e8
 
 docs:
   hello_world: |
@@ -83,6 +83,7 @@ docs:
     | `ags_headings(path)` | `(group, heading, unit, ags_type, sql_type, status, is_key, ordinal)` — the per-heading schema, enriched with the dictionary's KEY status. |
     | `ags_dictionary()` | the embedded standard AGS dictionary as a table (`group`, `heading`, `status`, `ags_type`, `unit`, `description`, …). |
     | `ags_relationships()` | `(child, parent, shared_keys)` — the spec parent→child graph that `_parent_id` follows. |
+    | `ags_rules()` | the AGS4 numbered-rule catalogue (`rule`, `title`, `severity`, `fixable`) — the extension *lists* the rules; the CLI/library *run* them. |
     | `load_ags(path)` | `(seq, stmt)` — CREATE-TABLE DDL to materialise every group into an indexed, repeat-/remote-queryable store. |
 
     Readers stream lazily (≈2048-row vector chunks); a non-conforming numeric cell becomes

--- a/extensions/laterite_ags4/docs/function_descriptions.csv
+++ b/extensions/laterite_ags4/docs/function_descriptions.csv
@@ -5,4 +5,6 @@ ags_groups,"List the groups in an AGS4 file with row and heading counts","Return
 ags_headings,"The per-heading schema of an AGS4 file, enriched with dictionary KEY status","Returns (group, heading, unit, ags_type, sql_type, status, is_key, ordinal)","SELECT * FROM ags_headings('site.ags') LIMIT 5;"
 ags_dictionary,"The embedded standard AGS dictionary as a table","Returns (group, heading, status, ags_type, unit, description)","SELECT * FROM ags_dictionary() LIMIT 5;"
 ags_relationships,"The AGS group parent-child (KEY) graph that _parent_id follows","Returns (child, parent, shared_keys)","SELECT * FROM ags_relationships();"
+ags_rules,"The AGS4 numbered-rule catalogue","Returns (rule, title, severity, fixable) — the extension *lists* the rules; the CLI and libraries *run* them","SELECT * FROM ags_rules() WHERE fixable;"
 load_ags,"Emit CREATE-TABLE DDL to materialise every AGS4 group into an indexed, queryable store","Returns (seq, stmt) — run the statements to get keyed tables","SELECT stmt FROM load_ags('site.ags') ORDER BY seq;"
+to_duckdb,"Emit ATTACH/CREATE-TABLE/DETACH DDL to persist every AGS4 group as a standalone .duckdb file","Returns (seq, stmt); the file matches the libraries' to_duckdb() output — keyed by _id/_parent_id","SELECT stmt FROM to_duckdb('site.ags', 'site.duckdb') ORDER BY seq;"


### PR DESCRIPTION
Bumps `laterite_ags4` to **0.9.0**.

This PR was opened for 0.8.0 and has not been merged, so rather than open a
second one it has been re-pointed at 0.9.0 — the branch name still reads
`laterite_ags4-0.8.0`, but the descriptor and the pinned ref are 0.9.0. That
also means this takes the registry **0.7.0 → 0.9.0** directly; 0.8.0 was never
published here.

`ref` is `01ea351ba30e2ec1dfb75f834be2a07d287d40e8` — a tagged release
(`v0.9.0`) of niko86/laterite-duckdb, built and tested in that repo's CI.

## What changed since 0.7.0

Nothing in the extension's SQL surface is removed or renamed. The two breaking
changes in the 0.9.0 engine release are on other surfaces (a browser/wasm API,
and file *emission*); this extension is a read-only reader and takes the engine
core with `default-features = false`, so neither reaches it.

The `docs/function_descriptions.csv` row for `ags_rules()` is included — it
shipped earlier but had never reached the published docs page, which renders
from both files.