### PR TITLE
read_lines: v0.3.0

### DIFF
--- a/extensions/read_lines/description.yml
+++ b/extensions/read_lines/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: read_lines
-  description: Read line-based text files with line numbers and efficient subset extraction. Supports glob patterns, line selection, and context lines around matches.
-  version: 0.2.1
+  description: Read line-based text files with line numbers and efficient subset extraction. Supports glob patterns, line selection with context, and GitHub-style '#L12-24' fragments so a line range can be attached to any path, including URIs served by other extensions.
+  version: 0.3.0
   language: C++
   build: cmake
   license: MIT
@@ -9,8 +9,10 @@ extension:
     - teaguesterling
 repo:
   github: teaguesterling/duckdb_read_lines
+  # andium (DuckDB v1.4.5 track) intentionally left at its prior commit; ref is a
+  # v1.5.4 tree, so v0.3.0 ships on the v1.5.x track only.
   andium: 8075509bc21b936c228879ada22c8a46657109aa
-  ref: refs/tags/v0.2.1
+  ref: 2426d08add6b0242572af2a75437aa6c67d4c970
 docs:
   hello_world: |
     -- Read all lines from a file


### PR DESCRIPTION
Updates `read_lines` from the registered **0.2.1** to **0.3.0**, pinned to the release commit `2426d08` rather than a tag ref.

## `#L…` line specs for URI paths

```sql
SELECT * FROM read_lines('git://docs/SCHEMAS.md@HEAD#L11-L12');
SELECT * FROM read_lines('notes.md#L42 +/-3');
```

The existing `file.md:11-12` suffix cannot be used with any path containing a `:` — i.e. every URI. RFC 3986 §3.5 makes the fragment strippable *by definition*, so a downstream filesystem never sees it and no agreement is needed from the extension serving the path. It is also GitHub's line-link syntax, copy-pasteable from a browser.

One grammar, not two: `#L` introduces the *existing* line-spec grammar, and an `L` before any number is tolerated, so `#L123-L456` is a strict subset parsing as the ordinary range `123-456`.

`:N-M`, the two-argument form, and filenames legitimately containing `#` are unchanged — the literal path is tested first, so nothing that resolved before can now fail.

The catalog `description` is updated accordingly; it previously described only the older forms.

## Faster

125 MB / 2M-line file, min CPU-ms of 7 interleaved runs:

| | before | after |
|---|---|---|
| tail `'+5-'` | 890 ms | **180 ms** |
| full scan | 880 ms | **560 ms** |
| `count(*)` | 840 ms | **510 ms** |
| 79 KB × 500 reps | 550 ms | **280 ms** |

From-end references no longer read the file twice, and output goes into chunk vectors instead of a `Value` per cell. Nothing regressed, including small files; non-seekable sources fall back cleanly.

## Notes

`andium` (DuckDB v1.4.5 track) is unchanged. It carried no explanatory comment, unlike the `markdown` and `func_apply` entries, so one is added — without it the key reads as a stray, and I nearly removed it as such while preparing this.

**848 → 936 assertions.**