### PR TITLE
Bump RDF to 2.8.2

### DIFF
--- a/extensions/rdf/description.yml
+++ b/extensions/rdf/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: rdf
-  description: A DuckDB extension to read and write RDF
-  version: 2.8.1
+  description: Read and write RDF, query using SPARQL
+  version: 2.8.2
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: nonodename/duck_rdf
-  ref: 8d20bad15a216d08d932de1660a690d6e10a3d52
+  ref: 6e595d2527f3d7ec8e19ac49871ba4b47ff2cfb3
 
 docs:
   hello_world: |
@@ -41,6 +41,12 @@ docs:
              'https://query.wikidata.org/sparql',
              'SELECT (COUNT(*) AS ?count) WHERE { ?item wdt:P31 wd:Q5 .}'
          );
+
+    -- 8. Execute a SPARQL query using against DuckDB tables using an R2RML mapping
+    SELECT * FROM execute_sparql(
+             'PREFIX ex: <http://example.com/ns#> SELECT ?e ?name WHERE { ?e ex:name ?name }',
+             'full_r2rml_mapping.ttl'
+         );
     
   extended_description: |
     The `duck_rdf` extension enables DuckDB to read and write RDF (Resource Description Framework)
@@ -50,7 +56,7 @@ docs:
     ### Supported Formats
 
     **Read:** Turtle (`.ttl`), NTriples (`.nt`), NQuads (`.nq`), TriG (`.trig`), and
-    RDF/XML (`.rdf`/`.xml`, experimental — read-only).
+    RDF/XML (`.rdf`/`.xml`).
 
     **Write:** NTriples, Turtle, NQuads (via R2RML mapping).
 
@@ -82,7 +88,7 @@ docs:
     SQL domain, it is subject to memory limits which this function aims to avoid by doing two 
     passes on the RDF, the first profiling the shape of the data using `profile_rdf()`.
 
-    The experimental `read_sparql(endpoint, query)` sends a SPARQL SELECT query to a remote 
+    The `read_sparql(endpoint, query)` function sends a SPARQL SELECT query to a remote 
     endpoint and returns the result set as a DuckDB table. Column names are derived from the 
     SPARQL variable names; all columns are VARCHAR. Unbound variables are returned as empty strings.
 
@@ -93,6 +99,15 @@ docs:
                 'SELECT (COUNT(*) AS ?count) WHERE {   ?item wdt:P31 wd:Q5 .}'
             );
     ```
+
+    You can also execute a SPARQL 1.1 query `execute_sparql(query, mapping)` against DuckDB tables 
+    using an R2RML mapping file to define the mapping between relational data and RDF. The SPARQL 
+    query is converted to SQL at query time using a rules based optimzer The function returns the 
+    result set as a DuckDB table. A good subset of SPARQL is supported. For more information see
+    the [docs](https://github.com/nonodename/duck_rdf/blob/main/docs/sparql.md).
+
+    To see the query that would be run, use `sparql_to_sql(sparql, mapping)`.
+
     ### Writing RDF (R2RML)
 
     Write RDF using [R2RML](https://www.w3.org/TR/r2rml/) mapping files with DuckDB's `COPY TO`


### PR DESCRIPTION
- Lots of performance improvements to SPARQL support
- Bump to Duck 1.5.5
- Native type support in SPARQL
- Full property path support for SPARQL
