### PR TITLE
luajit: bump to v0.32.2 — fix luajit_table parallel 0-rows

### DIFF
--- a/extensions/luajit/description.yml
+++ b/extensions/luajit/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: alitrack/duckdb-luajit
-  ref: refs/tags/v0.32.2
+  ref: 7dc1ada394605fc1f62401d4a0d60613d0e920d0
 
 docs:
   hello_world: |

--- a/extensions/luajit/description.yml
+++ b/extensions/luajit/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: luajit
   description: "In-process LuaJIT UDFs for DuckDB — JIT-compiled, parallel (per-thread states), trusted sandbox, GROUP BY aggregates, LIST/STRUCT/MAP bridges, embedded Fennel compiler"
-  version: 0.32.1
+  version: 0.32.2
   language: C
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: alitrack/duckdb-luajit
-  ref: refs/tags/v0.32.1
+  ref: refs/tags/v0.32.2
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps the luajit community-extension pointer from v0.32.1 to v0.32.2.

## What changed (source: alitrack/duckdb-luajit@v0.32.2)
**Bug fix — `luajit_table` returned 0 rows under default multi-thread.**
Root cause: `g_lua` is thread-local (per-thread Lua state). `quick_compile`/`install`
register the lib as a Lua global in only the *calling* thread's state, but the table
function's `tbt_init` can run on a *different* worker thread whose state lacks the
global. The old code fell back to `luaL_loadstring(name)`, which compiled the **name**
(a bare identifier) as source → evaluated to `nil` → not a table → `nrows=0` → silent
0 rows. Flaky: reproduced as `\[3,3,3,0,3,3\]` under default threads; stable with
`set threads=1`.

Fix: `tbt_init` now resolves the lib name in three tiers — (1) local global, (2) the
shared C source table (`udf_source_get`, populated by quick_compile/install and visible
across threads), (3) inline source — mirroring the lazy-compile pattern already used in
`agg_finalize`.

**Feature — module-table `.run` action dispatch** (`luajit_s('incremental', opts)`
invokes action libs after `install`).

## Verification (DuckDB v1.5.5, default threads)
- 30/30 fresh sessions, 6/6 sequential calls in one session, day/lc5/day mixed — all pass
- inline source 10/10; unregistered name → 0 rows, no crash
- full 20-file library regression: PASS=20 FAIL=0

No description.yml version/ref change needed in the source repo (hotfix per project
release convention — the pointer in this file is the single source of truth for the
community build).