### PR TITLE
[Raster] Update extension to v1.2.0

### DIFF
--- a/extensions/raster/description.yml
+++ b/extensions/raster/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: raster
   description: DuckDB extension for reading and writing geospatial raster data using SQL.
-  version: 1.1.0
+  version: 1.2.0
   language: C++
   build: cmake
   excluded_platforms: "windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads"
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: ahuarte47/duckdb-raster
-  ref: 5fb30ff6c4dae3a5189e918abc046bab95c9e60c
+  ref: 860f88d6a5bab2bf2f15ef8d743708a9d2228aab
 
 docs:
   hello_world: |


### PR DESCRIPTION
Changes:
* New options in the `RT_CubeStats` and  `RT_CubeStats_Agg` functions to calculate statistics for a specific band (0-based index) in a set of datacubes, but only for those valid (non-nodata) cells that fall within a geometry (**Zonal statistics**).
