### PR TITLE
faiss: exclude windows_amd64 and windows_amd64_mingw

### DIFF
--- a/extensions/faiss/description.yml
+++ b/extensions/faiss/description.yml
@@ -8,7 +8,11 @@ extension:
   maintainers:
     - JAicewizard
     - arjenpdevries
-  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads"
+  # windows_amd64 fails to link against the CLAPACK that vcpkg provides on MSVC
+  # (unresolved d_sign, pow_ri, pow_dd, r_sign - the f2c runtime), and it took the
+  # four platforms that do build down with it, so nothing was published at all.
+  # Temporary: remove once the MSVC LAPACK link is fixed upstream.
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64;windows_amd64_mingw"
   requires_toolchains: "fortran;omp"
   vcpkg_url: "https://github.com/microsoft/vcpkg.git"
   vcpkg_commit: "54760c3439fa2fdf2f42ccd730fcf2639c3fe101"


### PR DESCRIPTION
As requested in #2412, this drops the two Windows legs so the platforms that do build can publish again. Temporary, pending the MSVC LAPACK fix @JAicewizard is investigating.

### Why the other four platforms went missing too

In the 1.5.4 rebuild ([run 27813900848](https://github.com/duckdb/community-extensions/actions/runs/27813900848)):

| leg | result |
|---|---|
| `linux_amd64`, `linux_arm64`, `osx_amd64`, `osx_arm64` | success |
| `windows_amd64` | failure |
| `windows_amd64_mingw` | cancelled |
| `deploy` | **skipped** |

`deploy` is `needs: [prepare, build]`, so one failing leg withheld the four that succeeded, and no artifact was published for any platform. All five 1.5.4 URLs return 404 while every 1.5.3 URL returns 200.

The Windows failure is a link error against the CLAPACK vcpkg provides, without the f2c runtime ([job 82332813909](https://github.com/duckdb/community-extensions/actions/runs/27813900848/job/82332813909)):

```
lapack.lib(dlarfp.c.obj) : error LNK2001: unresolved external symbol d_sign
lapack.lib(slamch.c.obj) : error LNK2019: unresolved external symbol pow_ri
lapack.lib(sbdsqr.c.obj) : error LNK2019: unresolved external symbol pow_dd
lapack.lib(slarfg.c.obj) : error LNK2019: unresolved external symbol r_sign
extension\faiss\faiss.duckdb_extension : fatal error LNK1120: 14 unresolved externals
```

### Verified locally

Ran the real chain rather than assuming the field takes effect. `scripts/build.py` with `ALL_CHANGED_FILES=extensions/faiss/description.yml` emits:

```
COMMUNITY_EXTENSION_EXCLUDE_PLATFORMS=wasm_mvp;wasm_eh;wasm_threads;windows_amd64;windows_amd64_mingw
```

Feeding that to `modify_distribution_matrix.py --deploy_matrix` against `config/distribution_matrix.json`:

```
before: linux_amd64  linux_arm64  osx_amd64  osx_arm64  windows_amd64  windows_amd64_mingw
after:  linux_amd64  linux_arm64  osx_amd64  osx_arm64
```

Which is exactly the set that succeeded in the run above.

### Two notes

`should_run` compares with `arch in excluded_arch_values` after a `split(";")`, so this is exact membership and both legs have to be named — excluding only `windows_amd64` would leave the mingw leg in the matrix.

`windows_amd64_rtools` is not in faiss's matrix at all, so it is deliberately not added here.
