### PR TITLE
Add duckdb_rphonetic: Kölner Phonetik and Daitch-Mokotoff Soundex

### DIFF
--- a/extensions/duckdb_rphonetic/description.yml
+++ b/extensions/duckdb_rphonetic/description.yml
@@ -5,6 +5,8 @@ extension:
   language: Rust
   build: cmake
   license: Apache-2.0
+  requires_toolchains: "rust;python3"
+  excluded_platforms: "linux_amd64_musl"
   maintainers:
     - guizmaii
 

--- a/extensions/duckdb_rphonetic/description.yml
+++ b/extensions/duckdb_rphonetic/description.yml
@@ -1,0 +1,53 @@
+extension:
+  name: duckdb_rphonetic
+  description: Phonetic algorithms for German and European name matching
+  version: 0.1.0
+  language: Rust
+  build: cmake
+  license: Apache-2.0
+  maintainers:
+    - guizmaii
+
+repo:
+  github: guizmaii-opensource/duckdb-rphonetic
+  ref: a7cee7a7ab8f7d32fd1474b66b9ba6ac2f6f27d2
+
+docs:
+  hello_world: |
+    -- Kölner Phonetik: a German-language counterpart to Soundex.
+    -- Spelling variants of the same name encode identically.
+    SELECT cologne_phonetic('Müller'), cologne_phonetic('Mueller');
+    -- 657, 657
+
+    -- Daitch-Mokotoff Soundex returns SEVERAL codes for ambiguous spellings,
+    -- so a match is a set overlap rather than an equality test.
+    SELECT daitch_mokotoff('Klein'), daitch_mokotoff('Cleyn');
+    -- [586000], [586000, 486000]
+
+    SELECT list_has_any(daitch_mokotoff('Klein'), daitch_mokotoff('Cleyn'));
+    -- true
+  extended_description: |
+    Two phonetic encoders aimed at European name matching, wrapping the
+    [rphonetic](https://crates.io/crates/rphonetic) crate by Dalvany — a Rust
+    port of Apache Commons Codec.
+
+    * `cologne_phonetic(VARCHAR) -> VARCHAR` — Kölner Phonetik (Postel, 1969),
+      the German-language counterpart to Soundex. Handles umlauts and ß, so
+      `Müller` and `Mueller` share a code.
+    * `daitch_mokotoff(VARCHAR) -> VARCHAR[]` — Daitch-Mokotoff Soundex, built
+      for Germanic and Slavic surnames. Returns a list because ambiguous
+      spellings legitimately encode several ways; match with `list_has_any`.
+
+    Neither exists in core DuckDB, whose `soundex` and `double_metaphone` are
+    tuned for English. Trigram similarity is not a substitute: `Klein` and
+    `Cleyn` share no trigrams at all, yet both encoders match them.
+
+    **Behavioural note.** Kölner Phonetik implementations disagree on whether a
+    dropped `0` breaks a run of identical digits. This extension follows
+    `rphonetic`, which yields `cologne_phonetic('Dieter') = '227'`; Apache
+    Commons Codec yields `27`. The two differ on 36 of a 279-name test corpus.
+    Every divergence is committed to the repository and pinned by a test, so the
+    output cannot change silently. The published reference vectors
+    (`Müller-Lüdenscheidt` -> `65752682`, `Wikipedia` -> `3412`,
+    `Breschnew` -> `17863`) are unaffected. Daitch-Mokotoff agrees with
+    Commons Codec on all 279 names.

--- a/extensions/duckdb_rphonetic/description.yml
+++ b/extensions/duckdb_rphonetic/description.yml
@@ -12,7 +12,8 @@ extension:
 
 repo:
   github: guizmaii-opensource/duckdb-rphonetic
-  ref: a7cee7a7ab8f7d32fd1474b66b9ba6ac2f6f27d2
+  # v0.1.0
+  ref: b74284d0dfc71c94859468aef6ac4bbd0981dd19
 
 docs:
   hello_world: |


### PR DESCRIPTION
Adds `duckdb_rphonetic`, two phonetic encoders for European name matching.

| Function | Signature |
|---|---|
| `cologne_phonetic` | `VARCHAR -> VARCHAR` |
| `daitch_mokotoff` | `VARCHAR -> VARCHAR[]` |

```sql
SELECT cologne_phonetic("Müller"), cologne_phonetic("Mueller");   -- 657, 657
SELECT list_has_any(daitch_mokotoff("Klein"), daitch_mokotoff("Cleyn"));  -- true
```

**Why:** core DuckDB ships `soundex` and `double_metaphone`, both tuned for English. Neither Kölner Phonetik (the German-language counterpart to Soundex) nor Daitch-Mokotoff (built for Germanic and Slavic surnames) is available. Trigram similarity is not a substitute — `Klein` and `Cleyn` share no trigrams at all, yet both encoders match them.

Daitch-Mokotoff returns a list rather than a scalar because ambiguous spellings legitimately encode several ways; matching is a set overlap via `list_has_any`.

**Implementation:** a thin wrapper over the [`rphonetic`](https://crates.io/crates/rphonetic) crate by Dalvany, a Rust port of Apache Commons Codec. Apache-2.0, with a `NOTICE` crediting both.

**Testing:** Apache Commons Codec 1.22.1 is used as an oracle over a 279-name corpus. `test/oracle/run.sh` regenerates the expected values from the Maven Central jar, so the committed fixtures are reproducible rather than asserted. Daitch-Mokotoff agrees with Commons Codec on all 279 names, values and order.

**One behavioural note, documented rather than hidden.** Kölner Phonetik implementations disagree on whether a dropped `0` breaks a run of identical digits. This extension follows `rphonetic` — `cologne_phonetic("Dieter") = "227"` where Commons Codec gives `27` — and the two differ on 36 of the 279 names. Every divergence is committed and pinned by a test, so an upstream bump cannot change output silently. The published reference vectors (`Müller-Lüdenscheidt` → `65752682`, `Wikipedia` → `3412`, `Breschnew` → `17863`) are unaffected.

CI is green on all 9 platforms at the pinned ref (linux amd64/arm64, macOS x86_64/arm64, Windows amd64/mingw, wasm mvp/eh/threads), with the SQL suite executing on linux_amd64, both Windows targets and osx_arm64.