### PR TITLE
fit: bump to 1.0.1

### DIFF
--- a/extensions/fit/description.yml
+++ b/extensions/fit/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: fit
   description: Read Garmin .fit files using DuckDB - GPS tracks, heart rate, power metrics, and fitness device data
-  version: 1.0.0
+  version: 1.0.1
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: antoriche/duckdb-fit-extension
-  ref: 157a5762bba68e84e9affa4af17af45ef15f4be3
+  ref: 193b09dda67ffb5d6c23e8a72929a5bcca2e3ecf
 
 docs:
   hello_world:  |

--- a/extensions/fit/description.yml
+++ b/extensions/fit/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: antoriche/duckdb-fit-extension
-  ref: 193b09dda67ffb5d6c23e8a72929a5bcca2e3ecf
+  ref: d6f8a4660b3dec837ccc9b369b7a7f5a2f85bbb1
 
 docs:
   hello_world:  |


### PR DESCRIPTION
Update the `fit` extension to **v1.0.1**.

### What changed
- **Bug fix (main reason):** FIT files are now read through DuckDB's `FileSystem` instead of `std::fstream`. The previous approach couldn't read files under **DuckDB-WASM** (no host filesystem) — this fixes that. See antoriche/duckdb-fit-extension#1.
- **New capability:** reads now also work for `s3://`, `https://`, and DuckDB-registered in-memory files.
- Built against DuckDB **v1.5.5**.
- Added tests covering FileSystem-based reads (including `file://` URLs and glob patterns).

### Descriptor
- `version`: 1.0.0 → 1.0.1
- `ref`: pinned to commit `193b09dda67ffb5d6c23e8a72929a5bcca2e3ecf` (tag `v1.0.1`)