### PR TITLE
snowflake: bump to 0.5.1

### DIFF
--- a/extensions/snowflake/description.yml
+++ b/extensions/snowflake/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: snowflake
   description: Snowflake data source extension - query Snowflake databases directly from DuckDB
-  version: 0.5.0
+  version: 0.5.1
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: iqea-ai/duckdb-snowflake
-  ref: bf861da14bfa5578a02f819dc5a2aadd4bd415d6
+  ref: c4da4b52630c90bd6946ecc3ea106645a2a5dd0d
 
 install_notes: |
   **Important:** This extension requires the ADBC Snowflake driver (a separate shared library) to function.


### PR DESCRIPTION
Bumps the snowflake extension to 0.5.1 (ref = the v0.5.1 tag's merge commit).

Patch release on 0.5.0: projected `LIST`/`EXPLAIN`/`CALL` through `snowflake_query()` no longer crash (ArrowTypeInfo type mismatch) or silently return wrong columns - row-returning metadata statements now all route through the RESULT_SCAN re-target introduced for `SHOW`/`DESC` in 0.5.0.

Release notes: https://github.com/iqea-ai/duckdb-snowflake/releases/tag/v0.5.1
No changes to install_notes or docs - driver setup is unchanged.
