### PR TITLE
Bump gdrive to v2026.08.07

### DIFF
--- a/extensions/gdrive/description.yml
+++ b/extensions/gdrive/description.yml
@@ -16,7 +16,7 @@ extension:
 
 repo:
   github: DataZooDE/duckdb-gdrive
-  ref: 3dc834f02c8934dc2a3dbafb664d2f4a62157a6e
+  ref: e4d78a732f38225a9690e99828cc5c5e72a8a8d1
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps `gdrive` to [`v2026.08.07`](https://github.com/DataZooDE/duckdb-gdrive/releases/tag/v2026.08.07).

Main change since the pinned ref: a small feedback banner shown once per day the first time the extension loads in an interactive terminal, pointing at the issue tracker and inviting a star. It is silent when stderr is not a TTY, in CI, and in notebooks, and can be turned off with `SET datazoo_banner = false;` or `DATAZOO_NO_BANNER=1`.

The tagged commit also adds per-platform smoke tests that install the built artifact into a stock DuckDB CLI, load it and call a real function on Linux, macOS and Windows.

CI was green on this tag in the source repository.