### PR TITLE
Bump mongo extension to v0.2.7

### DIFF
--- a/extensions/mongo/description.yml
+++ b/extensions/mongo/description.yml
@@ -1,19 +1,19 @@
 extension:
   name: mongo
   description: Integrates DuckDB with MongoDB, enabling direct SQL queries over MongoDB collections without exporting data or ETL
-  version: 0.2.6
+  version: 0.2.7
   language: C++
   build: cmake
   license: MIT
   maintainers:
     - stephaniewang526
   # Optional: specify vcpkg commit if needed
-  vcpkg_commit: "9aa0650e5c8d23fe66701bafb3ec03ac732a3ff1"
+  vcpkg_commit: "f74a2eade17a628413746557d04db25ccf6e76f9"
   excluded_platforms: wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;
 
 repo:
   github: stephaniewang526/duckdb-mongo
-  ref: ee677c1392068aeb480e505b8b023d322ab0f4e0
+  ref: 5043b1d97ab815b99e162bab94be4e27508d1073
 
 docs:
   hello_world: |


### PR DESCRIPTION
- Bump `mongo` to **v0.2.7**
- Update `vcpkg_commit` to `f74a2ea` which ships `mongo-c-driver 2.3.1#2` with the upstream CMake 4.4 patch (CDRIVER-6367), fixing macOS arm64 and Windows build failures

cc @redox 