### PR TITLE
Bump erpl_web to v2026.08.10.1

### DIFF
--- a/extensions/erpl_web/description.yml
+++ b/extensions/erpl_web/description.yml
@@ -10,4 +10,4 @@ extension:
     - jrosskopf
 repo:
   github: DataZooDE/erpl-web
-  ref: cdecc5e716bf91ad19b9c11f0e3ab6d0c5fc84a0
+  ref: 86fc8d704931ebcc4422830c6700099c168ba8f2


### PR DESCRIPTION
Bumps `erpl_web` to [`v2026.08.10.1`](https://github.com/DataZooDE/erpl-web/releases/tag/v2026.08.10.1), the first release containing the feedback banner and the datazoo-oauth2 migration.

The banner is shown once per day the first time the extension loads in an interactive terminal, pointing at the issue tracker and inviting a star. It is silent when stderr is not a TTY, in CI and in notebooks, and can be turned off with `SET datazoo_banner = false;` or `DATAZOO_NO_BANNER=1`.

The tagged commit also adds per-platform smoke tests that install the built artifact into a stock DuckDB CLI, load it and call a real function on Linux, macOS and Windows.

CI green on the tag in the source repository, including all deploy jobs.