### PR TITLE
Bump gdrive to v2026.08.03

### DIFF
--- a/extensions/gdrive/description.yml
+++ b/extensions/gdrive/description.yml
@@ -16,7 +16,7 @@ extension:
 
 repo:
   github: DataZooDE/duckdb-gdrive
-  ref: c22f108fe83f849c0eb0bc5a271f54f14e1483b7
+  ref: 3dc834f02c8934dc2a3dbafb664d2f4a62157a6e
 
 docs:
   hello_world: |


### PR DESCRIPTION
Thanks for merging #2407. Bumping to the release cut since then.

Twelve defects were fixed after `v2026.08.01`, and **every one was a silent failure or a wrong answer rather than an error** — so none of them would be obvious to someone installing the currently published ref. The most user-visible:

- **A missing secret was reported as a missing *file*.** `file_size` returned NULL and `remove_file` returned false when no secret was configured, so a typo in a secret name told the user their data did not exist.
- **The extension could manufacture duplicate names on Drive.** Writing under a path whose parent was a file created a same-named folder beside it, leaving the original unreadable by path. Three separate code paths were affected; all are guarded now.
- **`glob` returned folders**, which callers then passed to `read_parquet`. Local `glob` of a directory returns zero rows; that parity is now matched.
- **`OpenFile` ignored `FILE_FLAGS_NULL_IF_NOT_EXISTS`**, which core relies on for speculative probes.
- Clearer errors for a revoked refresh token, an ADC credential naming no quota project, and the `SCOPE` vs `DRIVE_SCOPE` mix-up — the last previously reported "no secret configured" for a secret that plainly existed.

Two limitations are now documented rather than fixed, because Drive offers no primitive for either: concurrent writers can duplicate files *and* directories, and `DRIVE_SCOPE` cannot restrict an already-granted refresh token.

Verified on the tagged commit: 937 pure-logic assertions, 7 live SQL suites and 23 end-to-end tests against a real Google Drive account, plus CI green across Linux amd64/arm64, musl, Windows and both macOS architectures on DuckDB v1.5.5 and v1.4.5 LTS.

Release notes: https://github.com/DataZooDE/duckdb-gdrive/releases/tag/v2026.08.03