### PR TITLE
Bump otlp to 0.6.1

### DIFF
--- a/extensions/otlp/description.yml
+++ b/extensions/otlp/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: otlp
   description: Query OpenTelemetry traces, logs, and metrics with SQL — or stream live OTLP/HTTP into DuckDB, DuckLake, or Iceberg
-  version: 0.6.0
+  version: 0.6.1
   language: C++
   build: cmake
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: smithclay/duckdb-otlp
-  ref: 5f32698962567b9e30bf79746b166e89543bffb0
+  ref: 8e627d8e45637316f14ad5e62493ad754b8c34a1
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary

- bump the OTLP community extension from 0.6.0 to 0.6.1
- pin the descriptor to the latest merged default-branch commit

## Why

The new ref updates duckdb-otlp to DuckDB 1.5.5 while preserving the existing extension API and community platform exclusions.

## Impact

Community builds will use the current DuckDB 1.5.5-compatible OTLP source for file readers and native live ingest.

## Validation

- rebased onto the latest duckdb/community-extensions main
- passed scripts/build.py descriptor parsing for DuckDB v1.5.5
- verified successful upstream builds for the supported community platforms
