### PR TITLE
markdown: v1.6.0

### DIFF
--- a/extensions/markdown/description.yml
+++ b/extensions/markdown/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: markdown
   description: Read, analyze, and write Markdown files with block-level document representation and inline element support
-  version: 1.5.1
+  version: 1.6.0
   language: C++
   build: cmake
   license: MIT
@@ -10,10 +10,11 @@ extension:
   vcpkg_commit: bffcbb75f71553824aa948a7e7b4f798662a6fa7
 repo:
   github: teaguesterling/duckdb_markdown
-  # andium (DuckDB v1.4.5 track) intentionally left at its prior commit; the
-  # v1.5.1 structured-inline change ships on the v1.5.x track via ref.
+  # andium (DuckDB v1.4.5 track) intentionally left at its prior commit; every
+  # change since -- v1.5.1 structured inline blocks, the v1.5.2 UTF-8 truncation
+  # fix, and v1.6.0 -- ships on the v1.5.x track via ref, which is a v1.5.4 tree.
   andium: c9e1a4d3b98a814c86295ecb2ed760be286242ba
-  ref: refs/tags/v1.5.1
+  ref: 3e8e0d59abce16c227f5d52d26fd094c9448917a
 docs:
   hello_world: |
     -- Load the extension


### PR DESCRIPTION
Updates `markdown` from the registered **1.5.1** to **1.6.0**, pinned to the release commit `3e8e0d5` rather than a tag ref.

Two releases have landed since 1.5.1, and the first is a data-corruption fix.

## v1.5.2 — silent UTF-8 truncation

Any string the extension trimmed lost **all** of its trailing non-ASCII characters, silently:

| in the document | 1.5.1 | 1.6.0 |
|---|---|---|
| `aé` | `a` | `aé` |
| `🎆` | *(empty)* | `🎆` |
| `HO Vrchlabí` | `HO Vrchlab` | `HO Vrchlabí` |

It affected table cells and headers, **frontmatter values**, **wikilink targets and aliases**, and code-fence info strings. The cause was `StringUtil::RTrim`'s `ch > 0 &&` guard: `char` is signed, so every UTF-8 byte ≥ 0x80 reads as negative and the reverse scan erases the whole trailing run. It never reproduced on ARM, where `char` is unsigned.

**Anyone on 1.5.1 parsing non-ASCII documents is affected**, and re-ingestion is required — the truncation happened at parse time, so stored values are already wrong.

## v1.6.0

- **One table parser.** `ParseBlocks` used cmark's GFM extension while the extraction functions used a hand-rolled regex, so the same document could yield different tables depending on which function you called. An escaped pipe `a \| b` used to truncate the cell to `a \`. Link and image cells keep their URLs byte-identically; presentational markup (`**bold**`, `` `code` ``) is now flattened to text.
- **`LIST(VARCHAR)` inputs** on all three readers, matching `read_csv` / `read_parquet` / `read_json`.
- **VFS and URI paths** — the markdown-file guard tested the filename suffix, rejecting `git://docs/X.md@HEAD`. The new rule is monotone, so `my@file.md` and `sftp://user@host/doc.md` still resolve.
- **`md_stats(doc, exact)`** — an overload rather than redefined fields, so the one-argument form is byte-for-byte unchanged.
- Fixes: JSON de-escaping in table cells, `]` inside a cell or header breaking the rows array, header-only tables aborting with an INTERNAL error, and a leading BOM breaking four functions.

## Notes

`andium` (DuckDB v1.4.5 track) is deliberately left at its prior commit — `ref` is a v1.5.4 tree. The explanatory comment is refreshed to name every change now riding on the v1.5.x track.

**1308 → 1499 assertions**, 26 → 36 test cases, skipped files 1 → 0.