### PR TITLE
Add dumb_ducklake extension

### DIFF
--- a/extensions/dumb_ducklake/description.yml
+++ b/extensions/dumb_ducklake/description.yml
@@ -1,0 +1,44 @@
+extension:
+  name: dumb_ducklake
+  description: Plan DuckLake queries into self-contained parquet queries that run on DuckLake-unaware DuckDB executors
+  version: 0.1.1
+  language: C++
+  build: cmake
+  license: MIT
+  maintainers:
+    - kiwialec
+
+repo:
+  github: kiwialec/dumb-ducklake
+  ref: 3a2212118456663723229254560233607ef1277d
+
+docs:
+  hello_world: |
+    -- planner instance (DuckLake attached):
+    LOAD ducklake;
+    LOAD dumb_ducklake;
+    ATTACH 'ducklake:metadata.ducklake' AS lake;
+    SELECT dumb_ducklake_plan('SELECT count(*) FROM lake.sales WHERE brand_id = 8');
+    -- returns a rewritten SQL string over exactly the pruned parquet files;
+    -- run it on any stock DuckDB (no DuckLake, no metadata DB access needed).
+  extended_description: |
+    `dumb_ducklake` splits DuckLake querying into a planner and dumb executors.
+
+    `dumb_ducklake_plan(query [, mode] [, params])` plans and optimizes a SELECT with
+    DuckDB's real optimizer on a DuckLake-attached instance, letting DuckLake's zone-map
+    and partition pruning cut the file list, then rewrites every DuckLake table reference
+    into a parquet scan over exactly those files and returns the SQL text. Deleted rows
+    are handled by rewriting into an anti-join against the delete-file parquets. By
+    default the emitted SQL uses stock `read_parquet`, so executors need no extension at
+    all; with mode `'hinted'` it emits `read_parquet_hinted` with per-file
+    file_size/footer_size/encryption-key hints (fewer object-store round trips, required
+    for encrypted lakes). Prepared-statement placeholders are supported: values passed at
+    plan time drive pruning while the placeholders remain in the emitted SQL. CTEs,
+    local views over lake tables, dynamic PIVOT (pivot values are evaluated at plan
+    time) and `COPY (SELECT ...) TO` are handled; queries the optimizer answers from
+    metadata alone (e.g. bare `count(*)`) are materialized as constant SQL.
+
+    `read_parquet_hinted([{path, file_size, footer_size, encryption_key, ...}])` is a
+    drop-in `read_parquet` that accepts per-file metadata hints, skipping the size probe
+    and fetching parquet footers with a single exact-range read, with never-revalidate
+    caching for immutable lake files.


### PR DESCRIPTION
## Extension: dumb_ducklake

Splits [DuckLake](https://ducklake.select) querying into a **planner** and **dumb executors**: `dumb_ducklake_plan('<sql>')` runs on a DuckLake-attached instance and rewrites the query into a self-contained parquet query over exactly the pruned file list (zone maps + partition pruning, delete files applied via anti-join). By default the emitted SQL uses stock `read_parquet`, so the executing DuckDB needs **no extension and no metadata-database access at all**; an optional hinted mode emits `read_parquet_hinted` with per-file size/footer/key hints for fewer object-store round trips.

- Repo: https://github.com/kiwialec/dumb-ducklake (MIT, based on the extension template — builds with the standard toolchain out of the box)
- Pinned ref: `3a22121` = release [v0.1.1](https://github.com/kiwialec/dumb-ducklake/releases/tag/v0.1.1), built and tested green against DuckDB v1.5.5 across the full platform matrix
- A `duckdb-main` branch tracks DuckDB main for `ref_next` when the next release approaches
- Verified against a production DuckLake on S3: pruned-file results (including deleted rows) match native DuckLake exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)