### PR TITLE
[STAC]: Update extension to v0.2.0

### DIFF
--- a/extensions/stac/description.yml
+++ b/extensions/stac/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: stac
   description: DuckDB extension for reading data from SpatioTemporal Asset Catalogs (STAC) using SQL.
-  version: 0.1.0
+  version: 0.2.0
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: ahuarte47/duckdb-stac
-  ref: 2759131bfe73569e61b1cdc84d13c63bda753613
+  ref: 7c4a6f3874acab913c08db43c0cf8c651118f29c
 
 docs:
   hello_world: |


### PR DESCRIPTION
Changes:
* Support for STAC API - Filter Extension (https://github.com/stac-api-extensions/filter).
* Support for STAC API - Fields Extension (https://github.com/stac-api-extensions/fields).
* Support for STAC API - Sort Extension (https://github.com/stac-api-extensions/sort).
* Catch error message when the STAC API endpoint returns an error with content_type as JSON.
* Fix management of STAC API endpoints that require one collection at least to be specified.
* Fix performance of requests caching with the default TTL to 30 seconds.
* Fix recursive reading of the STAC catalog.
* Remove dependencies of LibXml, servers do not send XML responses.

