### PR TITLE
Bump datadog to 0.2.0

### DIFF
--- a/extensions/datadog/description.yml
+++ b/extensions/datadog/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: datadog
   description: Read logs from the Datadog Logs Search API into OTLP-shaped tables
-  version: 0.1.0
+  version: 0.2.0
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: smithclay/duckdb-datadog
-  ref: 81c7c2fb0a93a7bc46d925e543e53c640d072767
+  ref: aaf234fda701d1c4dffb75c3b9aa25a1ce32e9f9
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary

- bump the Datadog community extension from 0.1.0 to 0.2.0
- pin the descriptor to the latest merged default-branch commit

## Impact

The community build now includes the current Datadog extension functionality, including metrics, service maps, log aggregation, and trace read/write support.

## Validation

- rebased onto the latest duckdb/community-extensions main
- passed scripts/build.py descriptor parsing for DuckDB v1.5.5
- pinned extension commit has a green native and WASM build matrix
