### PR TITLE
Add rocket

### DIFF
--- a/extensions/rocket/description.yml
+++ b/extensions/rocket/description.yml
@@ -1,0 +1,74 @@
+extension:
+  name: rocket
+  description: ROCKET random convolutional kernel features for time-series classification
+  version: 0.1.0
+  language: C++
+  build: cmake
+  license: MIT
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads"
+  maintainers:
+    - maxdemarzi
+
+repo:
+  github: maxdemarzi/duckdb-rocket
+  ref: e325474a7cab58bc11a30ebba61604002cb8fe55
+
+docs:
+  hello_world: |
+    -- 250 kernels produce 500 features: element 2i is kernel i's global max,
+    -- 2i+1 its proportion of positive values.
+    SELECT rocket_transform(values, 250, 0, 0) AS features FROM series;
+
+    -- Kernel i is a pure function of (seed, i), so a group of kernels is addressable
+    -- without generating the groups before it. These are the same kernels:
+    SELECT rocket_transform(s, 4, 7, 4) = rocket_transform(s, 8, 7, 0)[9:16];
+    -- true
+
+    -- Multivariate: outer list channels, inner list timepoints. Still 2 features
+    -- per kernel -- the selected channels are summed inside one convolution.
+    SELECT rocket_transform(channels, 250, 0, 0) FROM multivariate_series;
+
+    -- Variable-length: pass an explicit reference length so every row shares one
+    -- kernel bank. Without it each row draws its own, and column j stops meaning
+    -- the same thing across rows.
+    SELECT rocket_transform(values, 250, 0, 0, 64) FROM ragged_series;
+
+  extended_description: |
+    `rocket_transform` implements ROCKET (Dempster, Petitjean & Webb, 2020): it convolves a
+    series with random kernels of random length, dilation, padding and bias, and reduces each
+    kernel's response to two features — the global maximum and the proportion of positive
+    values. No training is involved, so there is no model to fit or store.
+
+    ```
+    rocket_transform(series DOUBLE[], kernels_per_group BIGINT, seed BIGINT, first_kernel BIGINT)
+      -> DOUBLE[]
+    ```
+
+    Features are interleaved: element `2i` is kernel `i`'s max and `2i+1` its PPV.
+
+    `first_kernel` selects a contiguous slice of one conceptual kernel bank. Kernel `i` is a
+    pure function of `(seed, i)` — derived through SplitMix64 used as a splittable seed source —
+    so group `g` can be generated without generating groups `0..g-1`, and kernels can be fanned
+    across threads with no shared generator state. This is what makes it practical to split a
+    10,000-kernel bank into groups narrow enough for a downstream classifier's per-estimator
+    feature budget.
+
+    Multivariate series go in as `DOUBLE[][]` (channels of timepoints). Each kernel draws a
+    random subset of channels with independent weights per channel and still produces exactly
+    two features, because the selected channels are summed inside a single convolution. A
+    one-channel series produces byte-identical kernels through either overload.
+
+    For variable-length data, pass an explicit reference length as a fifth argument. Kernel
+    weights do not depend on series length but dilation and padding do, so without it each row
+    draws its own kernel bank and the columns stop being comparable across rows. Note also that
+    the max feature is biased upward by series length while PPV is not — if length correlates
+    with the label, half the features carry that correlation.
+
+    The pseudo-random stream is specified byte-for-byte in the project's SPEC.md, and the
+    extension is validated against golden vectors emitted by an independent Python
+    implementation: maximum absolute difference 1.8e-15, with PPV differences of exactly zero.
+
+    The intended use is composition with a tabular foundation model — for example
+    `anofox_tabfm`'s `tabfm_classify` — to classify time series without training anything:
+    features go in as columns, class probabilities come back, and probabilities are averaged
+    across kernel groups.

--- a/extensions/rocket/description.yml
+++ b/extensions/rocket/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: maxdemarzi/duckdb-rocket
-  ref: e325474a7cab58bc11a30ebba61604002cb8fe55
+  ref: c33d6b1a109e0ba9abf1722ad3fa424b79d31d86
 
 docs:
   hello_world: |

--- a/extensions/rocket/description.yml
+++ b/extensions/rocket/description.yml
@@ -5,7 +5,6 @@ extension:
   language: C++
   build: cmake
   license: MIT
-  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads"
   maintainers:
     - maxdemarzi
 


### PR DESCRIPTION
Adds `rocket` — ROCKET (Dempster, Petitjean & Webb, 2020) random convolutional kernel features for time-series classification, as a scalar function.

```sql
SELECT rocket_transform(values, 250, 0, 0) AS features FROM series;
```

Convolves a series with random kernels of random length, dilation, padding and bias, reducing each kernel's response to two features — the global maximum and the proportion of positive values. Nothing is trained, so there is no model to fit or store.

### What is distinctive

Kernel `i` is a pure function of `(seed, i)`, derived through SplitMix64 used as a splittable seed source. So a caller can generate group `g` of a conceptual kernel bank without generating groups `0..g-1`:

```sql
SELECT rocket_transform(s, 4, 7, 4) = rocket_transform(s, 8, 7, 0)[9:16];  -- true
```

That is what makes it practical to split a 10,000-kernel bank into groups narrow enough for a downstream classifier's per-estimator feature budget, and it means kernels can be fanned across threads with no shared generator state.

Multivariate series (`DOUBLE[][]`, channels of timepoints) are supported; each kernel draws a random channel subset and still emits exactly two features, because the selected channels are summed inside one convolution. A one-channel series produces byte-identical kernels through either overload.

### Correctness

The pseudo-random stream is specified byte-for-byte in the project's `SPEC.md`, and the extension is validated against golden vectors emitted by an independent Python implementation: **max absolute difference 1.8e-15, PPV differences exactly 0**. The same conformance check runs on Linux/gcc and Windows/MSVC and reproduces to the same figure, so the spec is portable rather than accidentally shaped by one toolchain.

End to end, it has been run over a ten-dataset UCR subset composed with a tabular foundation model (`anofox_tabfm`), reproducing each dataset's reference accuracy exactly across two machines and two operating systems.

### Notes

- `excluded_platforms` omits the wasm targets.
- `ref` is pinned to a commit on `main`.

Thanks for maintaining this repository.
