### PR TITLE
Bump anofox_tabfm to v2026.08.07

### DIFF
--- a/extensions/anofox_tabfm/description.yml
+++ b/extensions/anofox_tabfm/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: DataZooDE/anofox-tabfm
-  ref: 0c7f83ee8d94c0b4d9c520bd3b49edebb8c859bb
+  ref: bc6d8aff9b8c4c741113f476d09bb337ff85f386
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps `anofox_tabfm` to [`v2026.08.07`](https://github.com/DataZooDE/anofox-tabfm/releases/tag/v2026.08.07).

Main change since the pinned ref: a small feedback banner shown once per day the first time the extension loads in an interactive terminal, pointing at the issue tracker and inviting a star. It is silent when stderr is not a TTY, in CI, and in notebooks, and can be turned off with `SET datazoo_banner = false;` or `DATAZOO_NO_BANNER=1`.

The tagged commit also adds per-platform smoke tests that install the built artifact into a stock DuckDB CLI, load it and call a real function on Linux, macOS and Windows.

CI was green on this tag in the source repository.