### PR TITLE
anofox_statistics: bump to v0.8.1

### DIFF
--- a/extensions/anofox_statistics/description.yml
+++ b/extensions/anofox_statistics/description.yml
@@ -9,4 +9,4 @@ extension:
   requires_toolchains: rust
 repo:
   github: DataZooDE/anofox-statistics
-  ref: v0.8.0
+  ref: v0.8.1

--- a/extensions/anofox_statistics/description.yml
+++ b/extensions/anofox_statistics/description.yml
@@ -1,6 +1,6 @@
 extension:
   name: anofox_statistics
-  description: A DuckDB extension for statistical regression and inference in SQL - OLS, Ridge, Elastic Net, LARS/LassoLars, WLS, recursive least squares, robust estimators (Huber, RANSAC, Theil-Sen), GLMs (Poisson, Negative Binomial, Binomial, Tweedie, Gamma, Logistic) with offset support, mixed-effects/hierarchical GLMs, AFT survival regression, explicit priors with Laplace intervals, empirical-Bayes shrinkage, and time-series regression, all with full diagnostics and inference.
+  description: A DuckDB extension for statistical regression and inference in SQL - OLS, Ridge, Elastic Net, LARS/LassoLars, WLS, recursive least squares, robust estimators (Huber, RANSAC, Theil-Sen), GLMs (Poisson, Negative Binomial, Binomial, Tweedie, Gamma, Logistic) with offset support, mixed-effects/hierarchical GLMs with random slopes and crossed/nested factors, AFT survival regression, explicit priors with Laplace intervals, empirical-Bayes shrinkage, and time-series regression, all with full diagnostics and inference.
   language: C++
   build: cmake
   license: BSL 1.1
@@ -9,4 +9,4 @@ extension:
   requires_toolchains: rust
 repo:
   github: DataZooDE/anofox-statistics
-  ref: 24b0a739055d68cd7e81fbbab53ea73f237c81f7
+  ref: v0.8.0


### PR DESCRIPTION
Bumps the `anofox_statistics` extension `ref` to **v0.8.1** (from `24b0a73`).

v0.8.0 shipped the mixed-effects work but a macOS/WASM type mismatch broke those builds; **v0.8.1** fixes it (DataZooDE/anofox-statistics#122), so this pins the version that builds on every platform.

Since the currently-published `24b0a73`:
- **Mixed-effects GLMs** — random **slopes** (`{'random': […]}` → Σ) and **crossed/nested** factors (`{'groups': […]}` → per-factor variances), on top of random-intercept `glmm_fit_agg` / AFT / empirical-Bayes / explicit priors.
- **GLM aggregates** — `offset`, NULL-safe `x` lists, `converged`.
- **Correctness** — `anofox-regression` 0.5.13 fixes silent BLS/NNLS coefficient rotation for 3+ features.

Release notes: https://github.com/DataZooDE/anofox-statistics/releases/tag/v0.8.1