### PR TITLE
Add Data 360 extension

### DIFF
--- a/extensions/data360/description.yml
+++ b/extensions/data360/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: clawdbotborges/duckdb-data360
-  ref: 7127c8c3905675593f19b8fef58294141e4982a0
+  ref: fda061ad874a868c3f1177842bbe88a173e7136e
 
 docs:
   hello_world: |

--- a/extensions/data360/description.yml
+++ b/extensions/data360/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: clawdbotborges/duckdb-data360
-  ref: 00fe4b7c49baf0040891a7319707362853c67aef
+  ref: 8d7143eabefd958d987987ffd95bc24d9fbe1c40
 
 docs:
   hello_world: |

--- a/extensions/data360/description.yml
+++ b/extensions/data360/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: clawdbotborges/duckdb-data360
-  ref: 8d7143eabefd958d987987ffd95bc24d9fbe1c40
+  ref: 7127c8c3905675593f19b8fef58294141e4982a0
 
 docs:
   hello_world: |

--- a/extensions/data360/description.yml
+++ b/extensions/data360/description.yml
@@ -1,0 +1,25 @@
+extension:
+  name: data360
+  description: Read-only DuckDB access to Salesforce Data 360 Query API V3 with native Arrow IPC and OAuth 2.0 PKCE authentication.
+  version: 0.1.0
+  language: C++
+  build: cmake
+  license: Apache-2.0
+  maintainers:
+    - clawdbotborges
+  excluded_platforms: "linux_arm64;osx_amd64;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads"
+  vcpkg_commit: "94a541197763a4f449a1b91478df48c0584a6256"
+
+repo:
+  github: clawdbotborges/duckdb-data360
+  ref: 587fb0a0aace7a2a56869be3d423e95f506a0d45
+
+docs:
+  hello_world: |
+    INSTALL data360 FROM community;
+    LOAD data360;
+    SELECT * FROM data360_diagnostics();
+  extended_description: |
+    Read-only access to Salesforce Data 360 Query API V3 using bounded HTTPS,
+    native Arrow IPC conversion, named temporary credentials, and OAuth 2.0
+    Authorization Code with S256 PKCE.

--- a/extensions/data360/description.yml
+++ b/extensions/data360/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: clawdbotborges/duckdb-data360
-  ref: 587fb0a0aace7a2a56869be3d423e95f506a0d45
+  ref: 9d428bbdabdbe91d60703c6760d3334fb7480b6b
 
 docs:
   hello_world: |

--- a/extensions/data360/description.yml
+++ b/extensions/data360/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: clawdbotborges/duckdb-data360
-  ref: d72284e9804b97a83df777c9d5b57160c10fbd42
+  ref: 00fe4b7c49baf0040891a7319707362853c67aef
 
 docs:
   hello_world: |

--- a/extensions/data360/description.yml
+++ b/extensions/data360/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: clawdbotborges/duckdb-data360
-  ref: 9d428bbdabdbe91d60703c6760d3334fb7480b6b
+  ref: 2a31ffda1f1c569697056db377615ae8c67a7b21
 
 docs:
   hello_world: |

--- a/extensions/data360/description.yml
+++ b/extensions/data360/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: clawdbotborges/duckdb-data360
-  ref: fda061ad874a868c3f1177842bbe88a173e7136e
+  ref: fda061a1cd060d63d56e0dcd510b7bbc6ccf3bd1
 
 docs:
   hello_world: |

--- a/extensions/data360/description.yml
+++ b/extensions/data360/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: clawdbotborges/duckdb-data360
-  ref: 69dbd2370bb1550e06c760c38deedd938cfff5e5
+  ref: 84f9047d771b102a423c774a0ad997b61c678695
 
 docs:
   hello_world: |

--- a/extensions/data360/description.yml
+++ b/extensions/data360/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: clawdbotborges/duckdb-data360
-  ref: aeac0157ac8cb41517fb46068823b8ab338097be
+  ref: 69dbd2370bb1550e06c760c38deedd938cfff5e5
 
 docs:
   hello_world: |

--- a/extensions/data360/description.yml
+++ b/extensions/data360/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: clawdbotborges/duckdb-data360
-  ref: 2a31ffda1f1c569697056db377615ae8c67a7b21
+  ref: aeac0157ac8cb41517fb46068823b8ab338097be
 
 docs:
   hello_world: |

--- a/extensions/data360/description.yml
+++ b/extensions/data360/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: clawdbotborges/duckdb-data360
-  ref: 84f9047d771b102a423c774a0ad997b61c678695
+  ref: d72284e9804b97a83df777c9d5b57160c10fbd42
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary

Adds `data360`, a read-only DuckDB extension for Salesforce Data 360 Query API V3. It provides bounded native HTTPS transport, Arrow IPC decoding, and interactive OAuth 2.0 Authorization Code authentication with S256 PKCE and a fixed loopback callback.

## Security model

- no client secret or refresh token
- bearer material remains in process memory
- DuckDB temporary secrets contain only opaque session references
- no Python, shell, broker, Salesforce CLI, or curl executable runtime dependency
- read-only Query API interface

## Platforms

Initial publication targets Linux x86_64, macOS arm64, and Windows x86_64/MSVC. Native-socket-incompatible Wasm, MinGW, Linux arm64, and macOS x86_64 targets remain excluded until separately proven.

## Verification

Local DuckDB v1.5.5 debug/release builds, 10/10 CTest, both SQLLogic suites, a 500-cycle callback-listener stress test, extension load verification, secret scanning, and prohibited-runtime scanning pass. The standalone source repository runs DuckDB’s official extension distribution workflow; this PR is draft while hosted matrix results complete.
