### PR TITLE
Bump splunk to 0.2.0

### DIFF
--- a/extensions/splunk/description.yml
+++ b/extensions/splunk/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: splunk
   description: Read logs from a Splunk search REST API into OTLP-shaped tables
-  version: 0.1.0
+  version: 0.2.0
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: smithclay/duckdb-splunk
-  ref: 636b92030562f5c1e4a4b9d1aacd66f69ced0b6d
+  ref: 1c69eeecba53c63b0e1f5eb07c7933757daf1355
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary

- bump the Splunk community extension from 0.1.0 to 0.2.0
- pin the descriptor to the latest merged default-branch commit

## Impact

The community build now includes the current Splunk catalog and DuckDB 1.5.5/WASM compatibility work.

## Validation

- rebased onto the latest duckdb/community-extensions main
- passed scripts/build.py descriptor parsing for DuckDB v1.5.5
- pinned extension commit has a green native and WASM build matrix
