### PR TITLE
Bump duckdb_mcp to v2.2.0

### DIFF
--- a/extensions/duckdb_mcp/description.yml
+++ b/extensions/duckdb_mcp/description.yml
@@ -1,16 +1,16 @@
 extension:
   name: duckdb_mcp
   description: Model Context Protocol (MCP) extension for DuckDB that enables seamless integration between SQL databases and MCP servers. Provides both client capabilities for accessing remote MCP resources via SQL and server capabilities for exposing database content as MCP resources.
-  version: 2.1.1
+  version: 2.2.0
   language: C++
   build: cmake
-  license: MIT
+  license: Apache-2.0
   requires_toolchains: ""
   maintainers:
     - teaguesterling
 repo:
   github: teaguesterling/duckdb_mcp
-  ref: faf20bdeb07013f46eda5f745bab87df5f2709ff
+  ref: 7db1650a1b4c04914ae724dd43244e690094ffc0
 
 docs:
   hello_world: |


### PR DESCRIPTION
Updates duckdb_mcp 2.1.1 → 2.2.0 (`7db1650a`). License field updated to Apache-2.0, matching the extension's relicense.

**v2.2.0 highlights:**
- **Fail-closed defaults**: command spawning and the file-read tool are now disabled unless explicitly enabled — the safe default for an MCP server embedded in a database.
- **Tool-parameter binding fix**: tools whose schema declares a property the SQL template doesn't reference no longer fail on every call (regression from the v2.0.0 move to prepared statements).
- Built against DuckDB v1.5.4 (v1.5-variegata toolchain); Windows CI re-enabled upstream.

Full notes: https://github.com/teaguesterling/duckdb_mcp/releases/tag/v2.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B32kWhs96dz7VnR9dYYAJy