### PR TITLE
quackapi: 0.1.2 — Windows on tip; pin post-gemini-surface

### DIFF
--- a/extensions/quackapi/description.yml
+++ b/extensions/quackapi/description.yml
@@ -15,7 +15,7 @@ extension:
     FastAPI-class HTTP framework inside DuckDB — CREATE ROUTE turns SQL into
     typed, validated endpoints; one process is DB + HTTP (+ PDF/renderer via
     companion extensions).
-  version: 0.1.1
+  version: 0.1.2
   language: C++
   build: cmake
   license: MIT
@@ -29,7 +29,7 @@ extension:
 repo:
   github: asubbarao/quackapi
   # Pin to the packaging commit SHA (set by release engineer; never a branch).
-  ref: 32600ee3598dd69aecba6c308c476e44e5bcfce6
+  ref: 66536d52cbab6cccb5820730607f22778aed807a
 
 docs:
   hello_world: |

--- a/extensions/quackapi/description.yml
+++ b/extensions/quackapi/description.yml
@@ -29,7 +29,7 @@ extension:
 repo:
   github: asubbarao/quackapi
   # Pin to the packaging commit SHA (set by release engineer; never a branch).
-  ref: 66536d52cbab6cccb5820730607f22778aed807a
+  ref: 4406bb91a8a1285e713ead603b307fd88fdb95b6
 
 docs:
   hello_world: |
@@ -128,9 +128,9 @@ docs:
 
     ## Platforms & build
 
-    Targets **DuckDB v1.5.4**. C++17; depends only on DuckDB-bundled **httplib**
-    and **mbedtls** (no vcpkg, no libcurl). CI excludes wasm and Windows MinGW/rtools/arm64. Signed community
-    binaries for linux/osx are live; windows_amd64 re-opt-in via this descriptor.
+    Targets **DuckDB v1.5.5** only. C++17; depends only on DuckDB-bundled **httplib**
+    and **mbedtls** (no vcpkg, no libcurl). CI builds linux/macOS/windows_amd64;
+    excludes wasm and Windows MinGW/rtools/arm64.
 
     ## Limits (honest)
 

--- a/extensions/quackapi/description.yml
+++ b/extensions/quackapi/description.yml
@@ -29,7 +29,7 @@ extension:
 repo:
   github: asubbarao/quackapi
   # Pin to the packaging commit SHA (set by release engineer; never a branch).
-  ref: 4406bb91a8a1285e713ead603b307fd88fdb95b6
+  ref: 398d42cd41d3fb494420063d60b5aa367343d271
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary

- Bump **quackapi** to **0.1.2**, pin [`asubbarao/quackapi@66536d5`](https://github.com/asubbarao/quackapi/commit/66536d52cbab6cccb5820730607f22778aed807a)
- Includes gemini-surface features (RATE LIMIT, FORMAT parquet/arrow, GraphQL v0, TestClient, …)
- Descriptor already enables **windows_amd64** (excludes wasm/MinGW/rtools only)

## Windows / multi-version honesty

Community CI builds against **latest stable DuckDB only**. After merge:

| Host | Linux | macOS | Windows |
|------|-------|-------|---------|
| latest stable (e.g. v1.5.5) | yes | yes | **yes** |
| older (v1.5.3, …) | not backfilled | same | same |

Users on DuckDB **v1.5.3** must upgrade the host or use GitHub Release assets from asubbarao/quackapi — community CDN will not serve `/v1.5.3/`.

## Test plan

- [ ] Community CI builds quackapi for linux_amd64, linux_arm64, osx_*, windows_amd64
- [ ] `INSTALL quackapi FROM community` on DuckDB latest + Windows loads