### PR TITLE
luajit: bump to v0.31.1 — fix crash on batch UDF error paths

### DIFF
--- a/extensions/luajit/description.yml
+++ b/extensions/luajit/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: luajit
   description: "In-process LuaJIT UDFs for DuckDB — JIT-compiled, parallel (per-thread states), trusted sandbox, GROUP BY aggregates, LIST/STRUCT/MAP bridges, embedded Fennel compiler"
-  version: 0.31
+  version: 0.31.1
   language: C
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: alitrack/duckdb-luajit
-  ref: refs/tags/v0.31
+  ref: refs/tags/v0.31.1
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bump luajit to v0.31.1.

**Fix**: batch UDF executors (fjv/fjvi/fjvs) now invalidate output vector on error paths — previously an uninitialized vector was read as all-valid (NULL-free fast path), causing segfault / garbage values when a Lua UDF errored or returned a short table.

- version: 0.31.1
- ref: refs/tags/v0.31.1
- excluded_platforms unchanged

Own CI: all-green on v0.31.1 tag (SQLLogicTests + linux_amd64/arm64 + osx x2 + windows).