### PR TITLE
Bump duck_tails to v1.5.0 (enable Windows)

### DIFF
--- a/extensions/duck_tails/description.yml
+++ b/extensions/duck_tails/description.yml
@@ -1,17 +1,17 @@
 extension:
   name: duck_tails
   description: Smart Development Intelligence for DuckDB - Git-aware data analysis capabilities that allow querying git history, accessing files at any revision, and performing version-aware data analysis with SQL.
-  version: 1.4.2
+  version: 1.5.0
   language: C++
   build: cmake
   license: MIT
   requires_toolchains: vcpkg
-  excluded_platforms: wasm_mvp;wasm_eh;wasm_threads;windows_amd64;windows_amd64_mingw
+  excluded_platforms: wasm_mvp;wasm_eh;wasm_threads
   maintainers:
     - teaguesterling
 repo:
   github: teaguesterling/duck_tails
-  ref: db69b5579ccf46cab8208587e6a59f54cb5f224f
+  ref: refs/tags/v1.5.0
 
 docs:
   hello_world: |

--- a/extensions/duck_tails/description.yml
+++ b/extensions/duck_tails/description.yml
@@ -11,7 +11,7 @@ extension:
     - teaguesterling
 repo:
   github: teaguesterling/duck_tails
-  ref: refs/tags/v1.5.0
+  ref: aac04047feb111f087c416e488bb2625955b0d79
 
 docs:
   hello_world: |


### PR DESCRIPTION
Updates duck_tails 1.4.2 → 1.5.0 ([release notes](https://github.com/teaguesterling/duck_tails/releases/tag/v1.5.0)) and **enables Windows** (`windows_amd64`, `windows_amd64_mingw`).

The exclusion was for DuckDB's vendored-fmt MSVC build failure — fixed upstream in the v1.5.4 / v1.5-variegata toolchain this release builds against. Both Windows targets build **and pass the full test suite** in the extension's CI (the release also fixes a fixture-extraction bug that had prevented the test suite from running on Windows at all). WASM remains excluded: libgit2 has no wasm build.

Resolves the Windows `INSTALL` 404 users reported (teaguesterling/duck_tails#30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B32kWhs96dz7VnR9dYYAJy