### PR TITLE
cog: update to v0.3.0

### DIFF
--- a/extensions/cog/description.yml
+++ b/extensions/cog/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: cog
   description: GDAL-free Cloud-Optimized GeoTIFF (COG) reader — query remote rasters in place over HTTP range reads, with STAC catalog integration
-  version: 0.2.0
+  version: 0.3.0
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: st-layer/duckdb-cog
-  ref: fc5bae773e1a00251d3ed081ee45320023bd1586
+  ref: 5057905a3a74b0f3343de05fe2fabcf0fc0d902b
 
 docs:
   hello_world: |

--- a/extensions/cog/description.yml
+++ b/extensions/cog/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: cog
   description: GDAL-free Cloud-Optimized GeoTIFF (COG) reader — query remote rasters in place over HTTP range reads, with STAC catalog integration
-  version: 0.1.0
+  version: 0.2.0
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: st-layer/duckdb-cog
-  ref: 1d210fd7719ae44fef0ac908f4b3f6386677da52
+  ref: fc5bae773e1a00251d3ed081ee45320023bd1586
 
 docs:
   hello_world: |


### PR DESCRIPTION
Updates the `cog` extension to v0.3.0 (ref `5057905a3a74b0f3343de05fe2fabcf0fc0d902b`, tag [v0.3.0](https://github.com/st-layer/duckdb-cog/releases/tag/v0.3.0)).

Changes since the registered v0.1.0 (v0.2.0 was tagged upstream but never deployed here, so this PR ships both):

**v0.3.0** — driven by production field reports from a parcel-statistics workload:
- Process-wide tile-data cache (decoded tiles, byte-bounded LRU, single-flight; `COG_TILE_CACHE_MB`) — user-measured 526 s → 38.8 s per scene on season-scale zonal workloads
- Batch zonal: `RS_ZonalStats(path, VARCHAR[] wkt, band, stat) → DOUBLE[]` (tile union fetched once per call)
- `cog_cache_stats()` observability table function
- IO runtime sized by CPU count (`COG_IO_THREADS`); `read_stac_search` now errors instead of silently truncating at its default row cap

**v0.2.0**:
- WKT polygon zones (`POLYGON`/`MULTIPOLYGON`, pure-Rust PIP) for `RS_ZonalStats` and `RS_BandAsArray`

All changes are oracle-tested against rasterio in upstream CI; no build-system or dependency changes affecting the CE pipeline.