### PR TITLE
Update dicom extension to v0.7.0

### DIFF
--- a/extensions/dicom/description.yml
+++ b/extensions/dicom/description.yml
@@ -2,7 +2,7 @@ extension:
   name: dicom
   description: |
     DuckDB integration with medical imaging data (DICOM - Digital Imaging and Communication in Medicine).
-  version: 0.6.1
+  version: 0.7.0
   language: C++
   build: cmake
   excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads"
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: nmontesg/duck-dicom
-  ref: v0.6.1
+  ref: v0.7.0
 
 docs:
   hello_world: |


### PR DESCRIPTION
This PR updates the `dicom` extension to version v0.7.0:
* The main change is a fixing of a memory leak in the `retrieve_dicom` function when using `load_pixel_data=false` (the default arg value)
* Other minor changes include better includes organization, documentation fixes for the networking functions, and registering function information objects (instead of functions) to expose their documentation in table `duckdb_functions()`. 