### PR TITLE
stats_duck: bump to v0.8.0

### DIFF
--- a/extensions/stats_duck/description.yml
+++ b/extensions/stats_duck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: stats_duck
   description: A statistical computing toolkit for DuckDB — descriptive statistics, hypothesis tests, R-style distribution functions (d/p/q/r), OLS regression with HC and cluster-robust standard errors, grammar-of-graphics charts (VISUALIZE → Vega-Lite), and first-class readers/writers for SAS, SPSS, and Stata files, all directly in SQL.
-  version: 0.7.0
+  version: 0.8.0
   language: C++
   build: cmake
   license: Apache-2.0
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: KoliStat/the-stats-duck
-  ref: 6572642cfb6ee9331998ee375a841601414efe28
+  ref: efdd24dec2a6616f825e9f14c2919a5754554827
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps stats_duck to the [v0.8.0 release](https://github.com/KoliStat/the-stats-duck/releases/tag/v0.8.0) (`efdd24dec2a6616f825e9f14c2919a5754554827`, the commit tag `v0.8.0` points at).

Highlights since 0.7.0: a VISUALIZE type-override fix (violin/density corruption), a new header-only optimization kernel (not SQL-exposed), docs. No build-config changes — same platforms as the current listing (`windows_amd64` included since #2198).

FYI: we verified this source builds green against DuckDB v1.5.5 locally (full test suite), so it should be safe through the next stable roll as well.