### PR TITLE
anndata: update to v0.14.5

### DIFF
--- a/extensions/anndata/description.yml
+++ b/extensions/anndata/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: anndata
   description: Read AnnData (.h5ad) files for single-cell genomics data analysis, with support for local and remote (HTTP/HTTPS/S3) files
-  version: 0.14.3
+  version: 0.14.4
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: honicky/anndata-duckdb-extension
-  ref: 82b6f746ab56e39f2c69f607c1e43917ae6f0884
+  ref: 36de05af16af9f0c503d856fa5a914a5f2fbe227
 
 docs:
   hello_world: |

--- a/extensions/anndata/description.yml
+++ b/extensions/anndata/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: anndata
   description: Read AnnData (.h5ad) files for single-cell genomics data analysis, with support for local and remote (HTTP/HTTPS/S3) files
-  version: 0.14.4
+  version: 0.14.5
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: honicky/anndata-duckdb-extension
-  ref: 36de05af16af9f0c503d856fa5a914a5f2fbe227
+  ref: 283a556a3258f251a45691b5df64940a161d0eb5
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps the `anndata` extension from **0.14.3 → 0.14.5**, with `ref` pinned to the `v0.14.5` release tag (`283a556a3258f251a45691b5df64940a161d0eb5`).

> **Note:** this PR originally targeted 0.14.4 and has been retargeted to 0.14.5, which supersedes it — same fix, plus DuckDB v1.5.5 support. The descriptor diff is still two lines.

### Why it matters for the build

The `v0.14.3` ref currently pinned here no longer builds on `linux_amd64_musl` or `linux_arm64`. vcpkg's `hdf5` port enables its `szip` feature by default, which pulls in `libaec`, and the `libaec` portfile at our pinned registry baseline downloads its source tarball from `gitlab.dkrz.de` — a host that began returning HTTP 429 to GitHub Actions runner IP ranges around 2026-07-29:

```
Downloading https://gitlab.dkrz.de/k202009/libaec/-/archive/v1.1.3/libaec-v1.1.3.tar.gz
error: curl: (22) The requested URL returned error: 429
error: building libaec:x64-linux-release failed with: BUILD_FAILED
```

Only those two arches are affected, because they get no hits from the read-only vcpkg binary cache and therefore build `libaec` from source rather than restoring it.

**0.14.4** fixed this by vendoring a `libaec` overlay port — a verbatim copy of microsoft/vcpkg's own fix, which moved the source to the `Deutsches-Klimarechenzentrum/libaec` GitHub mirror. Overlay ports take precedence over the registry baseline, so exactly one port changes and every other dependency version is untouched.

**0.14.5** additionally targets **DuckDB v1.5.5** (up from v1.5.4). No source changes were needed — v1.5.5 is a patch release and touches none of the DuckDB internals this extension binds to.

### Verification

Full 10-arch matrix green on the `v0.14.5` tag, including both previously-failing arches and all deploy jobs:

```
linux_amd64 · linux_amd64_musl · linux_arm64
osx_amd64 · osx_arm64
windows_amd64 · windows_amd64_mingw
wasm_mvp · wasm_eh · wasm_threads
```

```
linux_amd64_musl   libaec:x64-linux-release@1.1.7#1
linux_arm64        libaec:arm64-linux-release@1.1.7#1
both               Downloading https://github.com/Deutsches-Klimarechenzentrum/libaec/…
```

Only `version` and `ref` change in the descriptor. Maintainer: @honicky.
