### PR TITLE
Bump osmium to v0.5.1

### DIFF
--- a/extensions/osmium/description.yml
+++ b/extensions/osmium/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: osmium
   description: Read OpenStreetMap data from OSM XML and PBF files
-  version: 0.5.0
+  version: 0.5.1
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: jake-low/duckdb-osmium
-  ref: 4bc336fba5bf3003f7c1156afffd409fb4070548
+  ref: 279e97773307c991487ccee7300e20a1b09dca9a
 
 docs:
   hello_world: |


### PR DESCRIPTION
Adds support for DuckDB v1.5.5

Changelog: https://github.com/jake-low/duckdb-osmium/blob/main/CHANGELOG.md
Full diff: https://github.com/jake-low/duckdb-osmium/compare/v0.5.0...v0.5.1

Related: #2381 