### PR TITLE
Bump DuckGQL to v0.1.1

### DIFF
--- a/extensions/duckgql/description.yml
+++ b/extensions/duckgql/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duckgql
   description: Adds ISO GQL graph querying and graph algorithms to DuckDB
-  version: 0.1.0
+  version: 0.1.1
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: rahul-iyer/duckdb-gql
-  ref: 17095d2b2b2b717b3db910327b3c67eff8f28ea7
+  ref: 2e87e4ef084291b180e4fc940f99cdfade3708dd
 
 docs:
   hello_world: |
@@ -45,20 +45,23 @@ docs:
     mutations with DuckDB's native relational storage and execution engine,
     plus an explicit CSR layer for graph algorithms.
 
-    **What works in v0.1.0**
+    **What works in v0.1.1**
 
     * Managed property graphs backed by typed DuckDB vertex and edge tables.
+    * Inline typed graph schemas that persist in the catalog and immediately
+      materialize constrained vertex and edge tables without `COPY GRAPH`.
     * Graph-header CSV, compressed CSV, and Parquet bulk import with optional
       endpoint and identity validation.
     * Directed `MATCH`, `OPTIONAL MATCH`, filtering, projection, aggregation,
       ordering, paging, fixed multi-hop patterns, and a bounded
       variable-length path subset.
     * Standalone node and directed-path `INSERT`, fixed directed
-      `MATCH`-and-`INSERT`, property and label mutation, and edge/node deletion.
+      `MATCH`-and-`INSERT`, single-node `INSERT RETURN`, property and label
+      mutation, and edge/node deletion.
     * Native DuckDB ART indexes for selective vertex-property equality lookups.
     * Explicit CSR-backed BFS, DFS, unweighted SSSP, PageRank, weak and strong
-      components, degree, closeness, local clustering coefficient, and triangle
-      counting.
+      components, Louvain community detection, degree, closeness, local
+      clustering coefficient, and triangle counting.
 
     **Storage and execution model**
 
@@ -73,17 +76,17 @@ docs:
 
     **Project status**
 
-    DuckGQL v0.1.0 is not yet a complete or conforming ISO GQL implementation.
+    DuckGQL v0.1.1 is not yet a complete or conforming ISO GQL implementation.
     Grammar recognition does not imply semantic or transactional conformance.
-    The machine-readable conformance manifest currently classifies 23 feature
-    families as partial and 13 as planned. Important restrictions include
+    The machine-readable conformance manifest currently classifies 24 feature
+    families as partial and 12 as planned. Important restrictions include
     autocommit-only graph lifecycle and CSR operations, connection-local CSR
     snapshots, a single vertex and edge input per bulk load, and incomplete
     general path searches, query composition, procedures, and the complete GQL
     value/type system.
 
     See the [documentation](https://duckgql.com/docs/), inspect the
-    [conformance manifest](https://github.com/rahul-iyer/duckdb-gql/blob/v0.1.0/test/conformance/iso-gql-2024.tsv),
+    [conformance manifest](https://github.com/rahul-iyer/duckdb-gql/blob/v0.1.1/test/conformance/iso-gql-2024.tsv),
     or try the [browser playground](https://duckgql.com/).
 
   known_limitations: |
@@ -101,9 +104,13 @@ docs:
       unweighted.
     * Multiple-path and undirected insertion, general runtime property maps,
       and open-graph schema evolution remain incomplete.
+    * `INSERT RETURN` currently supports one directly inserted node variable;
+      edge values, expressions, multiple return items, ordering, and pagination
+      are not yet supported.
     * General path modes and searches, shortest-path groups, complete
       variable-length path composition, procedure semantics, query composition,
-      graph types, and the complete GQL value/type system remain incomplete.
+      named graph types, typed storage enforcement, and the complete GQL
+      value/type system remain incomplete.
     * Existing DuckDB and DuckLake tables cannot yet be registered directly as
       zero-copy graphs; they must first be imported through graph-header CSV or
       Parquet files.


### PR DESCRIPTION
## Summary

Updates the DuckGQL Community Extension from `0.1.0` to `0.1.1`.

- Bumps the extension version to `0.1.1`.
- Updates the pinned DuckGQL repository commit.
- Documents inline typed graph creation and materialization.
- Adds Louvain community detection to the supported algorithms.
- Updates the ISO GQL conformance status and known limitations.
