### PR TITLE
Bump plinking_duck to v0.8.2

### DIFF
--- a/extensions/plinking_duck/description.yml
+++ b/extensions/plinking_duck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: plinking_duck
   description: Read PLINK 2 genomics file formats and run common genetic analyses directly in SQL
-  version: 0.8.0
+  version: 0.8.2
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: teaguesterling/plinking_duck
-  ref: 8c864c03a8292288e30e07dcc456b095e39a05cd
+  ref: b32b0cde755ee261ad4e25ca6634e9bc1c560786
 
 docs:
   hello_world: |
@@ -65,6 +65,12 @@ docs:
     - `af_range` / `ac_range` filter pushdown, and `include_genotypes` (hardcall
       category) / `genotype_range` for fast carrier lookups — in `orient := 'sample'`
       only the matching subjects are materialized
+
+    **Remote / cloud reads:**
+    - Read `.pgen` filesets directly from `s3://`, `https://`, and other DuckDB
+      filesystems (companions too) — targeted/region queries fetch only the bytes
+      they need via HTTP range reads. `plinking_pgen_io := 'localize'` downloads once
+      for remote full scans. Split-index (`.pgen.pgi`) filesets are read transparently.
 
     All functions support projection pushdown (skip genotype decompression for
     metadata-only queries), parallel scanning, sample subsetting, and region


### PR DESCRIPTION
Bumps `plinking_duck` from v0.8.0 to **v0.8.2**.

Changes since v0.8.0:

**v0.8.1**
- `plinking_pgen_io := 'localize'` — materialize a remote `.pgen` to a local temp and read it natively (best for remote full scans; per-query temp, configurable `plinking_localize_dir`).
- Split-index (`.pgen.pgi`) filesets read transparently on every path (local, remote, `vfs`, `localize`).
- macOS `funopen` remote-read path validated in CI.

**v0.8.2**
- Fix `INTERNAL Error` crash when a NULL LIST value (`list(x)` over zero rows — a LIST-typed NULL, e.g. via a session variable — or a bare NULL) is passed to a list-typed parameter (`samples`, `variants`, `include_genotypes`, `phenotype`, `covariates`, `weights`, or a file-list argument). Guarded with `IsNull()` before the list accessor at all sites.

Also refreshes the extended description to mention remote/cloud reads (shipped in 0.8.0).

ref → `b32b0cd` (tag `v0.8.2`). All tests pass locally on Linux; relying on community CI for the full platform matrix.