### PR TITLE
mssql: v0.2.4

### DIFF
--- a/extensions/mssql/description.yml
+++ b/extensions/mssql/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: mssql
   description: "Connect DuckDB to Microsoft SQL Server via native TDS (including TLS)."
-  version: "0.2.3"
+  version: "0.2.4"
   language: "C++"
   build: "cmake"
   licence: "MIT"
@@ -20,7 +20,7 @@ extension:
 
 repo:
   github: "hugr-lab/mssql-extension"
-  ref: "v0.2.3"
+  ref: "v0.2.4"
 
 docs:
   hello_world: |


### PR DESCRIPTION
Updates the mssql extension to [v0.2.4](https://github.com/hugr-lab/mssql-extension/releases/tag/v0.2.4).

Highlights:

- **Azure Synapse Serverless login fixed** (hugr-lab/mssql-extension#254): TDS 7.2+ DONE tokens in the login response were parsed with the pre-7.2 length, so Synapse's DONEINPROC-before-LOGINACK pattern failed every auth path.
- Login-time ROUTING ENVCHANGE is now followed on every authentication path — SQL auth and integrated (Kerberos/SSPI), not just Azure AD (spec 068); Kerberos hops acquire a ticket for the routed host's SPN.
- Login errors are classified by the server's error number (40613/40197/40501/49918 named as retryable, 18456 explained by its State byte), with the server's message always appended.
- `azure_tenant_id` ATTACH/secret parameter now reaches token acquisition.

No dependency or platform changes: `vcpkg_commit` stays — the extension's builtin-baseline is unchanged from 0.2.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Az9Jy698ZsXztSNTSjMMq