### PR TITLE
Bump zim to v0.6.1

### DIFF
--- a/extensions/zim/description.yml
+++ b/extensions/zim/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: zim
   description: Read .zim (Kiwix / openZIM) archives directly in DuckDB via libzim, from local files or remote S3/HTTP — offline Wikipedia, WikiMed, Stack Exchange, iFixit, and more, with a zim:// filesystem and full-text search.
-  version: 0.6.0
+  version: 0.6.1
   language: C++
   build: cmake
   license: GPL-2.0-or-later
@@ -12,7 +12,7 @@ extension:
   vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
 repo:
   github: teaguesterling/duckdb_zim
-  ref: 1faa9a3502bf174edcbac5e3eeac1840afd83561
+  ref: 00bf53727b7e769f535bd6e0fc0e2166a041a890
 docs:
   hello_world: |
     -- Load the extension


### PR DESCRIPTION
Updates zim 0.6.0 → 0.6.1 (`00bf5372`, [release notes](https://github.com/teaguesterling/duckdb_zim/releases/tag/v0.6.1)).

Patch release: NULL named parameters (`max_results`, `result_offset`, `with_snippet`, `ignore_errors`) in `zim_search`/`zim_suggest` now raise a clean `BinderException` instead of tripping an internal assertion and aborting the query — NULLs arrive naturally from prepared-statement parameters and omitted MCP tool arguments. Plus parallel-scan hardening tests and a ThreadSanitizer CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B32kWhs96dz7VnR9dYYAJy