### PR TITLE
mssql: update to v0.2.3

### DIFF
--- a/extensions/mssql/description.yml
+++ b/extensions/mssql/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: mssql
   description: "Connect DuckDB to Microsoft SQL Server via native TDS (including TLS)."
-  version: "0.2.2"
+  version: "0.2.3"
   language: "C++"
   build: "cmake"
   licence: "MIT"
@@ -20,37 +20,43 @@ extension:
 
 repo:
   github: "hugr-lab/mssql-extension"
-  ref: "v0.2.2"
+  ref: "v0.2.3"
 
 docs:
   hello_world: |
     INSTALL mssql FROM community;
     LOAD mssql;
-    ATTACH 'mssql://sa:YourStrong!Passw0rd@localhost:1433?database=master&use_encrypt=true' AS ms;
-    SELECT * FROM ms.dbo.table LIMIT 5;
+    ATTACH 'Server=localhost,1433;Database=master;User Id=sa;Password=YourStrong!Passw0rd' AS ms (TYPE mssql);
+    SELECT * FROM ms.dbo.your_table LIMIT 5;
 
   extended_description: |
-    The mssql extension provides a DuckDB connector for Microsoft SQL Server using the native TDS protocol.
+    DuckDB connector for Microsoft SQL Server, Azure SQL and Microsoft Fabric
+    over a native TDS 7.4 implementation — no ODBC, JDBC or FreeTDS required.
+    Attach a server as a DuckDB catalog and query, join, and bulk-load it
+    alongside your local data.
 
-    The extension is experimental and may not cover all edge cases. Please report any issues on the [GitHub repository](https://github.com/hugr-lab/mssql-extension).
+    Documentation: https://hugr-lab.github.io/mssql-extension/
 
-    Features:
-    - Native TDS protocol (no ODBC/JDBC required)
-    - Azure Entra ID authentication (Service Principal, CLI, Device Code, Environment Variables)
-    - Kerberos integrated authentication on POSIX (kinit / keytab / raw credentials) and Windows SSPI (current logon session via secur32.dll)
-    - Azure SQL Database and Microsoft Fabric support
-    - Lazy metadata loading for fast connections
-    - Schema, table, and view catalog integration
-    - Projection, filter, and ORDER BY pushdown
-    - TLS/SSL encrypted connections (encrypt parameter)
-    - INSERT support with RETURNING clause
-    - UPDATE and DELETE support (requires primary key)
-    - Per-catalog connection pooling with configurable limits
-    - Eager ATTACH-time credential validation (opt-out via lazy_validation true)
-    - Custom Application Name propagated to LOGIN7 program_name
-    - DuckDB secret management for credentials
-    - ANSI-compliant connections for DDL commands
-    - COPY TO for bulk data transfer via BCP protocol (SIMD-accelerated UTF-16 transcoding via simdutf)
-    - CREATE TABLE AS SELECT (CTAS) support
-    - Named SQL Server instance resolution via SQL Server Browser (UDP 1434)
-    - XML data type read/write support
+    **Reading.** Attached tables come with schema/table catalog integration,
+    lazy metadata cache, projection / filter / ORDER BY pushdown, and a
+    columnar batch-decoded result path. Reading UTF-8-collated columns skips
+    UTF-16 transcoding entirely (TDS UTF8SUPPORT).
+
+    **Writing.** COPY TO and CTAS ship over the BCP bulk-load protocol with a
+    columnar encoder and up to 8 parallel bulk sessions — about 6× faster
+    out of the box than 0.2.2 on a wide 38M-row table, and ~9× with sized
+    string targets (`MSSQL_VARCHAR(n)` / `MSSQL_NVARCHAR(n)` annotations or
+    `mssql_default_string_length`). Heap and clustered-columnstore targets
+    (rowgroups land compressed directly), TABLOCK decided from the target's
+    actual shape. INSERT with RETURNING, UPDATE/DELETE, transactions with
+    connection pinning.
+
+    **Authentication.** SQL logins, Azure Entra ID (Service Principal, CLI,
+    Device Code), Kerberos on POSIX (kinit/keytab), Windows SSPI, TLS,
+    DuckDB secrets.
+
+    **Operations.** Per-catalog connection pooling, eager ATTACH-time
+    credential validation, named-instance resolution via SQL Server Browser,
+    custom Application Name, XML type support.
+
+    Issues and feature requests: https://github.com/hugr-lab/mssql-extension


### PR DESCRIPTION
Updates the mssql extension to v0.2.3 and refreshes the description.

Release highlights ([release notes](https://github.com/hugr-lab/mssql-extension/blob/main/docs/release-notes/v0.2.3.md), [measured report](https://github.com/hugr-lab/mssql-extension/blob/main/test/bench/bench_results_v023_report.md)):

- Write path rebuilt: columnar BCP encoder + parallel bulk sessions — ~6× faster COPY/CTAS out of the box vs 0.2.2 on a wide 38M-row table, ~9× with sized string targets; clustered-columnstore targets land compressed rowgroups directly.
- Read path staged and batch-decoded; TDS UTF8SUPPORT (UTF-8 columns skip UTF-16 transcoding); default TDS packet size 4K→16K.
- Fixed: a segfault on bulk-writing dictionary-encoded input (any parquet/table source past ~1M rows on 0.2.2).
- Declared string types (`MSSQL_VARCHAR(n)` / `MSSQL_NVARCHAR(n)`), heap/columnstore table shapes, UTF-8 collations for created columns.
- New documentation site: https://hugr-lab.github.io/mssql-extension/

`vcpkg_commit` unchanged (matches the extension's builtin-baseline).