### PR TITLE
Bump zim to 0.6.2

### DIFF
--- a/extensions/zim/description.yml
+++ b/extensions/zim/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: zim
   description: Read .zim (Kiwix / openZIM) archives directly in DuckDB via libzim, from local files or remote S3/HTTP — offline Wikipedia, WikiMed, Stack Exchange, iFixit, and more, with a zim:// filesystem and full-text search.
-  version: 0.6.1
+  version: 0.6.2
   language: C++
   build: cmake
   license: GPL-2.0-or-later
@@ -12,7 +12,7 @@ extension:
   vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
 repo:
   github: teaguesterling/duckdb_zim
-  ref: 00bf53727b7e769f535bd6e0fc0e2166a041a890
+  ref: 3101ee81a99197ef344d70e8a8b4ec3beec75182
 docs:
   hello_world: |
     -- Load the extension


### PR DESCRIPTION
Bumps `zim` to [v0.6.2](https://github.com/teaguesterling/duckdb_zim/releases/tag/v0.6.2), pinned to commit `3101ee81a99197ef344d70e8a8b4ec3beec75182`.

Fixes a wrong-results bug: **`read_zim` advertised filter pushdown but silently discarded any filter it did not implement**, returning every row in the archive with no error.

`ApplyPushedFilters` handled only equality and `IN`. A predicate like `mimetype LIKE 'image/%'` is rewritten to a range comparison and reported fully pushed, at which point the optimizer removes it from the plan — so nothing applied it. Against a 5166-entry archive that query returned all 5166 rows instead of 108, including rows whose `mimetype` is NULL and therefore cannot satisfy the predicate under any correct evaluation.

The flaw was not specific to `mimetype`; `path`, `title`, `size` and `redirect_path` filters were all being dropped the same way. Pushed filters are now rebuilt as a bound expression and evaluated per chunk, and anything unmappable raises rather than being skipped.

318 assertions across 15 test cases, up from 294. Verified row-level rather than by count, identical at 1/4/8 threads, thread sanitizer green, and the new regression test was confirmed to fail without the fix.