### PR TITLE
Update cityjson extension to v0.3.0

### DIFF
--- a/extensions/cityjson/description.yml
+++ b/extensions/cityjson/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: cityjson
-  description: Read, write, and query CityJSON, CityJSONSeq, and FlatCityBuf 3D city model files.
-  version: 0.2.0
+  description: Read, write, and query CityJSON, CityJSONSeq, FlatCityBuf, and CityParquet 3D city model files.
+  version: 0.3.0
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: cityjson/duckdb-cityjson
-  ref: d511bdba26392bab7d4b789f294065a3fbed58d6
+  ref: 08f9de0183868d86f7937de22b0a717e24377a1e
 
 docs:
   hello_world: |
@@ -20,36 +20,63 @@ docs:
     -- Read a CityJSONSeq (line-delimited) file
     SELECT * FROM read_cityjsonseq('buildings.city.jsonl');
 
-    -- Read a FlatCityBuf file
-    SELECT * FROM read_flatcitybuf('buildings.fcb');
+    -- Read a FlatCityBuf file, pushing a bounding box into its spatial index
+    SELECT * FROM read_flatcitybuf('buildings.fcb',
+      min_x => 84000, min_y => 444000, max_x => 84500, max_y => 444500);
 
     -- Extract geometries as WKB at a specific Level of Detail
     SELECT * FROM read_cityjson('buildings.city.json', lod=>'1.2');
 
-    -- Write query results to CityJSONSeq
+    -- Write query results to CityJSONSeq; the source CRS and metadata travel too
     COPY (SELECT * FROM read_cityjson('buildings.city.json'))
       TO 'output.city.jsonl' (FORMAT cityjsonseq);
 
     -- Inspect file metadata
     SELECT * FROM cityjson_metadata('buildings.city.json');
 
+    -- Read material and texture definitions
+    SELECT * FROM cityjson_materials('buildings.city.jsonl');
+
+    -- Build a CityParquet package: a schema you can validate, mutate and write out
+    CREATE SCHEMA city;
+    CREATE TABLE city.building AS SELECT * FROM read_cityjson('buildings.city.json');
+    PRAGMA cityparquet_init('city');
+    PRAGMA cityparquet_validate('city');
+    SELECT * FROM cityparquet_write('city', 'out/city');
+
   extended_description: |
     The CityJSON extension provides table functions for reading and writing 3D city model files
-    in CityJSON (.city.json), CityJSONSeq (.city.jsonl), and FlatCityBuf (.fcb) formats.
-    CityJSON is a JSON-based encoding for 3D city models (buildings, terrain, vegetation, etc.)
-    based on the CityGML data model.
+    in CityJSON (.city.json), CityJSONSeq (.city.jsonl), and FlatCityBuf (.fcb) formats, and for
+    building CityParquet packages. CityJSON is a JSON-based encoding for 3D city models
+    (buildings, terrain, vegetation, etc.) based on the CityGML data model.
 
-    Supported functions:
+    Reading and writing:
     - `read_cityjson`, `read_cityjsonseq`, `read_flatcitybuf` — table functions for querying city objects
     - `cityjson_metadata`, `cityjsonseq_metadata`, `flatcitybuf_metadata` — inspect file headers
     - `COPY ... TO` with formats `cityjson`, `cityjsonseq`, and `flatcitybuf` — write query results
 
+    Appearance:
+    - `cityjson_materials`, `cityjson_textures`, `cityjson_geometry_templates` — sidecar readers
+    - Per-LoD `material_lod*` / `texture_lod*` reference columns, or `appearance := 'sidecar'`
+      to normalise appearance into sidecar tables with global ids and inlined UV coordinates
+
+    CityParquet packages — a package is a DuckDB schema, so it is queryable while you build it:
+    - `cityparquet_init`, `cityparquet_read`, `cityparquet_write` — create, load and write a package
+    - `insert_cityjson`, `insert_cityjsonseq`, `insert_flatcitybuf` — add a file, routed by CityGML module
+    - `cityparquet_validate`, `cityparquet_reconcile`, `cityparquet_orphans`, `cityparquet_vacuum`
+    - `cityparquet_delete` (with cascade) and `cityparquet_merge`
+    - `cityjson_geoparquet_geo` — the GeoParquet `geo` and CityParquet `city` footer objects
+
     Additional features:
     - Automatic schema inference from CityJSON attributes
     - Wide columnar layout: one WKB geometry column per Level of Detail, plus a per-object `bbox` extent
-    - LOD-based geometry extraction as WKB blobs via the `lod` parameter
+    - `geometry_properties_lod*` as a native STRUCT, so semantic surfaces and shells are columns
+    - Spatial and attribute-query pushdown on FlatCityBuf, using the file's R-tree and B+tree indexes
+    - Selective deserialisation: a query projecting no geometry never decodes it
     - Filter pushdown on `id`, `feature_id`, and `object_type`
     - Streaming reads of large CityJSONSeq files and remote files over HTTP/S3/GCS
+    - CRS handling follows GeoParquet's tri-state convention, so a georeferenced file never
+      silently claims OGC:CRS84
     - Support for CityJSON v2.0 and CityJSONSeq formats
 
     For more information on the CityJSON format, see https://www.cityjson.org/.


### PR DESCRIPTION
Updates `cityjson` from v0.2.0 to **v0.3.0**, pinned to
[`08f9de0`](https://github.com/cityjson/duckdb-cityjson/commit/08f9de0183868d86f7937de22b0a717e24377a1e)
(tag [`v0.3.0`](https://github.com/cityjson/duckdb-cityjson/releases/tag/v0.3.0)).

147 commits since 0.2.0; **30 new SQL functions, none removed.**

### What's new

- **CityParquet packages.** A package is a DuckDB schema you can create, validate,
  mutate, merge and write back out as a spec-conformant directory of Parquet files
  (`cityparquet_init` / `_read` / `_write` / `_validate` / `_reconcile` / `_delete` /
  `_merge` / `_orphans` / `_vacuum`, plus `insert_cityjson[seq]` and
  `insert_flatcitybuf`).
- **Appearance**: `cityjson_materials`, `cityjson_textures`,
  `cityjson_geometry_templates`, and per-LoD material/texture reference columns.
- **FlatCityBuf** reader and writer rewritten against the native C++ library, with
  spatial (R-tree) and attribute-query (B+tree) pushdown, and selective
  deserialisation so a query that projects no geometry never decodes it.
- **Round-trip fidelity fixes**: the source CRS and metadata header now survive a
  `COPY`, appearance definitions are written rather than left dangling, and
  timestamps keep their ISO-8601 form.

### Breaking changes

1. `geometry_properties_lod*` is now a `STRUCT` rather than JSON text, so semantic
   surfaces and shells are columns instead of strings to parse.
2. `flatcitybuf_metadata` reports `features_count`; `city_objects_count` is `NULL`
   for FlatCityBuf. The header counts features, and one feature may carry several
   CityObjects — reporting one as the other was wrong by ~2x on real data.
3. Arrow-native `Solid`s flatten their shells into one padded shell (opt-in
   `geometry_encoding := 'arrow-native'` path only).

### Note for reviewers

The `vcpkg.json` at this ref resolves `flatcitybuf` from a **git registry**
(`https://github.com/HideBa/vcpkg`, scoped to that single package with a pinned
baseline) rather than a repo-local overlay port. Everything else stays on the
builtin baseline. This is temporary: an upstream microsoft/vcpkg PR is open for
the port, and the registry entry is deleted once it merges. Happy to adjust if a
third-party registry is a problem for the build pipeline.
