### PR TITLE
Add gdrive extension

### DIFF
--- a/extensions/gdrive/description.yml
+++ b/extensions/gdrive/description.yml
@@ -1,7 +1,6 @@
 extension:
   name: gdrive
   description: Query files in Google Drive directly with a gdrive:// filesystem
-  version: 0.1.0
   language: C++
   build: cmake
   license: MIT
@@ -17,7 +16,7 @@ extension:
 
 repo:
   github: DataZooDE/duckdb-gdrive
-  ref: 181b851d5297c5db743b9eaa8f978ae183580ff2
+  ref: c22f108fe83f849c0eb0bc5a271f54f14e1483b7
 
 docs:
   hello_world: |

--- a/extensions/gdrive/description.yml
+++ b/extensions/gdrive/description.yml
@@ -1,0 +1,95 @@
+extension:
+  name: gdrive
+  description: Query files in Google Drive directly with a gdrive:// filesystem
+  version: 0.1.0
+  language: C++
+  build: cmake
+  license: MIT
+  # wasm: the extension is HTTPS calls to the Drive API plus a loopback
+  # redirect server for interactive OAuth. Neither works in a browser sandbox,
+  # and a wasm side-module defers symbol resolution to load time -- so it
+  # would build green in CI and then fail to LOAD. A clean "unavailable" is
+  # better than an unloadable artifact.
+  # mingw: vcpkg's OpenSSL port is fragile there; sibling extensions skip it.
+  excluded_platforms: "windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads"
+  maintainers:
+    - jrosskopf
+
+repo:
+  github: DataZooDE/duckdb-gdrive
+  ref: 181b851d5297c5db743b9eaa8f978ae183580ff2
+
+docs:
+  hello_world: |
+    -- Unattended: a service account. To WRITE you need a Shared Drive --
+    -- service accounts have no personal Drive storage quota and get
+    -- 403 storageQuotaExceeded anywhere else. Reading a shared folder is fine.
+    --
+    -- DRIVE_ID is a SHARED DRIVE id; ROOT_FOLDER_ID is a FOLDER id. They are
+    -- not interchangeable: passing a folder id as DRIVE_ID fails with
+    -- "Shared drive not found". Use whichever matches what was shared.
+    CREATE SECRET gdrive (
+        TYPE gdrive,
+        PROVIDER service_account,
+        KEY_FILE '/etc/creds/sa.json',
+        DRIVE_ID '0ABcDeFgHiJkLmNoPQ',       -- or ROOT_FOLDER_ID '1a2b3c...'
+        DRIVE_SCOPE 'https://www.googleapis.com/auth/drive.readonly'
+    );
+
+    -- Query a file by path. Drive has no path addressing, so each segment
+    -- costs a lookup; results are cached per secret.
+    SELECT count(*) FROM 'gdrive://Finance/2026/actuals.parquet';
+
+    -- Address a file by id instead: zero resolution calls. Prefer this in
+    -- generated or stored queries.
+    SELECT * FROM read_csv('gdrive://id:1a2b3cDeFgHiJkLmNoPQrStUvWxYz');
+
+    -- Glob a folder.
+    SELECT * FROM read_parquet('gdrive://exports/parts/*.parquet');
+
+    -- A native Google Sheet is queryable with no manual export: it has no
+    -- byte stream, so it is served through Drive's CSV export.
+    SELECT * FROM read_csv('gdrive://Finance/Budget');
+
+    -- Write a whole file. Writes are sequential; Drive cannot write at a
+    -- byte offset, so positional writes raise an error rather than corrupt.
+    COPY (SELECT * FROM t) TO 'gdrive://reports/out.parquet' (FORMAT parquet);
+
+    -- Inspect API calls and cache hits for the session.
+    SELECT * FROM gdrive_stats();
+
+  extended_description: |
+    Registers a `gdrive://` filesystem, so any DuckDB path expression can
+    address a file in Google Drive with no download or copy step. Because
+    DuckDB dispatches file access through its virtual filesystem, everything
+    layered on it inherits the scheme: `read_parquet`, `read_csv`, `COPY`,
+    `glob`, and table formats such as DuckLake — attaching a DuckLake whose
+    `DATA_PATH` is on Drive works and is tested live.
+
+    `ATTACH` of a DuckDB **database file** on `gdrive://` is NOT supported.
+    DuckDB opens database files through a different path that does not consult
+    the virtual filesystem, so the attempt fails immediately rather than
+    half-working.
+
+    This is **Google Drive**, not Google Cloud Storage — a different product
+    with a different API and access model. For `gs://` buckets use the `gcs`
+    extension.
+
+    Reads are ranged, so a Parquet scan fetches footers and column chunks
+    rather than whole files. Path resolution is cached per secret and per
+    drive, because Drive has no path addressing and each segment otherwise
+    costs an API call.
+
+    Two behaviours are deliberately strict. Drive permits two files with the
+    same name in one folder, so a path is not a unique identifier: rather than
+    pick one and make results depend on Drive's internal ordering, ambiguity
+    is an error naming both file ids. And Drive cannot write at a byte offset,
+    so positional writes raise an error instead of silently corrupting a file.
+
+    Drive is slower than object storage by a wide margin, and enforces
+    per-user API quotas that object storage does not. A ranged read costs
+    ~1.3 s regardless of how few bytes it requests, against ~1 ms for S3/GCS.
+    Use this when Drive is the system of record for data you want to query and
+    you would rather not maintain a second copy — not as a substitute for
+    object storage under a hot workload. On a workstation, Google Drive for
+    desktop plus ordinary local paths is simpler and faster.


### PR DESCRIPTION
Adds `gdrive`, a filesystem extension for **Google Drive** (not Google Cloud Storage).

It registers a `gdrive://` scheme, so anything that goes through DuckDB's virtual filesystem addresses a Drive file directly with no download or copy step:

```sql
CREATE SECRET gdrive (TYPE gdrive, PROVIDER service_account,
                      KEY_FILE '/etc/creds/sa.json', DRIVE_ID '0ABc...');

SELECT count(*) FROM 'gdrive://Finance/2026/actuals.parquet';
SELECT * FROM read_parquet('gdrive://exports/parts/*.parquet');
SELECT * FROM read_csv('gdrive://Finance/Budget');   -- a native Sheet
```

**What it covers:** ranged reads, glob, `COPY` writes, native Sheets/Docs via Drive's export, service-account and refresh-token auth, and DuckLake with its `DATA_PATH` on Drive.

**Testing.** There is no mock Drive and no HTTP replay layer — behaviour that needs a socket is tested against a real Google Drive account (live SQL suite plus a pytest harness), and pure logic is tested in Catch2. `v0.1.0` is green on DuckDB v1.5.5 and v1.4.5 LTS across Linux amd64/arm64, musl, Windows and both macOS architectures.

**Things reviewers usually ask:**

- *Excluded platforms* are `windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads`. wasm is not a gap to close later: the extension is HTTPS calls to the Drive API plus a loopback redirect server for OAuth, neither of which works in a browser sandbox, and a wasm side-module would build green and then fail to load. A clean "unavailable" seemed better than an unloadable artifact.
- *Performance* is stated plainly in the description rather than sold. A cold 87 MB Parquet scan is ~3x the same file on GCS at the defaults and ~2x with a larger block size; a Drive ranged read costs ~1.3 s regardless of how few bytes it asks for. The numbers and the method are in [`docs/benchmark.md`](https://github.com/DataZooDE/duckdb-gdrive/blob/v0.1.0/docs/benchmark.md).
- *Known coverage gap:* rate-limit (403/429) handling is asserted against captured Drive response bodies rather than live, because provoking real quota exhaustion needs a throwaway Google project. It is documented in the README rather than left implied.

`ref` points at the `v0.1.0` tag commit.