### PR TITLE
Add quack_flamegraph

### DIFF
--- a/extensions/quack_flamegraph/description.yml
+++ b/extensions/quack_flamegraph/description.yml
@@ -1,0 +1,55 @@
+extension:
+  name: quack_flamegraph
+  description: Query Brendan Gregg folded CPU/allocation profiles as DuckDB tables
+  version: 0.1.0
+  language: Rust
+  build: cargo
+  license: MIT
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw;linux_amd64_musl"
+  requires_toolchains: "rust;python3"
+  maintainers:
+    - kevintruong
+
+repo:
+  github: kevintruong/quack-flamegraph
+  ref: 253fab90fe4dcddc70f519ea79bd42dd74ce0d3d
+
+docs:
+  hello_world: |
+    INSTALL quack_flamegraph FROM community;
+    LOAD quack_flamegraph;
+
+    -- Hottest self time
+    SELECT leaf, exclusive
+    FROM flamegraph_exclusive('cpu.folded')
+    ORDER BY exclusive DESC
+    LIMIT 10;
+
+    -- Sample coverage (inclusive)
+    SELECT frame, inclusive
+    FROM flamegraph_inclusive('cpu.folded')
+    ORDER BY inclusive DESC
+    LIMIT 10;
+
+    -- Raw stacks
+    SELECT list_extract(frames, -1) AS leaf, samples
+    FROM read_folded('cpu.folded')
+    ORDER BY samples DESC
+    LIMIT 10;
+
+  extended_description: |
+    `quack_flamegraph` reads [folded stack](https://www.brendangregg.com/FlameGraphs/cpuflamegraphs.html)
+    files produced by `stackcollapse-*`, `perf --folded`, samply/xctrace collapse, and similar tools.
+
+    ### Functions
+
+    - `read_folded(path)` — table function returning `frames VARCHAR[]`, `samples BIGINT`, `source VARCHAR`
+    - `flamegraph_exclusive(path)` — leaf self-time (`GROUP BY` last frame)
+    - `flamegraph_inclusive(path)` — `unnest(frames)` (recursive names inflate)
+    - `flamegraph_coverage(path)` — unique-stack sample presence (`list_distinct`)
+    - `flamegraph_edges(path)` — parent→child sample mass
+    - `flamegraph_hot_stacks(path)` — stacks ordered for concentration checks
+
+    The parser drops zero-sample parent frames (common in Instruments/sample collapse), takes the last space-separated field as the count, and strips an optional `Thread_…:` prefix.
+
+    Built with DuckDB's [Rust C Extension API template](https://github.com/duckdb/extension-template-rs).


### PR DESCRIPTION
Adds `quack_flamegraph`, a DuckDB Rust C-API extension that queries [Brendan Gregg folded](https://www.brendangregg.com/FlameGraphs/cpuflamegraphs.html) CPU/allocation profiles as tables.

### Source

https://github.com/kevintruong/quack-flamegraph at `253fab90fe4dcddc70f519ea79bd42dd74ce0d3d`

Layout matches [extension-template-rs](https://github.com/duckdb/extension-template-rs): `cdylib`, `duckdb_entrypoint_c_api`, SQLLogic tests, `Main Extension Distribution Pipeline`.

### Build status

The extension repo pipeline is green on this listing SHA (wasm skipped — unstable C API / `C_STRUCT_UNSTABLE` is native-only, same as other Rust C-API listings):

https://github.com/kevintruong/quack-flamegraph/actions/runs/32505244263

`excluded_platforms` lists wasm, `linux_amd64_musl`, `windows_amd64_mingw`, and `windows_amd64_rtools`. Linux amd64/arm64, macOS amd64/arm64, and Windows MSVC build and pass the SQL tests.

### Functions

| Function | Purpose |
|---|---|
| `read_folded(path)` | folded stacks as `frames VARCHAR[]`, `samples BIGINT`, `source VARCHAR` |
| `flamegraph_exclusive(path)` | leaf self-time |
| `flamegraph_inclusive(path)` | unnest sample coverage (recursive names inflate) |
| `flamegraph_coverage(path)` | unique-stack sample presence |
| `flamegraph_edges(path)` | parent→child sample mass |
| `flamegraph_hot_stacks(path)` | fat stacks for concentration checks |

### License

MIT.