### PR TITLE
Bump scalarfs to v1.5.1 (enable Windows)

### DIFF
--- a/extensions/scalarfs/description.yml
+++ b/extensions/scalarfs/description.yml
@@ -10,8 +10,8 @@ extension:
 repo:
   github: teaguesterling/duckdb_scalarfs
   andium: 68faa6c72054123a6c6521dd41c12f929431da50
-  ref: refs/tags/v1.5.1
-  ref_next: 68faa6c72054123a6c6521dd41c12f929431da50
+  ref: 03a7d8e23178a2c9fcb3a16292dd60a23e059a8d
+  ref_next: 03a7d8e23178a2c9fcb3a16292dd60a23e059a8d
 docs:
   hello_world: |
     LOAD scalarfs;

--- a/extensions/scalarfs/description.yml
+++ b/extensions/scalarfs/description.yml
@@ -1,19 +1,16 @@
 extension:
   name: scalarfs
   description: A collection of virtual filesystems for working with scalars
-  version: 1.5.0
+  version: 1.5.1
   language: C++
   build: cmake
   license: MIT
-  # Windows excluded: duckdb's vendored fmt fails on the build runner's MSVC
-  # (stdext checked_array_iterator removed) -- upstream, not scalarfs.
-  excluded_platforms: "windows_amd64;windows_amd64_mingw"
   maintainers:
     - teaguesterling
 repo:
   github: teaguesterling/duckdb_scalarfs
   andium: 68faa6c72054123a6c6521dd41c12f929431da50
-  ref: 68faa6c72054123a6c6521dd41c12f929431da50
+  ref: refs/tags/v1.5.1
   ref_next: 68faa6c72054123a6c6521dd41c12f929431da50
 docs:
   hello_world: |


### PR DESCRIPTION
Updates scalarfs 1.5.0 → 1.5.1 ([release notes](https://github.com/teaguesterling/duckdb_scalarfs/releases/tag/v1.5.1)) and **enables Windows**.

The previous `excluded_platforms: windows_amd64;windows_amd64_mingw` was for DuckDB's vendored-fmt MSVC build failure (`stdext::checked_array_iterator` removed) — an upstream issue, now fixed in the v1.5.4 / v1.5-variegata toolchain the extension tracks. Both Windows targets build green in the extension's own CI. This resolves the `INSTALL scalarfs FROM community` HTTP 404 that Windows users hit (teaguesterling/duckdb_scalarfs#12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B32kWhs96dz7VnR9dYYAJy