### PR TITLE
erpl_tunnel: bump to 2026.08.22

### DIFF
--- a/extensions/erpl_tunnel/description.yml
+++ b/extensions/erpl_tunnel/description.yml
@@ -1,15 +1,20 @@
 extension:
   name: erpl_tunnel
   description: Reach any TCP service from DuckDB through an SSH bastion, Tailscale or NetBird — and publish local ports back onto those networks.
-  version: 2026.08.07
+  version: 2026.08.22
   language: C++
   build: cmake
   license: BSL 1.1
   excluded_platforms: "windows_amd64_rtools;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads;"
   requires_toolchains: "go"
+  # vcpkg.json pins builtin-baseline 84bab45d to hold openssl at 3.5.0: the newer
+  # 3.6.0 requires Linux kernel headers the arm64 build container does not carry.
+  # Without this the non-v1.5.5 builds would use the older default pin, which
+  # predates that baseline.
+  vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
   maintainers:
     - jrosskopf
 
 repo:
   github: DataZooDE/erpl-tunnel
-  ref: 08750ac79a773fd8712c686c091f8ea89c94ceac
+  ref: 01e6ebecdeab583cd7fdf5800856ff950a9f0fdf


### PR DESCRIPTION
Bumps `erpl_tunnel` from `2026.08.07` to `2026.08.22` ([release](https://github.com/DataZooDE/erpl-tunnel/releases/tag/v2026.08.22)).

## What changed

**Registering a function name the catalog already holds no longer aborts the whole `LOAD`.** `ExtensionLoader::RegisterFunction(PragmaFunction)` and the `CreateTableFunctionInfo` overload leave `on_conflict` at `ERROR_ON_CONFLICT`, so a pre-existing entry under one of our names took the extension down with `Pragma Function with name "tunnel_create" already exists!`, leaving it half-registered (`loaded = false`, some functions silently missing). Registrations now replace a conflicting entry.

This matters because the companion `erpl` extension has dropped its own bundled SSH tunnel and leaves deprecation stubs under these names pointing here — so the two need to be loadable together.

Plus per-platform smoke tests of the shipped artifact, and a CI fix for the v1.4.5 Windows and Linux arm64 builds.

## Note on `vcpkg_commit`

This bump adds an explicit `vcpkg_commit: 84bab45d…`, matching the default this repo already uses for DuckDB v1.5.5.

The extension's `vcpkg.json` now carries a `builtin-baseline` of that commit in order to hold `openssl` at 3.5.0: openssl 3.6.0 requires Linux kernel headers that the arm64 build container does not carry, and fails with `building openssl:arm64-linux-release failed with: BUILD_FAILED`. Without the pin, non-`v1.5.5` builds would fall back to the older `ce613c41…` default, which predates that baseline.