### PR TITLE
luajit: bump to v0.31 — add linux_arm64 platform

### DIFF
--- a/extensions/luajit/description.yml
+++ b/extensions/luajit/description.yml
@@ -1,17 +1,17 @@
 extension:
   name: luajit
-  description: "In-process LuaJIT UDFs for DuckDB — 12 functions, JIT-compiled, GROUP BY, batch mode ~3.6x native (single-thread)"
-  version: 0.17
+  description: "In-process LuaJIT UDFs for DuckDB — JIT-compiled, parallel (per-thread states), trusted sandbox, GROUP BY aggregates, LIST/STRUCT/MAP bridges, embedded Fennel compiler"
+  version: 0.31
   language: C
   build: cmake
   license: MIT
   maintainers:
     - alitrack
-  excluded_platforms: "linux_arm64;wasm_eh;wasm_mvp;wasm_threads;windows_amd64_mingw;windows_amd64_rtools"
+  excluded_platforms: "wasm_eh;wasm_mvp;wasm_threads;windows_amd64_mingw;windows_amd64_rtools"
 
 repo:
   github: alitrack/duckdb-luajit
-  ref: refs/tags/v0.17
+  ref: refs/tags/v0.31
 
 docs:
   hello_world: |
@@ -29,38 +29,38 @@ docs:
   extended_description: |
     ## luajit — JIT-compiled Lua UDFs for DuckDB
 
-    Write and run Lua functions directly in SQL. LuaJIT compiles them to native machine code
-    with trace-based JIT, **near-native performance** (batch mode ~3.6× native SQL single-threaded,
-    ~2500× faster than Python UDF).
+    Write and run Lua functions directly in SQL. LuaJIT compiles them to native machine
+    code with trace-based JIT, with **parallel execution**: each DuckDB worker thread
+    owns its own lua_State (no global lock), so thread parallelism maps directly to
+    LuaJIT parallelism.
 
-    **12 Functions:**
+    **16 Functions:**
     - `luajit_i` / `luajit_f` / `luajit_b` — typed scalar UDFs (BIGINT, DOUBLE, BOOLEAN)
-    - `luajit_v` — **chunk-batched scalar** (1 Lua call per chunk, ~3.6× native single-thread)
+    - `luajit_v` / `luajit_vi` / `luajit_vs` — **chunk-batched scalar** (1 Lua call per chunk, ~1.9× row-mode)
     - `luajit_m` — mixed-type auto-cast
-    - `luajit_l` / `luajit_s` / `luajit_map` — LIST/STRUCT/MAP type bridges
-    - `luajit_agg` — aggregate UDFs with GROUP BY support
-    - `luajit_table` — table-generating UDFs
-    - `luajit_module` — module management (10 modes)
+    - `luajit_l` / `luajit_s` / `luajit_map` — LIST/STRUCT/MAP type bridges (nested types incl. DATE)
+    - `luajit_agg` — aggregate UDFs with GROUP BY support (per-group full value table)
+    - `luajit_table` — streaming table-generating UDFs (O(1) memory, 1M rows)
+    - `luajit_module` — module management (**14 modes**: compile, quick_compile, fennel, trusted, inspect, macro, list, drop, reset, save, load, last_error, info)
 
     **Features:**
-    - Compile + auto-type + auto-macro in one call (`quick_compile`)
-    - Aggregate UDFs receive FULL value table, enabling median, stddev, percentile, etc.
-    - GROUP BY support with per-group Lua invocation
-    - File-based persistence (`save`/`load`) with auto-restore on `LOAD`
-    - Lua→DuckDB callback (`_duckdb_call`) for SQL execution from Lua
-    - LIST, STRUCT, MAP type bridges between DuckDB and Lua
+    - **Auto-detection (v0.23)**: quick_compile probes the UDF (int/date/STRUCT/array)
+      and auto-generates the right scalar or batch macro — no manual style selection
+    - **Per-thread lua_State pool (P4)**: no global lock on Lua execution — DuckDB
+      parallelism → LuaJIT parallelism (~2.6× on 4 threads, CPU-bound UDFs)
+    - **trusted sandbox mode**: removes io/ffi/package/require/load*/debug, reduces os
+      (applies lazily per state, on/off across threads)
+    - **`_duckdb_query` bridge**: run SQL from Lua, get result sets as Lua tables
+    - **Embedded Fennel compiler** (`mode:='fennel'`): Lisp syntax (match patterns,
+      compile-time macros) compiled to Lua — zero runtime cost
+    - DATE/TIMESTAMP/DECIMAL/HUGEINT bridging (incl. int64/int128 decimal storage)
+    - GROUP BY aggregates with full value tables (median, stddev, percentile, …)
+    - GC64 build: no 2GB memory ceiling; ~1MB self-contained binary, zero runtime deps
+    - save/load persistence with multi-line source escaping
 
-    **Performance (500K rows, single-threaded):**
-    - `luajit_v` (batch): 4.9ms (~3.6× native SQL)
-    - `luajit_i` (row-by-row): 24.3ms (~18× native)
-    - Python UDF: >160s (~200,000× native)
-    - Note: shared Lua state serializes under parallel execution; single-thread only
+    **Performance (1M rows, 2 BIGINT args, `a*b+a`, 4 threads):**
+    - batch `luajit_vi`: 13ms; row `luajit_i`: 13ms (2.6× vs row+serial)
+    - single-thread: batch 18ms (1.9× row-mode 34ms)
 
-    **Design:**
-    - LuaJIT 2.1 self-contained (~700KB binary)
-    - Zero external dependencies at runtime
-    - MIT licensed
-    - ~1050 lines of C
-
-    **Platforms:** Linux x64/arm64, macOS x64/arm64, Windows (MSVC). WASM excluded
-    (LuaJIT requires GNU Make + GCC).
+    **Platforms:** Linux x64/arm64, Windows (MSVC), macOS x64/arm64. WASM and mingw/rtools
+    excluded (LuaJIT requires specific toolchains); linux_arm64 verified (v0.31, CI + arm64 runtime test).


### PR DESCRIPTION
Update extensions/luajit/description.yml to v0.31 (refs/tags/v0.31):

- **version 0.17 → 0.31**, ref → refs/tags/v0.31
- **Remove linux_arm64 from excluded_platforms** — LuaJIT 2.1 officially supports aarch64; v0.31 CI builds linux_arm64 successfully (ubuntu-24.04-arm runner), artifact verified at runtime: duckdb v1.5.5 arm64 in arm64v8/ubuntu container — luajit_s UDF results correct, 1M-iteration JIT loop correct
- description/docs synced with upstream master

Tested: CI linux_arm64 job success; artifact luajit-v1.5.5-extension-linux_arm64 (409KB) ran in arm64 container — compile OK, UDF correct, JIT OK.