### PR TITLE
anofox_tabfm: 2026.08.14

### DIFF
--- a/extensions/anofox_tabfm/description.yml
+++ b/extensions/anofox_tabfm/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: anofox_tabfm
   description: Zero-shot tabular machine learning inside DuckDB — classification, regression, synthetic-data generation and imputation with real tabular foundation models (Mitra, TabPFN v2/2.5/3, TabICL, Orion-BiX, TabFM) on ONNX Runtime, no training loop
-  version: 0.4.0
+  version: '2026.08.14'
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: DataZooDE/anofox-tabfm
-  ref: 503bc596debdb830cbfa97c176acccbc885f60bf
+  ref: 443f8544631ec689c3a2e324b14aa6d59280c939
 
 docs:
   hello_world: |


### PR DESCRIPTION
Updates `anofox_tabfm` from `0.4.0` (ref `503bc59`, v2026.08.11) to **v2026.08.14**, and switches the `version` field to the project's date-based scheme so the listing and the release tag read the same.

Two releases are folded in.

### v2026.08.13

- **Nested feature columns raised an `INTERNAL` assertion instead of a binder error** ([#17](https://github.com/DataZooDE/anofox-tabfm/issues/17)). A `LIST`/`ARRAY`/`STRUCT`/`MAP`/`UNION` column fell through the preprocessing classifier's "unknown → categorical" fallback and reached the ONNX engine with an empty feature matrix; alongside usable scalar columns it was silently encoded as garbage and returned predictions with no warning. All four surfaces now reject nested feature and target columns at bind time, naming the column, its type and the way out. A relation that loses every feature column also raises an actionable error rather than the same assertion.
- **`anofox_tabfm_threads` now sizes itself by the container's CPU allocation**, not the host's core count. `hardware_concurrency()` reports the whole machine inside a container, so a 64-CPU allocation on a 256-core host resolved to 128 intra-op threads *per session*. The default now takes the smaller of the cpuset and the CFS bandwidth quota.
- Missing weights were reported as a raw ONNX Runtime error on Windows, because ORT phrases the failed stat differently there than on POSIX.

### v2026.08.14 — CUDA

- **`tabicl-v2` now runs on the CUDA execution provider.** Both TabICL graphs previously failed inside inference at a `ScatterND` node while running correctly on CPU: the CUDA `Slice` that trims an index range down to the context length returns its input untrimmed, because the CPU-side buffer holding that bound is recycled before the kernel reads it (an ONNX Runtime bug, still present in 1.28.0). The bounds are now pinned as graph outputs, which excludes them from buffer reuse. CPU output is bit-identical to before — verified against the real checkpoint — so this release changes nothing for CPU users.
- **A failed execution-provider load reported the wrong error entirely.** ORT logs EP load failures through its default logger, which only exists once an `Ort::Env` does, so a provider library that would not load surfaced as `Attempt to use DefaultLogger but none has been registered`.
- **CUDA device discovery now works on Windows** — the NVML probe behind `tabfm_devices()` was Linux-only.

The community build ships the portable CPU flavor, so the CUDA work does not change these binaries; it is included because the listing tracks the release tag.

The docs block is unchanged.