### PR TITLE
snowflake: bump to 0.5.2

### DIFF
--- a/extensions/snowflake/description.yml
+++ b/extensions/snowflake/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: snowflake
   description: Snowflake data source extension - query Snowflake databases directly from DuckDB
-  version: 0.5.1
+  version: 0.5.2
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: iqea-ai/duckdb-snowflake
-  ref: c4da4b52630c90bd6946ecc3ea106645a2a5dd0d
+  ref: b61f5ad827373db9a5614e5183c1477f601cc82c
 
 install_notes: |
   **Important:** This extension requires the ADBC Snowflake driver (a separate shared library) to function.


### PR DESCRIPTION
Bumps the snowflake extension to 0.5.2 (ref = the v0.5.2 tag commit).

Patch release on 0.5.1, two projection-correctness fixes in `snowflake_query()`:

- Statements beginning with a SQL comment crashed with `INTERNAL Error: Failed to cast ArrowTypeInfo`. The execution path was selected from the first token of the user's SQL, so a leading comment (dbt, BI tools, query routers prepend these routinely) made even a plain `SELECT` miss the projected-subquery path.
- Projecting one column out of a multi-column DDL/DML result returned a different column, silently — `SELECT output_bytes FROM snowflake_query('COPY INTO ...')` yielded `rows_unloaded`.

Release notes: https://github.com/iqea-ai/duckdb-snowflake/releases/tag/v0.5.2
No changes to install_notes or docs — driver setup is unchanged.
