### PR TITLE
sitting_duck: bump to v1.10.2

### DIFF
--- a/extensions/sitting_duck/description.yml
+++ b/extensions/sitting_duck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: sitting_duck
   description: Parse and analyze source code ASTs from 27 programming languages with tree-sitter grammars, pattern matching, and structural search
-  version: 1.10.1
+  version: 1.10.2
   language: C++
   build: cmake
   license: Apache-2.0
@@ -9,7 +9,7 @@ extension:
     - teaguesterling
 repo:
   github: teaguesterling/sitting_duck
-  ref: b1489034c5c299a03bb3477acd878158c7ed1811
+  ref: 6bff057cbf1e9b475029068e41e9a4ebfcb92797
 docs:
   hello_world: |
     -- Parse Python code and find function definitions


### PR DESCRIPTION
Bumps `sitting_duck` to [v1.10.2](https://github.com/teaguesterling/sitting_duck/releases/tag/v1.10.2).

Bug-fix release: `read_ast(..., source := 'full')` returned `start_column` and `end_column` as **0 for every node in every file**. The columns were present in the schema but never populated, so `source := 'full'` cost two columns and provided no positional information.

The struct carries two sets of position fields — a legacy pair and the flattened `source_*` pair from the schema migration. Parsing wrote only the flattened fields while both table projections read the legacy members, which kept their zero initializer. Line numbers were unaffected, which is why it went unnoticed.

This matters most for minified sources, where every node reports `start_line = 1` and columns are the only signal that can isolate a node — every `ast_get_source*` variant is line-addressed.

Covered by a new test (`test/sql/source_full_columns.test`) asserting the columns carry real positions rather than merely non-zero ones, including that more than one distinct `start_column` appears across a file, so a constant cannot pass. CI green on the merge commit.

No API changes.