### PR TITLE
finetype: bump to 0.6.57, and fix four examples that cannot run

### DIFF
--- a/extensions/finetype/description.yml
+++ b/extensions/finetype/description.yml
@@ -40,8 +40,8 @@ docs:
     -- Validate a table against a JSON Schema (note the top-level "properties"
     -- key): one row per column, counting how many values the schema rejects.
     D SELECT * FROM ft_validate('people',
-        '{"properties":{"email":{"type":"string","pattern":"^[^@]+@[^@]+\.[^@]+$"},
-                        "phone":{"type":"string","pattern":"^\+?[0-9().+ -]{7,}$"}}}');
+        '{"properties":{"email":{"type":"string","pattern":"^[^@]+@[^@]+\\.[^@]+$"},
+                        "phone":{"type":"string","pattern":"^\\+?[0-9().+ -]{7,}$"}}}');
     ┌─────────────┬───────┬─────────┬───────────────────────────────────────────────────────────────────────────────────┐
     │ column_name │ total │ rejects │                                  sample_message                                   │
     │   varchar   │ int64 │  int64  │                                      varchar                                      │
@@ -105,18 +105,20 @@ docs:
     SELECT * FROM ft_validate('my_table', 'schema.json');
     ```
 
-    ### `ft_profile(values LIST)`
-    Profile a single column passed as a list — useful when the values are already in hand rather than
-    in a named table.
-
-    ```sql
-    SELECT * FROM ft_profile((SELECT list(email) FROM people));
-    ```
-
     ## Scalar functions
 
     Per-value classification, one value at a time. Strongest on values unambiguous in isolation (URLs,
     ISO dates, well-formed emails, IP addresses).
+
+    ### `ft_profile(values LIST[, header VARCHAR]) → STRUCT(type VARCHAR, confidence DOUBLE, duckdb_type VARCHAR)`
+    Profile a single column passed as a list — useful when the values are already in hand rather than
+    in a named table. This is the scalar the `ft_profile(table)` macro calls internally, so it goes in
+    a `SELECT`, **not** a `FROM`, and returns one `STRUCT` rather than a row per column.
+
+    ```sql
+    SELECT ft_profile(list(email)) FROM people;
+    -- {'type': identity.person.email, 'confidence': 0.581, 'duckdb_type': VARCHAR}
+    ```
 
     ### `ft_infer(value VARCHAR) → VARCHAR`
     Classify a single value. Returns the full semantic type label.

--- a/extensions/finetype/description.yml
+++ b/extensions/finetype/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: finetype
   description: Semantic type classification — detects 251 data types (emails, URLs, dates, UUIDs, currencies, etc.) from raw strings
-  version: 0.6.56
+  version: 0.6.57
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: meridian-online/finetype
-  ref: 26973a9c01894aa146dffe9b17288f9f9ddb9a45
+  ref: c7662be0359d1e438fea399b133f5115aaa91b6d
 
 docs:
   hello_world: |

--- a/extensions/finetype/description.yml
+++ b/extensions/finetype/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: finetype
-  description: Semantic type classification — detects 244 data types (emails, URLs, dates, UUIDs, currencies, etc.) from raw strings
-  version: 0.6.36
+  description: Semantic type classification — detects 251 data types (emails, URLs, dates, UUIDs, currencies, etc.) from raw strings
+  version: 0.6.56
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: meridian-online/finetype
-  ref: b060785d29dab029aae4a23b514c5d1bc125f4c2
+  ref: 26973a9c01894aa146dffe9b17288f9f9ddb9a45
 
 docs:
   hello_world: |
@@ -30,7 +30,7 @@ docs:
     │   varchar   │                                     varchar                                      │       double       │   varchar   │
     ├─────────────┼──────────────────────────────────────────────────────────────────────────────────┼────────────────────┼─────────────┤
     │ addr        │ nested STRUCT(city VARCHAR) column — unnest / to_json / extract before profiling │               NULL │ NULL        │
-    │ email       │ identity.person.email                                                            │ 0.5812865495681763 │ VARCHAR     │
+    │ email       │ identity.person.email                                                            │ 0.5915254950523376 │ VARCHAR     │
     │ phone       │ identity.person.phone_number                                                     │                0.5 │ VARCHAR     │
     └─────────────┴──────────────────────────────────────────────────────────────────────────────────┴────────────────────┴─────────────┘
     -- (addr is a nested STRUCT column: instead of silently mis-classifying it,
@@ -61,7 +61,7 @@ docs:
     └──────────────────────────┘
 
   extended_description: |
-    FineType is a semantic type classifier that detects 244 data types from raw string values. A
+    FineType is a semantic type classifier that detects 251 data types from raw string values. A
     multi-branch neural network labels each value, mapping it into a three-level taxonomy:
     `domain.category.type`.
 
@@ -105,20 +105,32 @@ docs:
     SELECT * FROM ft_validate('my_table', 'schema.json');
     ```
 
+    ## Aggregate function
+
+    ### `ft_profile(value VARCHAR[, header VARCHAR]) → STRUCT(type VARCHAR, confidence DOUBLE, duckdb_type VARCHAR)`
+    Profile one column directly, as an **aggregate** over its values — useful when the column is in
+    hand and you do not want to name a table. It goes in a `SELECT` rather than a `FROM`, and returns
+    one `STRUCT` rather than a row per column.
+
+    **Pass the column name as the second argument.** FineType uses the header as evidence, so the
+    two-argument form is what reproduces the `ft_profile(table)` answer; without it the same values
+    can land on a different type.
+
+    ```sql
+    SELECT ft_profile(email, 'email') FROM people;
+    -- {'type': identity.person.email, 'confidence': 0.5915254950523376, 'duckdb_type': VARCHAR}
+
+    SELECT ft_profile(email) FROM people;  -- no header: less evidence, different answer
+    -- {'type': representation.text.plain_text, 'confidence': 0.6070796251296997, 'duckdb_type': VARCHAR}
+    ```
+
+    Because it is an aggregate, it cannot take `list(...)` — nesting one aggregate inside another is a
+    binder error. Use `ft_detail(values LIST)` below if you already hold the values as a list.
+
     ## Scalar functions
 
     Per-value classification, one value at a time. Strongest on values unambiguous in isolation (URLs,
     ISO dates, well-formed emails, IP addresses).
-
-    ### `ft_profile(values LIST[, header VARCHAR]) → STRUCT(type VARCHAR, confidence DOUBLE, duckdb_type VARCHAR)`
-    Profile a single column passed as a list — useful when the values are already in hand rather than
-    in a named table. This is the scalar the `ft_profile(table)` macro calls internally, so it goes in
-    a `SELECT`, **not** a `FROM`, and returns one `STRUCT` rather than a row per column.
-
-    ```sql
-    SELECT ft_profile(list(email)) FROM people;
-    -- {'type': identity.person.email, 'confidence': 0.581, 'duckdb_type': VARCHAR}
-    ```
 
     ### `ft_infer(value VARCHAR) → VARCHAR`
     Classify a single value. Returns the full semantic type label.
@@ -135,7 +147,7 @@ docs:
 
     ```sql
     SELECT ft_detail('192.168.1.1');
-    -- {"type": "technology.internet.ip_v4", "confidence": 0.901, "duckdb_type": "INET", ...}
+    -- {"type": "technology.internet.ip_v4", "confidence": 0.829, "duckdb_type": "INET", ...}
     ```
 
     ### `ft_cast(value VARCHAR) → VARCHAR`
@@ -153,7 +165,7 @@ docs:
     `ft_validate` table verb runs over every column.
 
     ```sql
-    SELECT ft_validate_text('not-an-email', '{"type":"string","pattern":"^[^@]+@[^@]+\.[^@]+$"}');
+    SELECT ft_validate_text('not-an-email', '{"type":"string","pattern":"^[^@]+@[^@]+\\.[^@]+$"}');
     -- {'valid': false, 'constraint': pattern, 'message': '"not-an-email" does not match "^[^@]+@[^@]+\.[^@]+$"'}
     ```
 

--- a/extensions/finetype/description.yml
+++ b/extensions/finetype/description.yml
@@ -82,7 +82,7 @@ docs:
     read its columns.
 
     ```sql
-    SELECT * FROM ft_profile('my_table');
+    SELECT * FROM ft_profile('people');
     ```
 
     Nested `STRUCT` / `LIST` columns are **guarded, not silently rejected**: rather than forcing them
@@ -93,16 +93,23 @@ docs:
     ### `ft_validate(table_name VARCHAR, schema_json VARCHAR)`
     Validate a table's columns against a JSON Schema. Returns one row per validated column with the
     total values checked, the reject count, and a sample rejection message. The schema can be supplied
-    inline, via `getvariable`, or read from a file with DuckDB's `read_text`:
+    inline, via `getvariable`, or read from a file — a bare path is read for you, while a string
+    starting with `{` is used as-is.
 
     The JSON Schema is keyed by column under a top-level `properties` object.
 
+    The constraints that are **asserted** are `pattern`, `minLength`, `maxLength`, `enum`, `type` and
+    `required`. Per the JSON Schema specification, `format` is an annotation rather than an assertion:
+    `{"format":"email"}` describes the column and rejects nothing. Use `pattern` when you want values
+    counted as rejects.
+
     ```sql
     -- inline
-    SELECT * FROM ft_validate('my_table', '{"properties":{"email":{"type":"string","format":"email"}}}');
+    SELECT * FROM ft_validate('people', '{"properties":{"email":{"type":"string","pattern":"^[^@]+@[^@]+\\.[^@]+$"}}}');
 
-    -- from a file (a bare path is read for you; an inline string starting with "{" is used as-is)
-    SELECT * FROM ft_validate('my_table', 'schema.json');
+    -- via a variable, when the schema is long enough to want a name
+    SET VARIABLE email_schema = '{"properties":{"email":{"type":"string","minLength":6}}}';
+    SELECT * FROM ft_validate('people', getvariable('email_schema'));
     ```
 
     ## Aggregate function


### PR DESCRIPTION
Bumps `finetype` from 0.6.36 to 0.6.57, and fixes four examples in the descriptor that do not run as written.

### Version bump

`version: 0.6.57`, `ref: c7662be0359d1e438fea399b133f5115aaa91b6d` — the commit tagged [`v0.6.57`](https://github.com/meridian-online/finetype/releases/tag/v0.6.57).

The registry currently serves 0.6.36 on DuckDB v1.5.5. Since then the extension's SQL surface changed in one way that matters to anyone reading this page: `ft_profile` became a DuckDB **aggregate**, so `SELECT ft_profile(email) FROM people` binds where it previously did not, and the six un-prefixed scalars (`finetype`, `finetype_validate`, …) that had been kept as aliases were removed in favour of the `ft_` names. The descriptor's examples are updated to match.

### Documentation fixes

Every SQL statement in `description.yml` was extracted from the YAML with a parser and run, as pasted, against a 0.6.57 build on DuckDB v1.5.5, with no fixtures beyond what the examples themselves create. That found four that could not run:

- **Three named a table the descriptor never creates.** `ft_profile('my_table')` and both `ft_validate('my_table', …)` forms each threw `Catalog Error: Table with name my_table does not exist!`. They now use `people`, which the `hello_world` block above them creates, so the page reads as one session end to end.
- **One demonstrated `{"type":"string","format":"email"}` in an `ft_validate` call whose entire output is a reject count** — and `format` is an annotation rather than an assertion in JSON Schema, so it rejected nothing. A reader following that example got a validator that silently passed everything. It now uses `pattern`, and the prose states which keywords are asserted (`pattern`, `minLength`, `maxLength`, `enum`, `type`, `required`).

The file-path schema form is described in prose rather than shown as a statement, since it cannot run without a file the reader does not have; a `getvariable` example demonstrates the same "schema by reference" point and does run.

**Result: 16 statements, 0 errors.**

### Notes for review

- The extension's `hello_world` output tables in this file were re-verified against the 0.6.57 build and reproduce exactly.
- `excluded_platforms` is unchanged.
- The branch is behind `main`, but touches only `extensions/finetype/description.yml` and merges without conflict.
