### PR TITLE
Bump erpl_idoc to v2026.08.07

### DIFF
--- a/extensions/erpl_idoc/description.yml
+++ b/extensions/erpl_idoc/description.yml
@@ -10,4 +10,4 @@ extension:
     - jrosskopf
 repo:
   github: DataZooDE/erpl-idoc
-  ref: 932869fb8cc0a0d3612d428c19b0d05aa9cf9e72
+  ref: 215ddb6197406d1ecdf65e6daf161b60a76c6e71


### PR DESCRIPTION
Bumps `erpl_idoc` to [`v2026.08.07`](https://github.com/DataZooDE/erpl-idoc/releases/tag/v2026.08.07).

Main change since the pinned ref: a small feedback banner shown once per day the first time the extension loads in an interactive terminal, pointing at the issue tracker and inviting a star. It is silent when stderr is not a TTY, in CI, and in notebooks, and can be turned off with `SET datazoo_banner = false;` or `DATAZOO_NO_BANNER=1`.

The tagged commit also adds per-platform smoke tests that install the built artifact into a stock DuckDB CLI, load it and call a real function on Linux, macOS and Windows.

CI was green on this tag in the source repository.