### PR TITLE
Bump quack_oauth to v2026.08.10

### DIFF
--- a/extensions/quack_oauth/description.yml
+++ b/extensions/quack_oauth/description.yml
@@ -10,4 +10,4 @@ extension:
     - jrosskopf
 repo:
   github: DataZooDE/quack-oauth
-  ref: 8e6621f53a9c39b8f30844d11a1c5c481528985e
+  ref: 0f30ca99ad34436e766c7aa550ef168e6eb4de8b


### PR DESCRIPTION
Bumps `quack_oauth` to [`v2026.08.10`](https://github.com/DataZooDE/quack-oauth/releases/tag/v2026.08.10), the first release containing the feedback banner.

The banner is shown once per day the first time the extension loads in an interactive terminal, pointing at the issue tracker and inviting a star. It is silent when stderr is not a TTY, in CI and in notebooks, and can be turned off with `SET datazoo_banner = false;` or `DATAZOO_NO_BANNER=1`.

The tagged commit also adds per-platform smoke tests that install the built artifact into a stock DuckDB CLI, load it and call a real function on Linux, macOS and Windows.

CI green on the tag in the source repository, including all deploy jobs.