### PR TITLE
Update motorsport_telemetry to 0.8.0

### DIFF
--- a/extensions/motorsport_telemetry/description.yml
+++ b/extensions/motorsport_telemetry/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: motorsport_telemetry
-  description: Query Cosworth PDS, MoTeC LD, and Racelogic VBOX telemetry directly in DuckDB
-  version: 0.6.1
+  description: Query AiM MP4, Cosworth PDS, MoTeC LD, and Racelogic VBOX telemetry directly in DuckDB
+  version: 0.8.0
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: tobi/duckdb_motorsport_telemetry
-  ref: 8cc06a597e33e7558be759cbffa44f2a2e1baa49
+  ref: e59091ede5322ac5e0f5a75971d273f04e6b461e
 
 docs:
   hello_world: |
@@ -24,11 +24,26 @@ docs:
     FROM read_telemetry('run.ld',
       rate := 100,
       channels := 'Ground Speed,Throttle Pos,Brake Pedal Pos');
+
+    SELECT name, unit, frequency_hz, sample_count
+    FROM telemetry_metadata('run.mp4')
+    WHERE sample_count > 0;
+
+    SELECT *
+    FROM read_aim('run.mp4',
+      rate := 10,
+      channels := 'RPM,GPS Speed,GPS Latitude,GPS Longitude');
   extended_description: |
-    `motorsport_telemetry` reads Pi Research/Cosworth PDS, MoTeC i2 LD, and
-    Racelogic VBOX VBO telemetry without an export step. It provides exact
-    channel metadata, native-rate long-form samples, and projected wide readers
-    with time/channel pruning and type-aware interpolation. Integer and event
-    channels always use previous-value semantics; only floating-point channels
-    can interpolate linearly. The parsers memory-map native files and table
-    functions produce vectorized DuckDB output.
+    `motorsport_telemetry` reads AiM `aimd` telemetry embedded in MP4, Pi
+    Research/Cosworth PDS, MoTeC i2 LD, and Racelogic VBOX VBO files without an
+    export step. AiM MP4 support is native-only; the DuckDB-Wasm build does not
+    link the AiM parser, so `.mp4` inputs and the `read_aim`/`read_aimd`
+    functions are unavailable in the browser. The native reader exposes scalar
+    `CHS` channels and expands each valid 56-byte `GPS0` aggregate into 16 GPS
+    channels, including WGS84 position, speed, heading, accuracy, timing, and
+    status. It provides exact channel metadata, native-rate long-form samples,
+    and projected wide readers with time/channel pruning and type-aware
+    interpolation. Integer and event channels always use previous-value
+    semantics; only floating-point channels can interpolate linearly. The
+    parsers memory-map native files and table functions produce vectorized
+    DuckDB output.


### PR DESCRIPTION
Updates `motorsport_telemetry` from 0.6.1 to 0.8.0 (source: https://github.com/tobi/duckdb_motorsport_telemetry, ref `e59091ede5322ac5e0f5a75971d273f04e6b461e`, tag `v0.8.0`).

Changes since 0.6.1:
- AiM `aimd` telemetry embedded in MP4 is supported natively (`read_aim` / `read_aimd`, plus auto-detection in `read_telemetry`, `telemetry_metadata`, `telemetry_samples`). Wasm targets stay excluded.
- The parsers now live in the tagged `motorsport-telemetry-rs` v1.1.0 crates: sample timelines follow the logger's own timestamps, lap boundaries come from the lap timer, and Cosworth `Global Time` is read as an absolute clock. Some 2025 Cosworth PDS layouts that previously decoded incorrectly now read cleanly.
- Unit provenance (`unit_source`), the unit registry (`telemetry_convert`, `telemetry_units`), `channel_map`, `write_telemetry` (MoTeC LD export), and `telemetry_column_comments`.

Unit and SQL integration tests pass on linux_amd64 against DuckDB 1.5.x; excluded platforms are unchanged from 0.6.1.