### PR TITLE
Update jsono to 0.1.2

### DIFF
--- a/extensions/jsono/description.yml
+++ b/extensions/jsono/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: jsono
   description: Analytics-optimized JSON storage — parse one time and read many times, and shred hot paths into typed columns for pushdown and row-group pruning
-  version: 0.1.1
+  version: 0.1.2
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: Flamefork/duckdb-jsono
-  ref: v0.1.1
+  ref: v0.1.2
 
 docs:
   hello_world: |

--- a/extensions/jsono/description.yml
+++ b/extensions/jsono/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: Flamefork/duckdb-jsono
-  ref: v0.1.2
+  ref: 2de74326d63862c3c5c60a919e136d19b412d0ca
 
 docs:
   hello_world: |


### PR DESCRIPTION
Updates the jsono community extension descriptor to release 0.1.2 and source tag v0.1.2.

Validation:
- Source tag CI passed on Linux, macOS, Windows, and WebAssembly.
- The community-extensions descriptor parser resolves the source ref to v0.1.2.