### PR TITLE
quackiso 1.5.0: mandates, investigations, and payment status requests

### DIFF
--- a/extensions/quackiso/description.yml
+++ b/extensions/quackiso/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: quackiso
   description: Query ISO 20022 (camt, pacs, pain) financial messages as SQL
-  version: 1.4.1
+  version: 1.5.0
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: tempoloss/quackiso
-  ref: 303af8767ebb3c299943201dad65739cb6614915
+  ref: af76fc5c236c5da1ea749b2860a6010b10b3be3f
 
 docs:
   hello_world: |
@@ -62,6 +62,19 @@ docs:
            original_settlement_date
     FROM read_pacs028('pacs028.xml');
 
+    -- The mandate itself (pain.009), which a direct debit pulls against:
+    -- who may collect, from whom, how often and up to what.
+    SELECT mandate_request_id, sequence_type, frequency, creditor_name,
+           debtor_name, collection_amount
+    FROM read_pain009('pain009.xml');
+
+    -- The investigation family (camt.027 here): the claim that money never
+    -- arrived. All seven investigation readers share the assignment and case
+    -- columns, so one case joins across the messages that answer it.
+    SELECT case_id, case_creator, assigner, assignee, original_amount,
+           original_settlement_date
+    FROM read_camt027('camt027.xml');
+
     -- Amounts are DECIMAL(38,5), so totals are exact.
     SELECT currency, SUM(amount) AS total
     FROM read_iso20022('statements/*.xml')
@@ -72,8 +85,8 @@ docs:
     Python preprocessing step, no per-schema glue code: point a table function at
     bank XML and get transactions as rows.
 
-    Fifteen functions: fourteen readers covering the payment lifecycle end to
-    end, in both directions, and a sniffer that routes files to them.
+    Twenty-six functions: twenty-five readers covering the payment lifecycle end
+    to end, in both directions, and a sniffer that routes files to them.
 
     * `read_iso20022(path)` - camt.053 statements, camt.054 notifications and
       camt.052 reports; one row per booked entry.
@@ -84,6 +97,12 @@ docs:
     * `read_pain001(path)` / `read_pain008(path)` - credit transfer and direct
       debit initiation; the paying or collecting side lives on the `<PmtInf>`
       group and is carried down, and direct debits carry the mandate.
+    * `read_pain009(path)` / `read_pain010(path)` / `read_pain011(path)` /
+      `read_pain012(path)` - the mandate's own lifecycle: the authorisation a
+      direct debit pulls against, its amendments, its cancellation and the
+      report that accepts or refuses each of the three. One row per mandate
+      record, with the amendment naming both the mandate it changes and what it
+      becomes.
     * `read_pacs003(path)` - the interbank leg of a direct debit collection.
     * `read_pain002(path)` / `read_pacs002(path)` - payment status reports,
       customer- and interbank-side; one row per status statement, at whichever
@@ -102,6 +121,13 @@ docs:
       cancellation requests (interbank and customer-side) and the resolution
       that answers them; a whole-batch cancellation with no transactions is
       still a row.
+    * `read_camt027(path)` / `read_camt028(path)` / `read_camt030(path)` /
+      `read_camt031(path)` / `read_camt036(path)` / `read_camt037(path)` /
+      `read_camt087(path)` - the investigation family: the claim that the money
+      never arrived, the information that answers it, the notification that the
+      case moved, the refusal, the debit authorisation request and its response,
+      and the request to modify a payment rather than cancel it. All seven share
+      the same assignment and case columns, so one case joins across them.
     * `sniff_iso20022(path)` - inventory before reading: one row per file with
       the detected message type, the family, the count of record elements a
       reader would turn into rows, and the reader that covers it. Identity comes
@@ -139,12 +165,13 @@ docs:
     so identity is the message's own container and rows are only produced
     inside it.
 
-    Tested against roughly 260 real messages from more than a dozen sources -
+    Tested against roughly 280 real messages from more than a dozen sources -
     Goldman Sachs US/UK/EU and wire, SIX interbank, CBPR+, ProgressSoft,
     Nivaes, Prowide, OpenBankProject, Mbanq, Handelsbanken, issettled, prog-nov,
-    salesking and Dolibarr among them - spanning sixteen message families and
-    every era of their vocabulary: renamed reason blocks, renamed containers,
-    namespace-prefixed subtrees, group-level fields carried down, and party
+    salesking and Dolibarr among them - spanning twenty-seven message families
+    and every era of their vocabulary: renamed reason blocks, renamed
+    containers, namespace-prefixed subtrees, group-level fields carried down,
+    bare BICs where later editions put a party choice, and party
     sides that reverse in a return. Every behaviour that looks like a special
     case came from one of those files.
 

--- a/extensions/quackiso/description.yml
+++ b/extensions/quackiso/description.yml
@@ -1,12 +1,9 @@
-# Submit this file to duckdb/community-extensions at
-# extensions/quackiso/description.yml
-# `ref` is the tagged release commit in tempoloss/quackiso.
 extension:
   name: quackiso
   description: Query ISO 20022 (camt, pacs, pain) financial messages as SQL
-  version: 1.3.0
+  version: 1.4.0
   language: Rust
-  build: cmake
+  build: cargo
   license: MIT
   maintainers:
     - tempoloss
@@ -15,7 +12,7 @@ extension:
 
 repo:
   github: tempoloss/quackiso
-  ref: 62c365d51c016827f37fe2dfbd8512214c886d16
+  ref: 5a0288e42d1dc81ff350b1beda3873a834e3835b
 
 docs:
   hello_world: |
@@ -57,6 +54,14 @@ docs:
     FROM read_pain002('pain002.xml')
     WHERE status_level = 'TRANSACTION';
 
+    -- Payment status requests (pacs.028): asking where a payment already sent
+    -- got to. A request states no status of its own, so every monetary column
+    -- is original_*, and scope says whether the row is one transaction or a
+    -- whole original message.
+    SELECT scope, original_msg_id, original_uetr, original_amount,
+           original_settlement_date
+    FROM read_pacs028('pacs028.xml');
+
     -- Amounts are DECIMAL(38,5), so totals are exact.
     SELECT currency, SUM(amount) AS total
     FROM read_iso20022('statements/*.xml')
@@ -67,7 +72,7 @@ docs:
     Python preprocessing step, no per-schema glue code: point a table function at
     bank XML and get transactions as rows.
 
-    Fourteen functions: thirteen readers covering the payment lifecycle end to
+    Fifteen functions: fourteen readers covering the payment lifecycle end to
     end, in both directions, and a sniffer that routes files to them.
 
     * `read_iso20022(path)` - camt.053 statements, camt.054 notifications and
@@ -84,6 +89,11 @@ docs:
       customer- and interbank-side; one row per status statement, at whichever
       level the bank stated it, because a batch can be accepted or rejected
       without a single transaction being detailed.
+    * `read_pacs028(path)` - payment status requests: the "where is my money?"
+      message, asking another bank for the status of a payment already sent. A
+      request carries no status of its own, so every monetary column is
+      `original_*`, and a request naming a whole original message with no
+      transaction detail is still a row.
     * `read_pacs004(path)` / `read_pacs007(path)` - returns and reversals:
       settled money coming back, from the receiver or taken back by the sender;
       the returned amount sits beside the original, so partial returns are
@@ -93,9 +103,10 @@ docs:
       that answers them; a whole-batch cancellation with no transactions is
       still a row.
     * `sniff_iso20022(path)` - inventory before reading: one row per file with
-      the detected message type, the family, the wire-level record count and the
-      reader that covers it. Identity comes from the namespace, the era-spelled
-      container names or the envelope binding, and content problems land in an
+      the detected message type, the family, the count of record elements a
+      reader would turn into rows, and the reader that covers it. Identity comes
+      from the namespace, the era-spelled container names or the envelope
+      binding, and content problems land in an
       `error` column instead of aborting the scan, so a folder of mixed
       downloads is a table rather than a failure.
 
@@ -119,7 +130,8 @@ docs:
     resident, measured by `cargo test membound`, and adds 7.8 MiB to a running
     DuckDB. A glob is parsed in parallel, one worker per file - XML has no
     safe split points, so a single document is never divided - with
-    `threads := n` to pin the pool; measured 6.9x on 8 files of 35 MB.
+    `threads := n` to pin the pool, itself capped at four times the machine's
+    parallelism; measured 6.9x on 8 files of 35 MB.
 
     A file of the wrong message type fails loudly instead of returning an empty
     table. The transaction element names collide across families (camt.056 and
@@ -130,7 +142,7 @@ docs:
     Tested against roughly 260 real messages from more than a dozen sources -
     Goldman Sachs US/UK/EU and wire, SIX interbank, CBPR+, ProgressSoft,
     Nivaes, Prowide, OpenBankProject, Mbanq, Handelsbanken, issettled, prog-nov,
-    salesking and Dolibarr among them - spanning thirteen message families and
+    salesking and Dolibarr among them - spanning sixteen message families and
     every era of their vocabulary: renamed reason blocks, renamed containers,
     namespace-prefixed subtrees, group-level fields carried down, and party
     sides that reverse in a return. Every behaviour that looks like a special

--- a/extensions/quackiso/description.yml
+++ b/extensions/quackiso/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: quackiso
   description: Query ISO 20022 (camt, pacs, pain) financial messages as SQL
-  version: 1.4.0
+  version: 1.4.1
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: tempoloss/quackiso
-  ref: 5a0288e42d1dc81ff350b1beda3873a834e3835b
+  ref: 303af8767ebb3c299943201dad65739cb6614915
 
 docs:
   hello_world: |


### PR DESCRIPTION
Re-pins `quackiso` to v1.5.0 (`af76fc5c236c5da1ea749b2860a6010b10b3be3f`). The registry currently builds v1.3.0 (`62c365d`), which predates twelve of the twenty-five readers. This PR opened as the 1.4.1 pin and now carries 1.5.0; the pacs.028 work below is unchanged and still part of it.

**New in 1.5.0: eleven readers, two families.**

`read_pain009` / `read_pain010` / `read_pain011` / `read_pain012` are the mandate's own lifecycle - the authorisation a direct debit pulls against, its amendment, its cancellation, and the report that accepts or refuses each of the three. A pain.008 collection already named a `mandate_id`; until now there was nothing to join it to. Grain is the record element, so a message stating three mandates is three rows, and the amendment carries both states: the mandate it changes and what it becomes.

`read_camt027` / `read_camt028` / `read_camt030` / `read_camt031` / `read_camt036` / `read_camt037` / `read_camt087` are the investigation family - the claim that money never arrived, the information that answers it, the notification that the case moved, the refusal, the debit authorisation request and its response, and the request to modify a payment rather than cancel it. Grain is the message. All seven expose the same assignment and case columns, so one case joins across every message that touches it, and camt.029 resolutions join to the claim they answer.

The assignment block is now parsed in one place (`wire::capture_assignment`) instead of three, and camt.029/055/056 call it. Their existing assertions are untouched, which is the proof the merge kept their behaviour.

Every column is proven non-NULL by a real fixture: twenty-three files from the ISO published business examples carried by `prog-nov/addon-iso20022` and `Nivaes/Iso20022Net`, provenance in each file header. Columns the schemas allow but no published sample carries were dropped rather than declared, and camt.037's first edition is read as it was spelled in 2005 - bare BICs, the payment stated inline - because it is the only sample carrying the amount the message exists to ask for.

**Descriptor changes.** `version` 1.5.0, `ref` on the tagged release commit, function list and corpus sentence updated to twenty-six functions and twenty-seven message families, and `hello_world` gains a `read_pain009` and a `read_camt027` statement.

**Previously in this PR, unchanged: `read_pacs028`** - payment status requests, the "where is my money?" message a bank sends when a payment it already submitted has gone quiet. A request carries no status of its own, so every monetary column on it is `original_*`. Two grains in one table, named by `scope`: a request detailing transactions gives one row per `TxInf`, and a request naming a whole original message with no transaction detail is still a row, because "where is my batch" is a question a bank does ask.

Also from the 1.4.0 audit and still included: a message's container is its scope instead of a latched flag, so a second message in one file cannot inherit the first one's identity; the counterparty is assembled as one party; CDATA is content on every path; an amount that fits `i128` but not `DECIMAL(38,5)` is refused instead of silently stored; February 31st is NULL instead of March 3rd; gzip is decided by the first two bytes rather than the file name; a directory matched by a glob is skipped instead of parsed.

**Verification, on the tagged ref `af76fc5`, all three workflows green:** Tests, which runs `make configure debug && make test` against `TARGET_DUCKDB_VERSION=v1.5.5` on Ubuntu plus the column coverage gate and the unit suite on Linux, macOS and Windows (https://github.com/tempoloss/quackiso/actions/runs/31884638263); Memory, the bounds run in release (https://github.com/tempoloss/quackiso/actions/runs/31884638287); Primitives, the doc anchors (https://github.com/tempoloss/quackiso/actions/runs/31884638274).

`cargo test` is 26 passed, 0 failed, 1 ignored, the ignored one being the 1.7 GB fixture Memory runs on a schedule. The SQL suite is 188 records. The coverage gate reports 25 readers, 61 files read, 472 columns, and it fails on any column no fixture proves non-NULL. Every statement in `hello_world` was run against the built extension with corpus paths substituted for the illustrative ones: eleven statements, eleven non-empty results.
