### PR TITLE
Add DocumentDB extension

### DIFF
--- a/extensions/documentdb/description.yml
+++ b/extensions/documentdb/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: documentdb/duckdb-documentdb
-  ref: 4f2316f0f14c08f107a8e1d573d0439bfcfe26e4
+  ref: 333524efa1067bff895013ecb718ac55363a1e09
 
 docs:
   hello_world: |

--- a/extensions/documentdb/description.yml
+++ b/extensions/documentdb/description.yml
@@ -4,6 +4,7 @@ extension:
   version: 0.1.0
   language: C++
   build: cmake
+ vcpkg_commit: bd93b56711a393a3c498991e023f94b7542832bb
   license: MIT
   maintainers:
     - sandeepsnairms

--- a/extensions/documentdb/description.yml
+++ b/extensions/documentdb/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: documentdb/duckdb-documentdb
-  ref: 98eb567a7308aaa4cf2303b55f11e10bc9aba269
+  ref: 4f2316f0f14c08f107a8e1d573d0439bfcfe26e4
 
 docs:
   hello_world: |

--- a/extensions/documentdb/description.yml
+++ b/extensions/documentdb/description.yml
@@ -1,0 +1,26 @@
+extension:
+  name: documentdb
+  description: DuckDB extension for DocumentDB metadata and SQL integration, with schema inference scaffolding and collection access helpers.
+  version: 0.1.0
+  language: C++
+  build: cmake
+  license: MIT
+  maintainers:
+    - sandeepsnairms
+  excluded_platforms: wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;
+
+repo:
+  github: documentdb/duckdb-documentdb
+  ref: 98eb567a7308aaa4cf2303b55f11e10bc9aba269
+
+docs:
+  hello_world: |
+    LOAD 'documentdb';
+
+    SELECT documentdb_version('documentdb') AS version;
+    SELECT documentdb_collections('app') AS collections;
+  extended_description: |
+    The duckdb-documentdb extension provides a DuckDB-facing integration layer for DocumentDB-style document collections.
+    The current implementation includes extension registration, collection metadata functions, and an initial schema inference
+    and scan-planning scaffold. It is intended to enable direct SQL querying and analytical access to document data without
+    an ETL step, while remaining compatible with the broader DuckDB extension model.

--- a/extensions/documentdb/description.yml
+++ b/extensions/documentdb/description.yml
@@ -4,7 +4,7 @@ extension:
   version: 0.1.0
   language: C++
   build: cmake
- vcpkg_commit: bd93b56711a393a3c498991e023f94b7542832bb
+  vcpkg_commit: bd93b56711a393a3c498991e023f94b7542832bb
   license: MIT
   maintainers:
     - sandeepsnairms

--- a/extensions/documentdb/description.yml
+++ b/extensions/documentdb/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: documentdb/duckdb-documentdb
-  ref: d60d7f8a3d4f590d7cc46ce3eb2722fda4faae5a
+  ref: 42543feb3f63847563623ee7ba8c6d6983ed5424
 
 docs:
   hello_world: |

--- a/extensions/documentdb/description.yml
+++ b/extensions/documentdb/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: documentdb/duckdb-documentdb
-  ref: 333524efa1067bff895013ecb718ac55363a1e09
+  ref: d60d7f8a3d4f590d7cc46ce3eb2722fda4faae5a
 
 docs:
   hello_world: |


### PR DESCRIPTION
The documentdb extension provides a DuckDB-facing integration layer for DocumentDB-style document collections. It includes extension registration, collection metadata access, and an initial schema inference and scan-planning scaffold aimed at enabling SQL-driven analytical access to document data without requiring an ETL step.

## What is included
- Extension registration and version metadata
- Collection discovery and metadata helpers
- Initial schema inference support
- Query planning scaffold for document collection access
- Compatibility with the standard DuckDB extension model

## Why this is useful
This allows users to work with DocumentDB-style collections directly from DuckDB, opening the door to SQL-based analysis over document data while keeping the extension modular and extensible for future features.

Example usage

```
LOAD 'documentdb';

SELECT documentdb_version('documentdb') AS version;
SELECT documentdb_collections('app') AS collections;
```

## Notes
This is an initial implementation focused on the integration foundation and metadata layer. It is intended to evolve into a fuller document-query experience while remaining consistent with DuckDB’s extension architecture.