### PR TITLE
anndata 0.14.7

### DIFF
--- a/extensions/anndata/description.yml
+++ b/extensions/anndata/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: anndata
   description: Read AnnData (.h5ad) files for single-cell genomics data analysis, with support for local and remote (HTTP/HTTPS/S3) files
-  version: 0.14.5
+  version: 0.14.7
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: honicky/anndata-duckdb-extension
-  ref: 283a556a3258f251a45691b5df64940a161d0eb5
+  ref: 208e55eab2e8f92d3f15eccd4ae3a0313582eddc
 
 docs:
   hello_world: |


### PR DESCRIPTION
Updates the anndata descriptor to v0.14.7 (`ref` is the annotated tag object, matching prior releases).

Routine version bump, plus one notable change: **this is the first release with working WebAssembly builds.** Previously the wasm side module was published without HDF5 linked in (`LINKED_LIBS` was never passed, and `-sSIDE_MODULE=2` tolerates unresolved symbols), so `LOAD anndata` failed at dlopen in duckdb-wasm ([honicky/anndata-duckdb-extension#24](https://github.com/honicky/anndata-duckdb-extension/issues/24)). As of 0.14.7:

- the side module statically links HDF5 + zlib + szip + aec (`wasm_mvp`, `wasm_eh`; ~3 MB each)
- file access works lazily via an HDF5 virtual file driver backed by `duckdb::FileSystem` — registered buffers, `registerFileHandle` files, and CORS-enabled HTTP/S3 URLs are read by byte range, so multi-GB `.h5ad` files are queryable in a browser
- CI now gates every wasm artifact on a link-level symbol-contract check plus a real `INSTALL`/`LOAD`/query smoke test under `@duckdb/duckdb-wasm`
- `wasm_threads` is not built (upstream `-fwasm-exceptions` flag gap in extension-ci-tools plus non-pthread HDF5 archives), which matches the default jsDelivr bundle set

Live demo of the wasm build: https://honicky.github.io/anndata-duckdb-extension/

🤖 Generated with [Claude Code](https://claude.com/claude-code)