### PR TITLE
yaml: bump to v1.8.0

### DIFF
--- a/extensions/yaml/description.yml
+++ b/extensions/yaml/description.yml
@@ -13,8 +13,8 @@ extension:
   
 repo:
   github: teaguesterling/duckdb_yaml
-  andium: e70455d42657fcbf5d4cb00292af775a5da5da15
-  ref: e70455d42657fcbf5d4cb00292af775a5da5da15
+  andium: 55ebe5ef4b6d3d191f2f709494bb09271b3016c7
+  ref: 55ebe5ef4b6d3d191f2f709494bb09271b3016c7
 
 docs:
   hello_world: |

--- a/extensions/yaml/description.yml
+++ b/extensions/yaml/description.yml
@@ -1,13 +1,7 @@
 extension:
   name: yaml
   description: Read YAML files into DuckDB with native YAML type support, comprehensive extraction functions, and seamless JSON interoperability
-  version: 1.7.0
-  # Windows fully built (no excluded_platforms). windows_amd64 (MSVC) shipped in the
-  # original v1.7.0 build; windows_amd64_mingw is now validated too — it compiles and
-  # passes the full suite on the v1.5.4 / v1.5-variegata toolchain (a real ~31-min
-  # build+test run). The earlier "fmt fails to compile vs the community MSVC STL"
-  # exclusion and the COPY-TO deadlock both proved stale/non-reproducing. Source is
-  # unchanged (same ref); this backfills the mingw platform for v1.7.0.
+  version: 1.8.0
   language: C++
   build: cmake
   license: MIT
@@ -19,8 +13,8 @@ extension:
   
 repo:
   github: teaguesterling/duckdb_yaml
-  andium: 4523b13794d366d727d598dd137f957c0e96caa4
-  ref: 4523b13794d366d727d598dd137f957c0e96caa4
+  andium: e70455d42657fcbf5d4cb00292af775a5da5da15
+  ref: e70455d42657fcbf5d4cb00292af775a5da5da15
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps the `yaml` extension to version `v1.8.0`.

### Improvements in v1.8.0
- **Streaming Table Functions**: Adopted full `GlobalTableFunctionState` and `LocalTableFunctionState` interfaces for `read_yaml` and `read_yaml_objects`, eliminating bind-time whole-document materialization and const-mutation.
- **Parallelism & Batch Ordering**: Per-worker mutex-guarded file dispatch with 64-bit batch indexing (`OperatorPartitionData`) for deterministic row ordering across worker threads.
- **Sampling Decoupling**: Decoupled schema inference sampling from scan execution.
- **CI Hardening**: Permanent MSVC and MinGW Windows validation.