### PR TITLE
quackiso 1.3.0: sniff_iso20022, the inventory function

### DIFF
--- a/extensions/quackiso/description.yml
+++ b/extensions/quackiso/description.yml
@@ -1,7 +1,10 @@
+# Submit this file to duckdb/community-extensions at
+# extensions/quackiso/description.yml
+# `ref` is the tagged release commit in tempoloss/quackiso.
 extension:
   name: quackiso
   description: Query ISO 20022 (camt, pacs, pain) financial messages as SQL
-  version: 1.2.0
+  version: 1.3.0
   language: Rust
   build: cmake
   license: MIT
@@ -12,7 +15,7 @@ extension:
 
 repo:
   github: tempoloss/quackiso
-  ref: 13db4e434cb205378f29fafb0e701ebc7d5780e1
+  ref: 62c365d51c016827f37fe2dfbd8512214c886d16
 
 docs:
   hello_world: |
@@ -21,6 +24,12 @@ docs:
     SELECT booking_date, amount, currency, credit_debit, counterparty_name
     FROM read_iso20022('statements/*.xml', threads := 8)
     ORDER BY booking_date;
+
+    -- What is in the folder, before choosing a reader: one row per file with
+    -- the message type, the reader that covers it, and the record count.
+    SELECT family, reader, count(*) AS files, sum(records) AS records
+    FROM sniff_iso20022('inbox/**/*.xml')
+    GROUP BY family, reader;
 
     -- Interbank credit transfers (pacs.008, the ISO 20022 MT103).
     SELECT uetr, amount, currency, debtor_name, creditor_agent_bic
@@ -58,8 +67,8 @@ docs:
     Python preprocessing step, no per-schema glue code: point a table function at
     bank XML and get transactions as rows.
 
-    Thirteen functions covering the payment lifecycle end to end, in both
-    directions:
+    Fourteen functions: thirteen readers covering the payment lifecycle end to
+    end, in both directions, and a sniffer that routes files to them.
 
     * `read_iso20022(path)` - camt.053 statements, camt.054 notifications and
       camt.052 reports; one row per booked entry.
@@ -83,6 +92,12 @@ docs:
       cancellation requests (interbank and customer-side) and the resolution
       that answers them; a whole-batch cancellation with no transactions is
       still a row.
+    * `sniff_iso20022(path)` - inventory before reading: one row per file with
+      the detected message type, the family, the wire-level record count and the
+      reader that covers it. Identity comes from the namespace, the era-spelled
+      container names or the envelope binding, and content problems land in an
+      `error` column instead of aborting the scan, so a folder of mixed
+      downloads is a table rather than a failure.
 
     All exception and status readers expose the original references (UETR,
     end-to-end id, original message id), so one payment joins across its whole
@@ -98,9 +113,11 @@ docs:
     Dates are typed rather than left as text; offsets are normalised to UTC, and
     both the `<Dt>` and `<DtTm>` wrappings are read.
 
-    Parsing is a streaming pass over XML events, so memory follows the vector
-    size rather than the file: a 1.7 GB statement reads in roughly 2 MB
-    resident. A glob is parsed in parallel, one worker per file - XML has no
+    Parsing is a streaming pass over XML events, so the peak is one output batch
+    plus the largest single XML subtree rather than the file: a 1.7 GB statement
+    of three million entries parses in 1.23 MiB of live heap and about 2 MB
+    resident, measured by `cargo test membound`, and adds 7.8 MiB to a running
+    DuckDB. A glob is parsed in parallel, one worker per file - XML has no
     safe split points, so a single document is never divided - with
     `threads := n` to pin the pool; measured 6.9x on 8 files of 35 MB.
 


### PR DESCRIPTION
Re-pins `quackiso` to v1.3.0 (`62c365d51c016827f37fe2dfbd8512214c886d16`). The registry currently builds v1.2.0 (`13db4e4`), which predates the fourteenth function.

**New: `sniff_iso20022(path)`** — inventory before reading. One row per file, whatever the file turns out to be, with the detected message type (`pacs.008.001.08`), the family, the namespace, `msg_id`, creation time, the wire-level record count, and the reader that covers it. Identity comes from the `Document` namespace, the era-spelled container names the readers accept, or the envelope's binding — BizMsgEnvlp, SWIFTNet DataPDU, Fedwire, and RTGS traffic that carries no `<Document>` at all; `head.001`, the AppHdr beside the message, is never mistaken for the message itself. Content problems land in an `error` column instead of aborting the scan, so a truncated download, a stray XSD or a `{placeholder}` template each get a row saying why rather than killing the inventory. The sniffer routes, the readers judge: a file attributed to `read_pacs008` can still fail loudly there.

The descriptor's `hello_world` gains that statement, and the function list gains its entry — thirteen readers plus the sniffer.

The streaming-memory paragraph now quotes measured figures instead of a remembered one. Three million entries, 1.73 GB on disk: 1.24 MiB of live heap and 2.04 MiB of peak RSS for the parser standalone, 7.7 MiB added to a live DuckDB baseline. Those come from test cases and a measurement script in the repo that run in CI, including the two terms the old wording glossed over — one output batch and the largest single XML subtree.

Verified from a clean `--recursive` clone of the tagged ref in a Linux container: `make configure debug && make test` pass against `TARGET_DUCKDB_VERSION=v1.5.5`, and every statement in `hello_world` was run against the built extension — eight statements, eight results, including the new sniff over the test corpus. `excluded_platforms` and `requires_toolchains` unchanged.
