### PR TITLE
Bump anofox_visualization to v0.1.0

### DIFF
--- a/extensions/anofox_visualization/description.yml
+++ b/extensions/anofox_visualization/description.yml
@@ -10,7 +10,7 @@ extension:
   requires_toolchains: rust
 repo:
   github: DataZooDE/anofox-visualization
-  ref: c9848dbc96350487e10b38986b4c7ea51dfce2b1
+  ref: d9aaf93fb80497c07e0586a1cccd3f2647dda964
 docs:
   hello_world: |
     -- One scalar plus convenience macros. Pass columns; get an SVG per group.


### PR DESCRIPTION
Bumps `anofox_visualization` to [`v0.1.0`](https://github.com/DataZooDE/anofox-visualization/releases/tag/v0.1.0) — the first tagged release of this extension. It was previously pinned to a bare commit on `main`.

`v0.1.0` matches the version already declared in the extension's `Cargo.toml`, its `Version()` fallback and its own descriptor.

New since the pinned commit: a small feedback banner shown once per day the first time the extension loads in an interactive terminal, pointing at the issue tracker and inviting a star. Silent when stderr is not a TTY, in CI and in notebooks; disable with `SET datazoo_banner = false;` or `DATAZOO_NO_BANNER=1`.

The distribution pipeline is green on this tag for Linux (amd64/arm64), macOS (x86_64/arm64) and Windows.