### PR TITLE
luajit: bump to v0.32 (per-db UDF lifecycle registry)

### DIFF
--- a/extensions/luajit/description.yml
+++ b/extensions/luajit/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: luajit
   description: "In-process LuaJIT UDFs for DuckDB — JIT-compiled, parallel (per-thread states), trusted sandbox, GROUP BY aggregates, LIST/STRUCT/MAP bridges, embedded Fennel compiler"
-  version: 0.32
+  version: 0.32.1
   language: C
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: alitrack/duckdb-luajit
-  ref: refs/tags/v0.32
+  ref: refs/tags/v0.32.1
 
 docs:
   hello_world: |

--- a/extensions/luajit/description.yml
+++ b/extensions/luajit/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: luajit
   description: "In-process LuaJIT UDFs for DuckDB — JIT-compiled, parallel (per-thread states), trusted sandbox, GROUP BY aggregates, LIST/STRUCT/MAP bridges, embedded Fennel compiler"
-  version: 0.31.1
+  version: 0.32
   language: C
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: alitrack/duckdb-luajit
-  ref: refs/tags/v0.31.1
+  ref: refs/tags/v0.32
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bump luajit extension to v0.32.

**What's new in v0.32:**
- UDF lifecycle closed loop: registrations (compile / quick_compile / install / fennel / load) persist into a `luajit_udf_registry` table in the current database file; UDFs auto-restore on LOAD when reopening the same .db, and do NOT leak into other databases (each db has its own registry).
- `drop` / `reset` also clear the registry — no zombie UDFs after restart.
- `quick_compile` macros are catalog objects that persist with the db; their UDF source now persists in the registry too, so macros keep working after restart.
- Read-only databases silently skip persistence.
- Anonymous source expressions (`luajit_i('return x * 2', 21)` → 42) verified and documented in Quick Start.

Verified: own repo CI all green (6 platforms + sqllogictest).