### PR TITLE
anofox_tabfm: 2026.08.15

### DIFF
--- a/extensions/anofox_tabfm/description.yml
+++ b/extensions/anofox_tabfm/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: anofox_tabfm
   description: Zero-shot tabular machine learning inside DuckDB — classification, regression, synthetic-data generation and imputation with real tabular foundation models (Mitra, TabPFN v2/2.5/3, TabICL, Orion-BiX, TabFM) on ONNX Runtime, no training loop
-  version: '2026.08.14'
+  version: '2026.08.15'
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: DataZooDE/anofox-tabfm
-  ref: 443f8544631ec689c3a2e324b14aa6d59280c939
+  ref: 51f0850f0e635d35b7ba054b1bd732b18a026c35
 
 docs:
   hello_world: |


### PR DESCRIPTION
Updates `anofox_tabfm` from `2026.08.14` to **2026.08.15**.

Both changes are to error paths a user hits when something is already wrong, so the messages are the feature.

### The flavor-install route pointed at a host that does not exist

`ext.anofox.com` had no DNS record, so the install route the extension printed could not work for anyone. The host was wrong *and* the path was wrong, and correcting only the host would still have dead-ended a GPU user, because the repository serves the cpu flavor only. The message now names the route that works — building from source — and cites the repository for released cpu builds.

(No effect on this listing: the community build is the cpu flavor, which is exactly what that repository serves.)

### The class ceiling was hardcoded and blamed the user's graph

Exceeding a model's class limit reported *"TabFM v1 supports at most 10"* whatever model was selected, and a model with a narrower head ran a full forward pass before failing with *"check the registered model's graph"* — pointing at a registration that was never wrong. The ceiling now comes from the selected model's registry entry, and the message names the model, the limit, the column and its class count.

### Also in this release

Every `ScatterND` slice bound in the shipped graphs is now pinned, with CI enforcing it and the exporters re-applying it, so the workaround that keeps `tabicl-v2` running on the CUDA execution provider cannot be dropped by a re-export. CPU output is bit-identical — verified against the real checkpoints — so nothing changes for the builds this listing serves.

Both reports came from @maxdemarzi. The docs block is unchanged.