### PR TITLE
laterite_ags4: bump to 0.11.0

### DIFF
--- a/extensions/laterite_ags4/description.yml
+++ b/extensions/laterite_ags4/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: laterite_ags4
   description: Read AGS4 geotechnical data files as typed, UUID-keyed tables directly from SQL — born-typed columns, deterministic content-addressed keys that join across groups by construction, and an embedded AGS dictionary. A read-only SQL surface. Local, http(s):// and s3:// (with httpfs).
-  version: 0.10.0
+  version: 0.11.0
   language: Rust
   build: cargo
   license: MIT
@@ -28,7 +28,7 @@ repo:
   github: niko86/laterite-duckdb
   # Pin to the release commit SHA once the repo is pushed + tagged (community-
   # extensions pins a SHA, not a branch). Placeholder until then:
-  ref: b6ef2debe3ebd6b7c72c81d0dcc9ff7b62e1ee31
+  ref: bae75a0daf8d026e282f5892ef535e32ed828d74
 
 docs:
   hello_world: |


### PR DESCRIPTION
Updates the `laterite_ags4` community extension to 0.11.0, pinned to release commit `bae75a0daf8d026e282f5892ef535e32ed828d74`.