### PR TITLE
Update dicom extension to 0.6.1

### DIFF
--- a/extensions/dicom/description.yml
+++ b/extensions/dicom/description.yml
@@ -2,7 +2,7 @@ extension:
   name: dicom
   description: |
     DuckDB integration with medical imaging data (DICOM - Digital Imaging and Communication in Medicine).
-  version: 0.5.0
+  version: 0.6.1
   language: C++
   build: cmake
   excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads"
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: nmontesg/duck-dicom
-  ref: v0.6.0
+  ref: v0.6.1
 
 docs:
   hello_world: |


### PR DESCRIPTION
This PR:
* Updates the `dicom` extension for DuckDB 1.5.5
* Changes the object store used for internal testing from MinIO to Garage