### PR TITLE
zim: v0.8.1

### DIFF
--- a/extensions/zim/description.yml
+++ b/extensions/zim/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: zim
-  description: Read .zim (Kiwix / openZIM) archives directly in DuckDB via libzim, from local files or remote S3/HTTP — offline Wikipedia, WikiMed, Stack Exchange, iFixit, and more, with a zim:// filesystem and full-text search.
-  version: 0.6.2
+  description: Read and write .zim (Kiwix / openZIM) archives directly in DuckDB via libzim, from local files or remote S3/HTTP — offline Wikipedia, WikiMed, Stack Exchange, iFixit, and more, with a zim:// filesystem, full-text search, and COPY TO for building archives from any query.
+  version: 0.8.1
   language: C++
   build: cmake
   license: GPL-2.0-or-later
@@ -12,7 +12,7 @@ extension:
   vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
 repo:
   github: teaguesterling/duckdb_zim
-  ref: 3101ee81a99197ef344d70e8a8b4ec3beec75182
+  ref: df80e1e713b08f75e4fb8f7e0a18250486b127f7
 docs:
   hello_world: |
     -- Load the extension
@@ -66,6 +66,17 @@ docs:
     -- column says which archive each hit came from.
     SELECT file, path, title FROM zim_search('library/*.zim', 'insulin', max_results := 5);
 
+    -- Write an archive from any query: COPY ... TO ... (FORMAT zim).
+    -- 'path' and 'content' are required; title/mimetype/redirects are optional.
+    COPY (SELECT path, title, mimetype, content FROM articles)
+    TO 'out.zim' (FORMAT zim, TITLE 'My Archive', LANGUAGE 'eng', INDEX true);
+
+    -- read_zim's output is COPY's input, so a ZIM -> ZIM copy is one statement.
+    -- Read content as BLOB: content_as_varchar returns NULL for non-UTF-8 entries
+    -- (every image and font), which would write them out empty.
+    COPY (SELECT * FROM read_zim('in.zim', include_content := true))
+    TO 'copy.zim' (FORMAT zim);
+
     -- Single-entry access, metadata, and utilities.
     SELECT zim_get_text('wikipedia.zim', 'A/Berlin');
     SELECT zim_main_entry('wikipedia.zim');
@@ -117,6 +128,18 @@ docs:
     WebAssembly too, where full-text search is not). Both are **federated**: the first
     argument can be a single path, a glob, or a `LIST`, so a query runs across many
     archives at once.
+
+    **Writing archives**: `COPY (query) TO 'out.zim' (FORMAT zim, ...)` builds a ZIM
+    from any relation. Columns are resolved by name — `path` and `content` are
+    required, with `title`, `mimetype`, `is_redirect`/`redirect_path` and libzim's
+    `front_article`/`compress` hints optional — and `read_zim`'s own output schema is
+    accepted directly, so a ZIM→ZIM copy is a single statement. Archive metadata,
+    a cover illustration, the main page, compression and a Xapian full-text index
+    are set through copy options, so the archive you write is immediately
+    searchable with `zim_search`. Writing never overwrites an existing file, and a
+    failed copy leaves nothing behind; `MAIN_PATH` and every redirect target are
+    validated against the entries actually written, because libzim silently accepts
+    a missing main page and silently drops dangling redirects.
 
     **Metadata, scalars & utilities**: `read_zim_metadata()`, `zim_metadata()` /
     `zim_metadata_keys()`, `zim_counter()` (the self-describing mimetype histogram),


### PR DESCRIPTION
Updates `zim` from the registered **0.6.2** to **0.8.1**. Three releases have landed since, so this adds a capability rather than only bumping a version.

Pinned to the release commit `df80e1e` rather than a tag ref, so the build cannot be retargeted after the fact.

## v0.7.0 — the extension can now write archives

`COPY (query) TO 'out.zim' (FORMAT zim, …)` builds a ZIM from any relation, so the `description`, `hello_world` and `extended_description` are updated — the entry previously described a read-only extension.

Columns resolve by name (`path` and `content` required; `title`, `mimetype`, `is_redirect`/`redirect_path` and libzim's hints optional), and `read_zim`'s own output schema is accepted directly, so a ZIM→ZIM copy is one statement. Metadata, a cover illustration, the main page, compression and a Xapian index are set through copy options, so a written archive is immediately searchable with `zim_search`.

Writing never overwrites an existing file, a failed copy leaves nothing behind, and `MAIN_PATH` and every redirect target are validated against the entries actually written — libzim silently accepts a missing main page and silently drops dangling redirects.

## v0.8.0 — pushdown correctness, cancellable scans, streaming `zim://`

- A pushed-down `WHERE mimetype …` was OR-ed into the `mimetype :=` argument instead of intersected, so a `WHERE` clause could make a query return **more** rows than the argument allowed.
- Long scans with a selective predicate could not be interrupted; measured 8.5s → 1.0s to respond to `Ctrl-C` on a 3M-entry archive.
- The `zim://` filesystem serves ranged reads instead of materialising whole entries — a 268 MB entry drops from 557 MB to 34 MB peak for a ranged consumer, and whole-entry reads got *faster* (48.7 ms → 25.7 ms). Also fixed an out-of-bounds read where `location + nr_bytes` could overflow past the bounds check.

## v0.8.1 — replaced archives no longer serve stale bytes

The archive pool cached an opened handle keyed by path and never revalidated it, so replacing a `.zim` in place — which is how Kiwix ships updates — kept serving the old archive for the life of the connection. It now reopens when `(dev, inode, mtime, size)` changes. Remote archives are exempt, since there is no `stat` over HTTP.

## Build metadata

`vcpkg_commit` is unchanged and still matches the extension's own CI pin. `excluded_platforms` is unchanged (Windows is still unsupported).

CI green on Linux x64/arm64, macOS x64/arm64, all three WASM variants, ThreadSanitizer, and the remote-search integration test. 538 assertions plus four shell-level harnesses.