### PR TITLE
Update duckdb-pst to 0.2.1

### DIFF
--- a/extensions/pst/description.yml
+++ b/extensions/pst/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: pst
   description: Read and edit in place Microsoft PST files with rich schemas for common MAPI types (emails, contacts, appointments, tasks)
-  version: 0.2.0
+  version: 0.2.1
   language: C++
   build: cmake
   excluded_platforms: "windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads"
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: intellekthq/duckdb-pst
-  ref: v0.2.0
+  ref: v0.2.1
 
 docs:
   hello_world: |

--- a/extensions/pst/description.yml
+++ b/extensions/pst/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: intellekthq/duckdb-pst
-  ref: v0.2.1
+  ref: d0a69a498c7726b7b75ed32616c7feac3271ff55
 
 docs:
   hello_world: |


### PR DESCRIPTION
https://github.com/intellekthq/duckdb-pst/releases/tag/v0.2.1

Fixes anonymous CI checkout by switching the microsoft-pst-sdk submodule from SSH to its public HTTPS URL.