### PR TITLE
anofox_tabular: 2026.08.22

### DIFF
--- a/extensions/anofox_tabular/description.yml
+++ b/extensions/anofox_tabular/description.yml
@@ -9,4 +9,4 @@ extension:
     - jrosskopf
 repo:
   github: DataZooDE/anofox-tabular
-  ref: 53658d32f3c7e530f9e135640def86243102b824
+  ref: 40ab2d3ce2760e77f0b64824852ac6adefad291b


### PR DESCRIPTION
Update anofox_tabular to release v2026.08.22 (`40ab2d3ce2760e77f0b64824852ac6adefad291b`).

Highlights since the previous pinned ref:
- New data-quality check primitives: `regex_match`, `values_in_set`, `agg_check`, `duplicate_count`, `occurrence`, `match_rate` (referential integrity), `compliance` (custom SQL predicate with bind-time validation)
- Time-aware checks: `rel_count_change`, `metric_anomaly_iqr`, `rolling_values_in_set`
- Config-driven check-suite runner `run_checks(checks_table)` with a uniform result schema, monitor-only severity, identifier partitioning and result persistence
- DuckDB target bumped to v1.5.5

The release pipeline in DataZooDE/anofox-tabular is fully green on this commit (build, sqllogictests, smoke test and deploy on linux_amd64, windows_amd64, osx_amd64, osx_arm64). Excluded platforms are unchanged.