### PR TITLE
Bump erpl_tunnel to v2026.08.07

### DIFF
--- a/extensions/erpl_tunnel/description.yml
+++ b/extensions/erpl_tunnel/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: erpl_tunnel
   description: Reach any TCP service from DuckDB through an SSH bastion, Tailscale or NetBird — and publish local ports back onto those networks.
-  version: 2026.07.30
+  version: 2026.08.07
   language: C++
   build: cmake
   license: BSL 1.1
@@ -12,4 +12,4 @@ extension:
 
 repo:
   github: DataZooDE/erpl-tunnel
-  ref: 94def6722e061ad915b6caa91e4a95226090131a
+  ref: 08750ac79a773fd8712c686c091f8ea89c94ceac


### PR DESCRIPTION
Bumps `erpl_tunnel` to [`v2026.08.07`](https://github.com/DataZooDE/erpl-tunnel/releases/tag/v2026.08.07).

Main change since the pinned ref: a small feedback banner shown once per day the first time the extension loads in an interactive terminal, pointing at the issue tracker and inviting a star. It is silent when stderr is not a TTY, in CI, and in notebooks, and can be turned off with `SET datazoo_banner = false;` or `DATAZOO_NO_BANNER=1`.

The tagged commit also adds per-platform smoke tests that install the built artifact into a stock DuckDB CLI, load it and call a real function on Linux, macOS and Windows.

CI was green on this tag in the source repository.