### PR TITLE
fusion_scanner 0.3.0

### DIFF
--- a/extensions/fusion_scanner/description.yml
+++ b/extensions/fusion_scanner/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: fusion_scanner
   description: Query Oracle Fusion from DuckDB through BI Publisher, with SSO, an ATTACH-able catalog and cached metadata
-  version: 0.2.0
+  version: 0.3.0
   language: C++
   build: cmake
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: krokozyab/ofquack
-  ref: 0bb99ecbfdace76e2bc25245767279d2910ff604
+  ref: 8490c817869f4049b9372e9520cf081a4c80f5b4
 
 docs:
   hello_world: |


### PR DESCRIPTION
The attached catalog now lists every table in the dictionary, and cached metadata no longer expires by age. Pins ref to 8490c81, whose full build matrix passed on DuckDB v1.5.5.