### PR TITLE
chore: build celestial for duckdb v1.5.5

### DIFF
--- a/extensions/celestial/description.yml
+++ b/extensions/celestial/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: celestial
   description: Astronomical coordinates utilities
-  version: 0.2.0
+  version: 0.2.1
   language: C++
   build: cmake
   license: Apache-2.0
@@ -10,8 +10,8 @@ extension:
 
 repo:
   github: lisa-sgs/duckdb-celestial
-  ref: 152bd83e144dd743ef06aca6843164c744e1a7c0
-  andium: 152bd83e144dd743ef06aca6843164c744e1a7c0
+  ref: fcc3ab3615868d219ca4cff5c61e2db8a3c4beb0
+  andium: fcc3ab3615868d219ca4cff5c61e2db8a3c4beb0
 
 docs:
   hello_world: |


### PR DESCRIPTION
Not sure why the celestial extension was not built for duckdb v1.5.5.
I'm submitting this patch to trigger a build manually but I thought this was done automatically ? Is this because the extension does not build against main ?