### PR TITLE
Update substrait extension to 1.5.5

### DIFF
--- a/extensions/substrait/description.yml
+++ b/extensions/substrait/description.yml
@@ -1,11 +1,12 @@
 extension:
   name: substrait
   description: Allows conversion execution of Substrait query plans
-  version: 1.5.4
+  version: 1.5.5
   language: C++
   build: cmake
   license: Apache-2.0
   maintainers:
+    - andrew-coleman
     - anshuldata
     - cgkiran
     - EpsilonPrime
@@ -13,7 +14,7 @@ extension:
 
 repo:
   github: substrait-io/duckdb-substrait-extension
-  ref: e61b3bdf6fa92120b52b583914b742b9f3c50130
+  ref: 4ea63ddbd67c4e511fcf10c9ff63cd6185c389ea
 
 docs:
   hello_world: |


### PR DESCRIPTION
Updates the `substrait` community extension to 1.5.5.

- Bumps `repo.ref` to the current upstream main tip `4ea63ddb`, which includes the DuckDB v1.5.5 upgrade plus nine follow-up fixes.
- Bumps `extension.version` 1.5.4 → 1.5.5.
- Adds `andrew-coleman` as a maintainer.

Supersedes #2369.
