### PR TITLE
Add erpl_tunnel extension

### DIFF
--- a/extensions/erpl_tunnel/description.yml
+++ b/extensions/erpl_tunnel/description.yml
@@ -1,0 +1,15 @@
+extension:
+  name: erpl_tunnel
+  description: Reach any TCP service from DuckDB through an SSH bastion, Tailscale or NetBird — and publish local ports back onto those networks.
+  version: 2026.07.30
+  language: C++
+  build: cmake
+  license: BSL 1.1
+  excluded_platforms: "windows_amd64_rtools;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads;"
+  requires_toolchains: "go"
+  maintainers:
+    - jrosskopf
+
+repo:
+  github: DataZooDE/erpl-tunnel
+  ref: 94def6722e061ad915b6caa91e4a95226090131a


### PR DESCRIPTION
`erpl_tunnel` opens a tunnel from a DuckDB session to a TCP service that lives behind a firewall or NAT — an SSH bastion, a Tailscale tailnet, or a NetBird network — and gives you back a plain `localhost:PORT` to point any client at:

```sql
CREATE SECRET bastion (TYPE ssh_tunnel, host 'bastion.example.com', user 'jump', password '…');
PRAGMA tunnel_import(secret = 'bastion',
    remote_host = 'internal-http', remote_port = 8000, local_port = 9000);
SELECT * FROM read_csv_auto('http://localhost:9000/data.csv');
```

It also works the other way. `tunnel_export` publishes a local port onto the network, so a peer can query *this* DuckDB directly over the quack protocol — useful when one machine holds the credentials and network path (a SAP gateway, or a lakehouse on storage only it can reach) and colleagues have neither.

Everything ships inside the single extension file: libssh2/OpenSSL and the mesh nodes (`tsnet`, NetBird `client/embed`) are embedded, so there is no `tailscaled`, no `netbird` daemon, no kernel TUN and no root.

### Notes for review

- **`requires_toolchains: "go"`** — the mesh backends are Go `c-shared` shims. The build bootstraps its own pinned, checksum-verified Go when the toolchain's Go is older than the shims require, so it does not depend on the CI Go version.
- **Excluded platforms** — wasm (no cgo `c-shared`) and the mingw/rtools Windows targets. musl selects an SSH-only build automatically.
- **License** is BSL 1.1, matching `erpl_idoc` (#2203) from the same family and the same maintainer.
- **`ref` points at `v2026.07.30`**, whose full matrix is built and tested in the extension's own CI against DuckDB v1.5.5 and v1.4.5 — linux amd64/arm64, macOS amd64/arm64 and Windows.

Testing is against real infrastructure rather than mocks: a dockerised sshd for both tunnel directions, and real WireGuard data planes against the official Tailscale and NetBird daemons, including an acceptance test in which a peer `ATTACH`es over quack and queries the extension's own DuckDB across the mesh.