### PR TITLE
Add pintail community extension

### DIFF
--- a/extensions/pintail/description.yml
+++ b/extensions/pintail/description.yml
@@ -1,0 +1,27 @@
+extension:
+  name: pintail
+  description: Lightweight geospatial indexing functions for DuckDB, including Geohash encoding, GEOMETRY decoding, bounding boxes, and neighbors.
+  version: 0.1.0
+  language: C++
+  build: cmake
+  license: Apache-2.0
+  maintainers:
+    - tshelianthus
+
+repo:
+  github: tshelianthus/duckdb-pintail
+  ref: ef5644d2450bcdf269482292e5ab78b7b24dccb3
+
+docs:
+  hello_world: |
+    INSTALL pintail FROM community;
+    LOAD pintail;
+
+    SELECT st_geohash(31.2304, 121.4737, 6);
+
+  extended_description: |
+    Pintail is a lightweight geospatial and spatial-indexing extension for DuckDB.
+    The initial release provides dependency-free Geohash encoding, native Core
+    GEOMETRY decoding (POINT/POLYGON, EPSG:4326), bounding-box extraction, and
+    adjacent-cell operations implemented in C++17. Decode functions return
+    GEOMETRY(EPSG:4326) and do not require DuckDB Spatial, GEOS, or PROJ.


### PR DESCRIPTION
## Summary

Adds Pintail v0.1.0 to the DuckDB Community Extensions repository.

Pintail is a dependency-free C++17 geospatial indexing extension providing Geohash encoding, native Core GEOMETRY decoding, bounding-box extraction, and eight-direction neighbor lookup.

## Release details

- Source: https://github.com/tshelianthus/duckdb-pintail
- Version: `0.1.0`
- Fixed source ref: `ef5644d2450bcdf269482292e5ab78b7b24dccb3`
- License: Apache-2.0
- External dependencies: none
- Excluded platforms: none

## Validation

- Debug and release builds pass.
- SQLLogicTest suite passes.
- All 20 checks in the release-preparation PR passed: https://github.com/tshelianthus/duckdb-pintail/pull/1
- The post-merge workflow on `main` also passed: https://github.com/tshelianthus/duckdb-pintail/actions/runs/32503869834

## Example

```sql
INSTALL pintail FROM community;
LOAD pintail;
SELECT st_geohash(31.2304, 121.4737, 6);
```
