### PR TITLE
[Raster] Update extension to v1.5.0

### DIFF
--- a/extensions/raster/description.yml
+++ b/extensions/raster/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: raster
   description: DuckDB extension for reading and writing geospatial raster data using SQL.
-  version: 1.3.0
+  version: 1.4.0
   language: C++
   build: cmake
   excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads"
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: ahuarte47/duckdb-raster
-  ref: 8a77d293b1b59913bb993a561daa8d4d3ea72889
+  ref: 45d4e26ea8a44dd9dac9f3e5b92c1875d23516a6
 
 docs:
   hello_world: |

--- a/extensions/raster/description.yml
+++ b/extensions/raster/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: raster
   description: DuckDB extension for reading and writing geospatial raster data using SQL.
-  version: 1.4.0
+  version: 1.5.0
   language: C++
   build: cmake
   excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads"
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: ahuarte47/duckdb-raster
-  ref: 45d4e26ea8a44dd9dac9f3e5b92c1875d23516a6
+  ref: a2690f6b67dbd2555cf971cd9b9fceb9a977d9be
 
 docs:
   hello_world: |


### PR DESCRIPTION
Changes:
* New `RT_Create` function to create a new raster file with specified parameters (CRS, BBOX, raster size, number of bands, data type, nodata value, etc.).
* Add `lerc`, `webp` and `zstd` encoding to Gtiff reader.
* New `ignore_nodata` parameter in the `RT_ReadCells` function. It allows to ignore cells with nodata values when reading raster data. The `ignore_nodata` parameter can take the following values:
  - `0`: Never ignore cells (default).
  - `1`: Ignore cells with at least one band having a nodata value.
  - `2`: Ignore cells with all bands having nodata values.
