### PR TITLE
Add Superhuman Docs extension

### DIFF
--- a/extensions/superhuman_docs/description.yml
+++ b/extensions/superhuman_docs/description.yml
@@ -1,0 +1,32 @@
+extension:
+  name: superhuman_docs
+  description: Attach Superhuman Docs documents as DuckDB databases and query or modify their tables with SQL
+  version: 0.1.0
+  language: Rust & C++
+  build: cmake
+  license: MIT
+  requires_toolchains: rust
+  maintainers:
+    - its-felix
+
+repo:
+  github: its-felix/duckdb-superhuman-docs
+  ref: 2f90c92377abf4cb53a03ab57c66265b2d1d2886
+
+docs:
+  hello_world: |
+    CREATE SECRET superhuman_docs_token (
+        TYPE superhuman_docs,
+        TOKEN 'superhuman-docs-api-token'
+    );
+
+    ATTACH 'doc-id' AS superhuman_docs_doc (TYPE superhuman_docs);
+
+    SELECT * FROM superhuman_docs_doc.main."Tasks";
+
+  extended_description: |
+    The Superhuman Docs extension exposes a Superhuman Docs document as an attached DuckDB database. Tables in the document become DuckDB tables that can be queried with `SELECT` and modified with `INSERT`, `UPDATE`, and `DELETE`.
+
+    Authentication can be supplied through a DuckDB secret or directly when attaching. The extension accepts raw document IDs and prefixed Coda or Superhuman Docs browser URLs. It maps supported Superhuman Docs column formats to native DuckDB types, including decimals, dates, timestamps, intervals, lists, and structs.
+
+    For configuration options, type mappings, mutation semantics, and usage examples, see the [extension repository](https://github.com/its-felix/duckdb-superhuman-docs).

--- a/extensions/superhuman_docs/description.yml
+++ b/extensions/superhuman_docs/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: its-felix/duckdb-superhuman-docs
-  ref: 2f90c92377abf4cb53a03ab57c66265b2d1d2886
+  ref: 1d85c9eaecc407655a6d49720a56f46346258069
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary

The Superhuman Docs extension lets DuckDB attach a Superhuman Docs document as a database. Tables within the document are exposed as DuckDB tables and support `SELECT`, `INSERT`, `UPDATE`, and `DELETE` operations.

The extension supports authentication through DuckDB secrets or attach options, accepts document IDs and prefixed Coda or Superhuman Docs URLs, and maps supported document column formats to native DuckDB types, including decimals, dates, timestamps, intervals, lists, and structs.

This PR adds the extension to the community repository using its DuckDB 1.5-compatible revision.