### PR TITLE
fit: update to v1.0.2

### DIFF
--- a/extensions/fit/description.yml
+++ b/extensions/fit/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: fit
   description: Read Garmin .fit files using DuckDB - GPS tracks, heart rate, power metrics, and fitness device data
-  version: 1.0.1
+  version: 1.0.2
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: antoriche/duckdb-fit-extension
-  ref: d6f8a4660b3dec837ccc9b369b7a7f5a2f85bbb1
+  ref: 3ec9b4137afdd103deb058109eb7eba189691356
 
 docs:
   hello_world:  |


### PR DESCRIPTION
Updates the `fit` extension to **v1.0.2**.

## What's new
- Read compressed FIT files directly: `.fit.gz` and `.fit.zst` are decompressed as they are read (`SELECT * FROM fit_records('ride.fit.gz')`).
- New `compression` parameter to override extension-based detection (`auto`, `infer`, `gzip`, `zstd`, `uncompressed`, `none`).

## Changes to description.yml
- `version`: 1.0.1 → 1.0.2
- `ref`: pinned to tag `v1.0.2` (`3ec9b4137afdd103deb058109eb7eba189691356`)

Upstream release: https://github.com/antoriche/duckdb-fit-extension/releases/tag/v1.0.2