### PR TITLE
Bump anofox_scenario to v2026.08.07

### DIFF
--- a/extensions/anofox_scenario/description.yml
+++ b/extensions/anofox_scenario/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: DataZooDE/anofox-scenario
-  ref: ef43c760b1ea297d21b14b693044d29828a07ab6
+  ref: 7d2ca9b03ae82c8248a32d4d0ed6c4da8144c5ef
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps `anofox_scenario` to [`v2026.08.07`](https://github.com/DataZooDE/anofox-scenario/releases/tag/v2026.08.07).

Main change since the pinned ref: a small feedback banner shown once per day the first time the extension loads in an interactive terminal, pointing at the issue tracker and inviting a star. It is silent when stderr is not a TTY, in CI, and in notebooks, and can be turned off with `SET datazoo_banner = false;` or `DATAZOO_NO_BANNER=1`.

The tagged commit also adds per-platform smoke tests that install the built artifact into a stock DuckDB CLI, load it and call a real function on Linux, macOS and Windows.

CI was green on this tag in the source repository.