### PR TITLE
webbed: v2.7.0

### DIFF
--- a/extensions/webbed/description.yml
+++ b/extensions/webbed/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: webbed
   description: Comprehensive processing extension for web markup languages (XML and HTML) with SAX streaming for large files, intelligent schema inference, XPath-based data extraction, and HTML table parsing.
-  version: 2.6.1
+  version: 2.7.0
   language: C++
   build: cmake
   license: MIT
@@ -15,9 +15,9 @@ extension:
 repo:
   github: teaguesterling/duckdb_webbed
   andium: ddda30f11352138b2451657419640370d1612137
-  # andium (DuckDB v1.4.5 track) left at its prior commit; the v2.6.1
-  # structured-inline fix ships on the v1.5.x track via ref.
-  ref: refs/tags/v2.6.1
+  # andium (DuckDB v1.4.5 track) left at its prior commit; the v2.7.0
+  # correctness fixes ship on the v1.5.x track via ref.
+  ref: c1b32efa4b8106d04ae74d0d898d9a650461792f
 docs:
   docs_url: https://duckdb-webbed.readthedocs.io
   hello_world: |
@@ -90,4 +90,4 @@ docs:
 
     See https://duckdb-webbed.readthedocs.io for comprehensive documentation and examples.
 
-    Built on libxml2 for robust, standards-compliant parsing with comprehensive error handling and memory-safe RAII implementation. 91 test suites with 3011 assertions, including DOM/SAX equivalence, adversarial/security, and multi-file parallelism testing. The extension supports mixed file systems, configurable schema inference, and efficient processing of large document collections.
+    Built on libxml2 for robust, standards-compliant parsing with comprehensive error handling and memory-safe RAII implementation. 94 test suites with 3155 assertions, including DOM/SAX equivalence, adversarial/security, and multi-file parallelism testing. The extension supports mixed file systems, configurable schema inference, and efficient processing of large document collections.


### PR DESCRIPTION
Bumps `webbed` to v2.7.0 — a correctness release covering five reported issues.

- **#129** — `html_extract_*` now accepts plain `VARCHAR`, so `html_extract_text(content, '//h2')` works without an explicit `::HTML` cast.
- **#130** — `html_extract_tables_json` was unusable: a table with no `<th>` raised an `INTERNAL` error, and the declared return type never matched the value (the `rows` element type was derived from the document's own header names, so any cast or field access failed). The content-dependent field is replaced by a fixed-shape `table_json VARCHAR`.
- **#131** — `<tfoot>` rows were dropped or silently relabelled as data; `html_extract_table_rows` now reports `row_type = 'footer'`.
- **#132** — control characters below `0x20` were copied through verbatim, producing invalid JSON.
- **#134** — a syntactically invalid XPath silently returned empty, indistinguishable from a valid expression that matched nothing. It now raises. An *undeclared namespace prefix* still returns empty, since that fails at evaluation rather than at parse.

Release notes: https://github.com/teaguesterling/duckdb_webbed/releases/tag/v2.7.0

`ref` is the raw v2.7.0 commit (`c1b32ef`) rather than a tag ref. All shippable platforms are green on that commit: linux amd64/arm64, osx amd64/arm64, windows amd64, and wasm mvp/eh/threads.

`andium` (DuckDB v1.4.5 track) stays at its prior commit; these fixes ship on the v1.5.x track via `ref`.