### PR TITLE
quackiso 1.6.2: SWIFT MT alongside ISO 20022, and a non-XML file refused before it is buffered

### DIFF
--- a/extensions/quackiso/description.yml
+++ b/extensions/quackiso/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: quackiso
   description: Query ISO 20022 (camt, pacs, pain) and SWIFT MT financial messages as SQL
-  version: 1.6.0
+  version: 1.6.1
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: tempoloss/quackiso
-  ref: 219f601f411c14c3db5e1feae88d9e80b1f3faa3
+  ref: e15dfb5e6b29fe00c7387668824b40127529d756
 
 docs:
   hello_world: |

--- a/extensions/quackiso/description.yml
+++ b/extensions/quackiso/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: quackiso
   description: Query ISO 20022 (camt, pacs, pain) and SWIFT MT financial messages as SQL
-  version: 1.6.1
+  version: 1.6.2
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: tempoloss/quackiso
-  ref: e15dfb5e6b29fe00c7387668824b40127529d756
+  ref: 565d42b1d4f6c4dd0f607b4855c5d614ebc028d5
 
 docs:
   hello_world: |
@@ -192,6 +192,16 @@ docs:
     pacs.004 both say `TxInf`, pacs.008 and pain.001 both say `CdtTrfTxInf`),
     so identity is the message's own container and rows are only produced
     inside it.
+
+    A file that is not XML at all is refused before it is buffered. An XML reader
+    reads at most 64 KiB of the decompressed input first: no markup in that
+    prefix, or a SWIFT MT block header ahead of any markup, is an error naming
+    the reason. Rejecting an 8 MiB file costs what rejecting a 128 KiB one does,
+    0.86 MiB of live heap, because the reader never reaches the parser. Markup
+    inside the prefix still goes to the parser, so a malformed document keeps its
+    own diagnostics; `sniff_iso20022` still reports a non-XML file as a row
+    rather than failing the scan, and the `read_mt*` readers keep their own
+    framing.
 
     Tested against around 283 real messages from more than a dozen sources -
     Goldman Sachs US/UK/EU and wire, SIX interbank, CBPR+, ProgressSoft,

--- a/extensions/quackiso/description.yml
+++ b/extensions/quackiso/description.yml
@@ -28,9 +28,11 @@ docs:
     FROM sniff_iso20022('inbox/**/*.xml')
     GROUP BY family, reader;
 
-    -- SWIFT MT is read the same way, by path: one row per :61: statement line,
-    -- with the account and its balances carried onto every one of them.
-    SELECT account, value_date, credit_debit, amount, currency, closing_balance
+    -- SWIFT MT is read the same way, by path: one row per :61: statement line.
+    -- A `:61:` states no currency of its own, so the statement's balance carries
+    -- it, along with the account, onto every entry.
+    SELECT account, value_date, credit_debit, amount,
+           closing_balance_currency, closing_balance
     FROM read_mt940('statements/*.txt')
     ORDER BY value_date;
 

--- a/extensions/quackiso/description.yml
+++ b/extensions/quackiso/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: quackiso
-  description: Query ISO 20022 (camt, pacs, pain) financial messages as SQL
-  version: 1.5.1
+  description: Query ISO 20022 (camt, pacs, pain) and SWIFT MT financial messages as SQL
+  version: 1.6.0
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: tempoloss/quackiso
-  ref: 9970d1cea70d5379cf7d0692eade1ea65dccb824
+  ref: 219f601f411c14c3db5e1feae88d9e80b1f3faa3
 
 docs:
   hello_world: |
@@ -27,6 +27,12 @@ docs:
     SELECT family, reader, count(*) AS files, sum(records) AS records
     FROM sniff_iso20022('inbox/**/*.xml')
     GROUP BY family, reader;
+
+    -- SWIFT MT is read the same way, by path: one row per :61: statement line,
+    -- with the account and its balances carried onto every one of them.
+    SELECT account, value_date, credit_debit, amount, currency, closing_balance
+    FROM read_mt940('statements/*.txt')
+    ORDER BY value_date;
 
     -- Interbank credit transfers (pacs.008, the ISO 20022 MT103).
     SELECT uetr, amount, currency, debtor_name, creditor_agent_bic
@@ -81,15 +87,19 @@ docs:
     WHERE credit_debit = 'DBIT'
     GROUP BY currency;
   extended_description: |
-    quackiso reads ISO 20022 financial messages directly into DuckDB tables. No
-    Python preprocessing step, no per-schema glue code: point a table function at
-    bank XML and get transactions as rows.
+    quackiso reads ISO 20022 and SWIFT MT financial messages directly into DuckDB
+    tables. No Python preprocessing step, no per-schema glue code: point a table
+    function at bank XML or at a folder of MT statements and get transactions as
+    rows.
 
-    Twenty-six functions: twenty-five readers covering the payment lifecycle end
+    Thirty-four functions: thirty-three readers covering the payment lifecycle end
     to end, in both directions, and a sniffer that routes files to them.
 
     * `read_iso20022(path)` - camt.053 statements, camt.054 notifications and
       camt.052 reports; one row per booked entry.
+    * `read_camt057(path)` - notifications to receive: money on its way in and
+      not yet booked; one row per expected item, with the account carried down
+      from its notification.
     * `read_pacs008(path)` / `read_pacs009(path)` - customer and
       financial-institution credit transfers (the ISO 20022 MT103 and
       MT202/MT202COV); in the COV form the `underlying_*` columns carry the
@@ -103,7 +113,14 @@ docs:
       report that accepts or refuses each of the three. One row per mandate
       record, with the amendment naming both the mandate it changes and what it
       becomes.
-    * `read_pacs003(path)` - the interbank leg of a direct debit collection.
+    * `read_pain013(path)` / `read_pain014(path)` - request to pay: the creditor
+      asking the debtor to activate a payment, and the answer. The request's
+      debtor and payment terms live on the `<PmtInf>` group and are carried down;
+      the answer states its status at group, payment-info or transaction level,
+      whichever the debtor's bank used.
+    * `read_pacs003(path)` / `read_pacs010(path)` - the interbank leg of a
+      direct debit collection, and the form where both sides are banks; there
+      the collecting bank sits on the credit instruction and is carried down.
     * `read_pain002(path)` / `read_pacs002(path)` - payment status reports,
       customer- and interbank-side; one row per status statement, at whichever
       level the bank stated it, because a batch can be accepted or rejected
@@ -128,11 +145,20 @@ docs:
       case moved, the refusal, the debit authorisation request and its response,
       and the request to modify a payment rather than cancel it. All seven share
       the same assignment and case columns, so one case joins across them.
+    * `read_mt103(path)` / `read_mt202(path)` / `read_mt940(path)` /
+      `read_mt942(path)` - SWIFT MT, the FIN originals the pacs and camt messages
+      replaced and banks still send: the customer transfer, the interbank
+      transfer with its COV cover, the customer statement and the interim report.
+      MT is flat tag-structured text rather than XML, so these share the scan and
+      column machinery and nothing else; the statement readers carry the account
+      and its balances onto every `:61:` line. MT carries no namespace, so the
+      sniffer identifies it by its block structure instead, and routes it the
+      same way it routes XML.
     * `sniff_iso20022(path)` - inventory before reading: one row per file with
       the detected message type, the family, the count of record elements a
       reader would turn into rows, and the reader that covers it. Identity comes
-      from the namespace, the era-spelled container names or the envelope
-      binding, and content problems land in an
+      from the namespace, the era-spelled container names, the envelope binding,
+      or an MT block header, and content problems land in an
       `error` column instead of aborting the scan, so a folder of mixed
       downloads is a table rather than a failure.
 
@@ -153,11 +179,11 @@ docs:
     Parsing is a streaming pass over XML events, so the peak is one output batch
     plus the largest single XML subtree rather than the file: a 1.7 GB statement
     of three million entries parses in 1.23 MiB of live heap and about 2 MB
-    resident, measured by `cargo test membound`, and adds 7.8 MiB to a running
-    DuckDB. A glob is parsed in parallel, one worker per file - XML has no
-    safe split points, so a single document is never divided - with
-    `threads := n` to pin the pool, itself capped at four times the machine's
-    parallelism; measured 6.9x on 8 files of 35 MB.
+    resident, measured by `cargo test --release membound -- --ignored`, and
+    adds 7.7 MiB to a running DuckDB. A glob is parsed in parallel, one worker
+    per file - XML has no safe split points, so a single document is never
+    divided - with `threads := n` to pin the pool, itself capped at four times
+    the machine's parallelism; measured 6.9x on 8 files of 35 MB.
 
     A file of the wrong message type fails loudly instead of returning an empty
     table. The transaction element names collide across families (camt.056 and
@@ -165,7 +191,7 @@ docs:
     so identity is the message's own container and rows are only produced
     inside it.
 
-    Tested against roughly 280 real messages from more than a dozen sources -
+    Tested against around 283 real messages from more than a dozen sources -
     Goldman Sachs US/UK/EU and wire, SIX interbank, CBPR+, ProgressSoft,
     Nivaes, Prowide, OpenBankProject, Mbanq, Handelsbanken, issettled, prog-nov,
     salesking and Dolibarr among them - spanning twenty-seven message families


### PR DESCRIPTION
Re-pins `quackiso` to v1.6.2 (`565d42b1d4f6c4dd0f607b4855c5d614ebc028d5`). The registry currently builds v1.5.1 (`9970d1c`), which is twenty-five readers; 1.6.2 is thirty-three.

**Four SWIFT MT readers, the first thing this extension reads that is not XML.** MT is not markup: a message is five brace-delimited blocks and block 4 is flat tag-structured text, where a field starts at a line spelled `:nn:` or `:nnA:` and its value runs to the next such line. Only the framing and the leaf shapes are new; the row streams, the column writers, the scan driver and gzip are the machinery the XML readers already use.

`read_mt103` is single customer credit transfers, the FIN original of pacs.008. `read_mt202` is MT202 and MT202COV, the cover's underlying customer transfer beside the interbank leg. `read_mt940` is customer statements, one row per `:61:` line with the account and all four balances carried onto it, and `read_mt942` is the interim report of what has happened since the last statement. Both shapes real files come in are read: a full block-structured FIN message, and a bare statement file that is block 4 alone, which is how a bank usually ships an MT940. The framer settles which by looking, not by the file name.

The sniffer recognises MT as well, by shape rather than by a namespace: `{1:` or a bare `:20:` is MT, the family is the MT number extended by the block-3 validation flag when there is one (`mt.103.stp`), `namespace` and `created` come out NULL because MT states neither, and `records` counts the rows the named reader would return. A file with no markup in it at all is reported as such instead of being handed to the XML parser to fail there.

**The bounded unit is one message, and it is measured.** A statement writes its closing balance *after* its entries, in `:62F:`, and every row carries that balance, so nothing per entry is held between rows: the statement-level fields are parsed first, then each entry is parsed out of its own byte range as the output batch asks for it. Sixty-four statements peak where eight do, at 2.43 MiB. One statement of 8,000 entries costs one of 2,000 plus the text those 6,000 entries added, 2.43 MiB to 2.87 MiB. Both figures are recorded and fail the build at more than 25% off. A single statement of 200,000 entries, 13.5 MB of text, reads in that same bound.

**This PR also carries four ISO 20022 readers that landed after 1.5.1** and whose descriptor prose never reached the registry: `read_pacs010` (a direct debit where both sides are banks), `read_camt057` (notifications to receive), and `read_pain013` / `read_pain014` (request to pay, and the answer). That is why the descriptor moves from twenty-six functions to thirty-four rather than by four.

**1.6.1 caps the buffered subtree.** `record_subtree` accumulated a whole XML subtree with nothing counting bytes, while every `read_mt*` reader has held `MAX_MESSAGE_BYTES` since MT landed. Gzip removed the last implicit bound, so a small file on disk can inflate into gigabytes of heap, and in a loadable extension the allocation failure takes the DuckDB process down instead of failing the one query. The cap is 64 MiB, the same ceiling as `mt::MAX_MESSAGE_BYTES`. The number is not a free choice: `membound` builds 4 MiB and 16 MiB subtrees and asserts they parse, so anything at or below 16 MiB would turn those red. A gzipped `<CdtTrfTxInf>` padded past the cap now returns an error naming the tag rather than aborting the process.

**1.6.2 refuses a file that is not XML before it is buffered, which is why this is not 1.6.1.** That cap bounded a subtree inside a document that parsed; nothing bounded a file that was never XML to begin with. `read_iso20022` on 128 KiB of `a` bytes reached quick-xml, which returns the whole run as one Text event, so the allocation followed the file and gzip removed the last bound on it: the same failure shape as the subtree, with the same consequence in a loadable extension. An XML reader now reads at most 64 KiB of the decompressed input first and classifies that prefix with the sniffer's own classifier. No markup in it is `not XML: no markup in the first 64 KiB`; an MT block header ahead of any markup is `not XML: SWIFT MT marker before markup`. The accepted prefix replays into the stream without seeking, so FIFO input still works and the gzip decoder keeps the compressed bytes it had buffered.

The guard is a default on the row-stream trait: all twenty-nine XML table streams inherit it, and it is overridden only by the four `read_mt*` streams, which keep their own framing and cap, and by the sniffer, which still reports a non-XML file as a row instead of aborting the scan. Markup inside the prefix still reaches quick-xml, so a malformed document keeps its own diagnostics rather than being relabelled. Rejecting 8 MiB costs what rejecting 128 KiB does, 0.86 MiB of live heap and no measurable RSS growth, 0.98 MiB gzipped; removing the default guard locally turns that test red at 1.09 MiB against 16.84 MiB for the two sizes. Against the built extension, `read_iso20022('Cargo.lock')` and `read_pacs008('Cargo.lock')` return the prefix error while `sniff_iso20022('Cargo.lock')` still returns it as an error row.

**Verified on the tag in CI:** Tests, Memory and Primitives all green on v1.6.2 (https://github.com/tempoloss/quackiso/actions/runs/32723700885, https://github.com/tempoloss/quackiso/actions/runs/32723700685, https://github.com/tempoloss/quackiso/actions/runs/32723700645). `cargo test` is 57 passed on Linux, macOS and musl and 56 on Windows, where the FIFO case is `cfg(unix)`, with 0 failed and 2 ignored: the 1.7 GB fixture Memory runs on a schedule, and the 64 MiB subtree above, both ignored because they write large fixtures. The SQL suite is unchanged at 233 records, `test/` not having been touched since v1.6.1. The coverage gate reports 33 readers, 69 files read, 712 columns and 6 expected errors, and it fails on any column no fixture proves non-NULL. The twelve `hello_world` statements in this descriptor and four more in the README run against the built extension, eleven functions exercised, every result non-empty.

The corpus sweep reads other projects' MT files as well as their XML: wolph/mt940 and prowide-core, pinned by commit sha, for 36 real MT files among 82 recorded outcomes, plus 244 files generated from swift-mt-message's 172 scenarios. It reports 0 findings. Real MT is not ASCII in practice and both cases are read: a `:86:` carrying half-width katakana, a `:20:` with `Ü` and `ß` in it.

**One thing this PR fixes about itself.** The first commit's `hello_world` asked `read_mt940` for `currency`, which does not bind: a `:61:` line states no currency of its own, so an entry inherits the statement's and the column is `closing_balance_currency`. A later commit corrects it. It was found by running every `hello_world` statement against the built extension with a corpus path substituted for each illustrative one, which is now how they are checked.

`excluded_platforms` and `requires_toolchains` are unchanged.