### PR TITLE
anofox_statistics: bump to latest (hierarchical GLMs, AFT survival, offset/converged, BLS/NNLS pivot fix)

### DIFF
--- a/extensions/anofox_statistics/description.yml
+++ b/extensions/anofox_statistics/description.yml
@@ -1,6 +1,6 @@
 extension:
   name: anofox_statistics
-  description: A DuckDB extension for statistical regression analysis, providing OLS, Ridge, Elastic Net, LARS/LassoLars, WLS, recursive least squares, robust estimators (Huber, RANSAC, Theil-Sen), GLMs (Poisson, Negative Binomial, Binomial, Tweedie, Gamma, Logistic), and time-series regression with full diagnostics and inference directly in SQL.
+  description: A DuckDB extension for statistical regression and inference in SQL - OLS, Ridge, Elastic Net, LARS/LassoLars, WLS, recursive least squares, robust estimators (Huber, RANSAC, Theil-Sen), GLMs (Poisson, Negative Binomial, Binomial, Tweedie, Gamma, Logistic) with offset support, mixed-effects/hierarchical GLMs, AFT survival regression, explicit priors with Laplace intervals, empirical-Bayes shrinkage, and time-series regression, all with full diagnostics and inference.
   language: C++
   build: cmake
   license: BSL 1.1
@@ -9,4 +9,4 @@ extension:
   requires_toolchains: rust
 repo:
   github: DataZooDE/anofox-statistics
-  ref: 6521cd9ec146456407f607af204555ece8011dd8
+  ref: 24b0a739055d68cd7e81fbbab53ea73f237c81f7


### PR DESCRIPTION
Updates the existing `anofox_statistics` extension `ref` from `6521cd9` to the current `main` (`24b0a73`), and refreshes the description to cover capabilities added since the last submission.

**Since the pinned ref (`6521cd9`), `main` has landed:**
- Mixed-effects / hierarchical GLMs (`glmm_fit_agg`), AFT survival regression (`aft_fit_agg`), explicit per-coefficient priors with Laplace intervals, and empirical-Bayes shrinkage (DataZooDE/anofox-statistics#108).
- Uniform `offset` support and NULL-safe `x` list handling, plus a `converged` field on the six GLM aggregates (#110, #111).
- Fix for a silent BLS/NNLS coefficient-rotation bug on 3+ features via the upstream `anofox-regression` 0.5.13 bump (#114).

Extension repo, build, and tests are green at the new ref (Rust unit tests + full SQL suite). Maintainer unchanged (`sipemu`).

Note: this is independent of my other open PR (#2416, `anofox_visualization`) — different extension, separate branch.