### PR TITLE
oracle_scanner: bump to 0.2.0

### DIFF
--- a/extensions/oracle_scanner/description.yml
+++ b/extensions/oracle_scanner/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: oracle_scanner
   description: Read and write Oracle Database with no Oracle client
-  version: '0.1.0'
+  version: '0.2.0'
   language: C++
   build: cmake
   license: Apache-2.0
@@ -12,4 +12,5 @@ extension:
 
 repo:
   github: krokozyab/quack-oracle
-  ref: 6f454dbe00c28fddd0132f49439eba261852e08c
+  # The commit tagged v0.2.0, pinned by SHA so what is built cannot move.
+  ref: 60bb95fa0bba53ec7446aa810042e2055758ef64


### PR DESCRIPTION
Opens an OCI wallet through its auto-login cwallet.sso, so WALLET_PASSWORD is no longer required. The ref is the commit tagged v0.2.0