### PR TITLE
Bump anofox_tabular to v2026.08.07

### DIFF
--- a/extensions/anofox_tabular/description.yml
+++ b/extensions/anofox_tabular/description.yml
@@ -9,4 +9,4 @@ extension:
     - jrosskopf
 repo:
   github: DataZooDE/anofox-tabular
-  ref: a9d45d1c6a0f0878fcf92c4aca1f2d51fa8b8979
+  ref: 53658d32f3c7e530f9e135640def86243102b824


### PR DESCRIPTION
Bumps `anofox_tabular` to [`v2026.08.07`](https://github.com/DataZooDE/anofox-tabular/releases/tag/v2026.08.07).

Main change since the pinned ref: a small feedback banner shown once per day the first time the extension loads in an interactive terminal, pointing at the issue tracker and inviting a star. It is silent when stderr is not a TTY, in CI, and in notebooks, and can be turned off with `SET datazoo_banner = false;` or `DATAZOO_NO_BANNER=1`.

The tagged commit also adds per-platform smoke tests that install the built artifact into a stock DuckDB CLI, load it and call a real function on Linux, macOS and Windows.

CI was green on this tag in the source repository.