### PR TITLE
Bump anofox_similarity to v2026.08.07

### DIFF
--- a/extensions/anofox_similarity/description.yml
+++ b/extensions/anofox_similarity/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: DataZooDE/anofox-similarity
-  ref: 17ece448ca4a2d3a7d73c30dd8e53055478249bc
+  ref: a1f329752f2d80ca64a92713c6eac8ee9cfc664c
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps `anofox_similarity` to [`v2026.08.07`](https://github.com/DataZooDE/anofox-similarity/releases/tag/v2026.08.07).

Main change since the pinned ref: a small feedback banner shown once per day the first time the extension loads in an interactive terminal, pointing at the issue tracker and inviting a star. It is silent when stderr is not a TTY, in CI, and in notebooks, and can be turned off with `SET datazoo_banner = false;` or `DATAZOO_NO_BANNER=1`.

The tagged commit also adds per-platform smoke tests that install the built artifact into a stock DuckDB CLI, load it and call a real function on Linux, macOS and Windows.

CI was green on this tag in the source repository.