### PR TITLE
Bump duck_block_utils to 1.5.0

### DIFF
--- a/extensions/duck_block_utils/description.yml
+++ b/extensions/duck_block_utils/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duck_block_utils
   description: Build, transform, validate, and extract content from structured documents using the duck_block type
-  version: 1.4.0
+  version: 1.5.0
   language: C++
   build: cmake
   license: MIT
@@ -13,7 +13,7 @@ repo:
   # v1.4.0 targets a v1.5.x tree (dropped v1.4.x support) and is not built-verified
   # against v1.4.5. v1.4.5 users should move to the v1.5.x track.
   andium: 125662df9e5450105dc9b7957ad955cb53d7beec
-  ref: refs/tags/v1.4.0
+  ref: 0263b0efa01d3a05f8fc9841e1bc21fc21602aa1
 docs:
   hello_world: |
     -- Build a document programmatically


### PR DESCRIPTION
Bumps `duck_block_utils` to [v1.5.0](https://github.com/teaguesterling/duckdb_duck_block_utils/releases/tag/v1.5.0), pinned to commit `0263b0efa01d3a05f8fc9841e1bc21fc21602aa1`.

Two fixes, both about inline elements:

- **`db_blocks_headings` / `db_blocks_toc` returned empty titles** for headings whose text lives in `kind='inline'` children rather than `content` — which is what `webbed` emits for any heading containing `<code>`, `<em>` or `<a>`. Those headings silently disappeared from a table of contents. All three extractors now fall back to the inline-children run, as the duck_blocks spec already required consumers to do.
- **`pandoc_ast_to_blocks` dropped `Code` and `Math` inlines entirely** — silent data loss, not a styling difference. `` Run `make install` first. `` became `Run  first.` in every pandoc-routed format. Fixing it also recovered Link child inlines and Image alt inlines, which the inline flattener had been discarding.

571 assertions across 10 test cases, of which 541 are pre-existing and pass unchanged. CI green on the source branch before merge.

The `ref` moves from `refs/tags/v1.4.0` to the commit id, per the guidance to pin commits rather than tag names.