### PR TITLE
Add TsFile community extension

### DIFF
--- a/extensions/tsfile/description.yml
+++ b/extensions/tsfile/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: ColinLeeo/tsfile-duckdb
-  ref: 7888e1ba1bab0758aa417ed9fa16e93de70bcf4f
+  ref: 34e6865cbb251cf318cc443d8bb3a26c018e60a9
 
 docs:
   hello_world: |

--- a/extensions/tsfile/description.yml
+++ b/extensions/tsfile/description.yml
@@ -1,0 +1,33 @@
+extension:
+  name: tsfile
+  description: Query Apache TsFile table-model files directly from DuckDB
+  version: 0.1.0
+  language: C++
+  build: cmake
+  license: Apache-2.0
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads"
+  maintainers:
+    - ColinLeeo
+
+repo:
+  github: ColinLeeo/tsfile-duckdb
+  ref: daf087936d4187c28efbb129d87bc9f6bcef087a
+
+docs:
+  hello_world: |
+    INSTALL tsfile FROM community;
+    LOAD tsfile;
+
+    SELECT time, device_id, temperature
+    FROM read_tsfile('/data/measurements.tsfile', 'sensors')
+    WHERE time BETWEEN 1700000000000 AND 1700003600000;
+
+  extended_description: |
+    The TsFile extension exposes the read_tsfile(path, table_name) table
+    function for querying Apache TsFile table-model files. It maps TsFile
+    columns to DuckDB types, pushes projections and time predicates into the
+    reader, and streams results in DuckDB vector-sized batches.
+
+    The initial release supports one local file and one table per scan.
+    Tree-model files, multi-file scans, automatic table discovery, parallel
+    scans, and TAG/FIELD predicate pushdown are not yet implemented.

--- a/extensions/tsfile/description.yml
+++ b/extensions/tsfile/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: ColinLeeo/tsfile-duckdb
-  ref: daf087936d4187c28efbb129d87bc9f6bcef087a
+  ref: 7888e1ba1bab0758aa417ed9fa16e93de70bcf4f
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary

Add the `tsfile` Community Extension for querying Apache TsFile table-model files directly from DuckDB.

The extension source is maintained at:

https://github.com/ColinLeeo/tsfile-duckdb

This descriptor pins source commit:

`daf087936d4187c28efbb129d87bc9f6bcef087a`

## Functionality

The extension provides the following table function:

```sql
read_tsfile(path, table_name)
```

It currently supports:

- DuckDB projection pushdown into the TsFile reader
- Time predicate pushdown for `=`, `<`, `<=`, `>`, `>=`, and `BETWEEN`
- BOOLEAN, INT32, INT64, FLOAT, DOUBLE, TEXT, STRING, TIMESTAMP, DATE, and BLOB values
- NULL values
- Arrow C Data Interface batch export from the TsFile reader
- Results spanning multiple DuckDB vector batches

Example:

```sql
INSTALL tsfile FROM community;
LOAD tsfile;

SELECT time, device_id, temperature
FROM read_tsfile('/data/measurements.tsfile', 'sensors')
WHERE time BETWEEN 1700000000000 AND 1700003600000;
```

## Dependency packaging

The extension pins Apache TsFile commit:

`7ca2e79fbdd9a36ef9dde5e522b7c23020536aeb`

TsFile and its bundled compression libraries are built as position-independent static libraries in an isolated CMake project.

The resulting extension:

- Does not require `TSFILE_ROOT`
- Does not require a preinstalled `libtsfile`
- Does not depend on a shared TsFile library at runtime
- Recursively obtains all dependencies through pinned Git submodules

## Platforms

The initial descriptor targets Linux, macOS, and Windows.

WASM platforms are excluded because the current implementation uses the native TsFile C++ reader and local filesystem access.

## Validation

The following validation has been completed on DuckDB `v1.5.5` and macOS ARM64:

- Community Extension descriptor successfully parsed by `scripts/build.py`
- Static DuckDB extension build succeeded
- Loadable extension build succeeded
- SQLLogicTest passed with 27 assertions
- Standalone loadable-extension query returned the expected 60 rows
- The generated extension has no dynamic dependency on `libtsfile` or its bundled codecs

## Data transfer

TsFile query batches are exposed through the Arrow C Data Interface. The current DuckDB adapter materializes those Arrow buffers into DuckDB-owned vectors. Direct Arrow buffer adoption is a future performance optimization and is not required for functional correctness.

## Current limitations

The initial release supports one local TsFile and one table per scan.

The following functional capabilities are not yet implemented:

- Tree-model TsFile queries
- Multi-file scans and glob paths
- Automatic table discovery
- Parallel scans
- TAG/FIELD predicate pushdown