### PR TITLE
Update zarr extension to v0.1.3

### DIFF
--- a/extensions/zarr/description.yml
+++ b/extensions/zarr/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: zarr
-  description: Query Zarr array stores (v2 and v3) with SQL - read xarray-convention datasets as tables
-  version: 0.1.2
+  description: Query Zarr array stores (v2 and v3) with SQL — read xarray-convention datasets as tables
+  version: 0.1.3
   language: Rust
   build: cargo
   requires_toolchains: "rust;python3"
@@ -13,19 +13,19 @@ extension:
 
 repo:
   github: xqlsystems/duckdb-zarr
-  ref: v0.1.2
+  ref: v0.1.3
 
 docs:
   hello_world: |
     INSTALL zarr FROM community;
     LOAD zarr;
 
-    -- Read a local Zarr store as a table.
+    -- Read a local Zarr store as a table
     SELECT time, lat, lon, temperature
     FROM read_zarr('path/to/store.zarr')
     LIMIT 10;
 
-    -- Inspect and query a multiscale OME-Zarr bioimage.
+    -- Inspect and query a multiscale OME-Zarr bioimage
     SELECT name, dims, shape
     FROM read_zarr_metadata('image.ome.zarr');
 
@@ -33,16 +33,17 @@ docs:
     FROM read_zarr('image.ome.zarr', array_path = '0')
     GROUP BY c;
   extended_description: |
-    The Zarr extension exposes [Zarr](https://zarr.dev/) array stores as SQL tables,
+    The duckdb-zarr extension exposes [Zarr](https://zarr.dev/) array stores as SQL tables,
     following the [xarray](https://xarray.dev/) dimension convention used by climate science,
     geospatial, and bioimaging datasets.
 
     **Functions**
 
-    - `read_zarr(path)` scans all rows from a single-group Zarr store.
-    - `read_zarr(path, dims=['time','lat','lon'])` selects one dim group from a multi-group store.
-    - `read_zarr_metadata(path)` inspects array names, dtypes, shapes, and roles.
-    - `read_zarr_groups(path)` enumerates distinct dimension groups in a store.
+    - `read_zarr(path)` — scan all rows from a single-group Zarr store.
+    - `read_zarr(path, dims=['time','lat','lon'])` — select one dim group from a multi-group store
+      (`dims` is a list of dimension names).
+    - `read_zarr_metadata(path)` — inspect array names, dtypes, shapes, and roles.
+    - `read_zarr_groups(path)` — enumerate distinct dimension groups in a store.
 
     **Automatic path interception**
 
@@ -58,9 +59,10 @@ docs:
     - Zarr v2 and v3
     - Codecs: gzip, zstd, blosc, crc32c, sharding, transpose, bytes (big/little endian)
     - CF conventions: `scale_factor`/`add_offset` packed integers, `_FillValue`/`missing_value` null masking
-    - Local filesystem, HTTP/HTTPS, S3, GCS, and Azure Blob Storage
-      (consolidated metadata required for remote array listing; S3/GCS/Azure credentials
-      are read from DuckDB's secrets manager - `CREATE SECRET ... TYPE S3` etc.)
+    - Local filesystem, HTTP/HTTPS, S3, GCS, and Azure Blob Storage. Remote stores must carry
+      consolidated metadata — a Zarr v2 `.zmetadata` object or a Zarr v3 `consolidated_metadata`
+      block — because object stores cannot list directories. S3/GCS/Azure credentials are read
+      from DuckDB's secrets manager — `CREATE SECRET ... TYPE S3` etc.
 
     **Bioimage and OME-Zarr**
 


### PR DESCRIPTION
Updates the `zarr` community extension to `v0.1.3` (xqlsystems/duckdb-zarr).

## What's new
- **Bind-time performance fix on wide remote v2 stores**: dim-group classification previously called `open_array()` on every array in the store several times over, and each open costs up to 3 HTTP round trips. A new `ConsolidatedCacheStore` serves metadata lookups (including negative "not found" answers) from an in-memory map built once from the store's consolidated metadata, turning O(arrays) bind-time round trips into O(1) — measured two orders of magnitude wall-clock improvement on a real ~100-array remote store. See xqlsystems/duckdb-zarr#35.

Rendered via this repo's own `make render-community-descriptor REF=v0.1.3` and validated with `scripts/check_release_ready.py --strict-community-ref` (see xqlsystems/duckdb-zarr#38).

🤖 Generated with [Claude Code](https://claude.com/claude-code)