### PR TITLE
[mlpack] Update to duckdb 1.5.5

### DIFF
--- a/extensions/mlpack/description.yml
+++ b/extensions/mlpack/description.yml
@@ -13,7 +13,7 @@ extension:
 repo:
   github: eddelbuettel/duckdb-mlpack
   andium: 8437d78423e3cfc65f9226606908b301c2314710
-  ref: eb1c65298476621b2cf088a24e6633e453df66f9
+  ref: ead4698674d803909b1f9c01b083ecc7ea586c3a
 
 docs:
   hello_world: |
@@ -27,7 +27,7 @@ docs:
     CREATE TABLE M (key VARCHAR, json VARCHAR);
 
     -- Train model for 'Y' on 'X' using parameters 'Z', store in 'M'
-    CREATE TEMP TABLE A AS SELECT * FROM mlpack_adaboost("X", "Y", "Z", "M");
+    CREATE TEMP TABLE A AS SELECT * FROM mlpack_adaboost_train("X", "Y", "Z", "M");
 
     -- Count by predicted group
     SELECT COUNT(*) as n, predicted FROM A GROUP BY predicted;


### PR DESCRIPTION
Updating mlpack (and CI) references to 1.5.5, correct one example call in docs, not expecting any issues; builds locally.