### PR TITLE
quackiso 1.5.1: a truncated document is an error

### DIFF
--- a/extensions/quackiso/description.yml
+++ b/extensions/quackiso/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: quackiso
   description: Query ISO 20022 (camt, pacs, pain) financial messages as SQL
-  version: 1.5.0
+  version: 1.5.1
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: tempoloss/quackiso
-  ref: af76fc5c236c5da1ea749b2860a6010b10b3be3f
+  ref: 9970d1cea70d5379cf7d0692eade1ea65dccb824
 
 docs:
   hello_world: |


### PR DESCRIPTION
1.5.0 returns zero rows and no error for a document that stops inside an open element, so a statement cut off by a failed transfer reads as an empty table. 1.5.1 raises instead.

quick-xml only raises `MissingEndTag` from `read_to_end`, which none of the readers call, so a `read_event_into` loop is handed `Event::Eof` with the element stack still full. The check is now in one wrapper that all 25 readers and the sniffer go through.

Verified against the built extension on windows_amd64: 190 records in the SQL suite, 0 failed; `cargo test` 27 passed, 1 ignored; column coverage 25 readers, 61 files, 472 columns. The mid-tag fixture still fails inside quick-xml with `tag not closed`, so the new check is not swallowing real syntax errors.

`ref` points at v1.5.1 (`9970d1c`).