### PR TITLE
Bump anofox_forecast to v0.6.0

### DIFF
--- a/extensions/anofox_forecast/description.yml
+++ b/extensions/anofox_forecast/description.yml
@@ -10,4 +10,4 @@ extension:
     - sipemu
 repo:
   github: DataZooDE/anofox-forecast
-  ref: f43004a0fe746588ea143c89967623fcc0a3111c
+  ref: ebe4a822ae170d25f83ebef8c160ac297c015825


### PR DESCRIPTION
Bumps `anofox_forecast` to [`v0.6.0`](https://github.com/DataZooDE/anofox-forecast/releases/tag/v0.6.0).

Main change since the pinned ref: a small feedback banner shown once per day the first time the extension loads in an interactive terminal, pointing at the issue tracker and inviting a star. It is silent when stderr is not a TTY, in CI, and in notebooks, and can be turned off with `SET datazoo_banner = false;` or `DATAZOO_NO_BANNER=1`.

The tagged commit also adds per-platform smoke tests that install the built artifact into a stock DuckDB CLI, load it and call a real function on Linux, macOS and Windows.

CI was green on this tag in the source repository.