### PR TITLE
duck_block_utils: v1.6.1

### DIFF
--- a/extensions/duck_block_utils/description.yml
+++ b/extensions/duck_block_utils/description.yml
@@ -13,7 +13,7 @@ repo:
   # v1.4.0 targets a v1.5.x tree (dropped v1.4.x support) and is not built-verified
   # against v1.4.5. v1.4.5 users should move to the v1.5.x track.
   andium: 125662df9e5450105dc9b7957ad955cb53d7beec
-  ref: e10adcd111ec175caa853058f5f84554bbf4c929
+  ref: 840e3bbd87e288a17fa3a91082238ac1b5107d0e
 docs:
   hello_world: |
     -- Build a document programmatically

--- a/extensions/duck_block_utils/description.yml
+++ b/extensions/duck_block_utils/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duck_block_utils
   description: Build, transform, validate, and extract content from structured documents using the duck_block type
-  version: 1.5.0
+  version: 1.6.0
   language: C++
   build: cmake
   license: MIT
@@ -13,7 +13,7 @@ repo:
   # v1.4.0 targets a v1.5.x tree (dropped v1.4.x support) and is not built-verified
   # against v1.4.5. v1.4.5 users should move to the v1.5.x track.
   andium: 125662df9e5450105dc9b7957ad955cb53d7beec
-  ref: 0263b0efa01d3a05f8fc9841e1bc21fc21602aa1
+  ref: a4a9a540f7988a192ed3ee9c55a2ff0c055e2010
 docs:
   hello_world: |
     -- Build a document programmatically

--- a/extensions/duck_block_utils/description.yml
+++ b/extensions/duck_block_utils/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duck_block_utils
   description: Build, transform, validate, and extract content from structured documents using the duck_block type
-  version: 1.6.0
+  version: 1.6.1
   language: C++
   build: cmake
   license: MIT
@@ -13,7 +13,7 @@ repo:
   # v1.4.0 targets a v1.5.x tree (dropped v1.4.x support) and is not built-verified
   # against v1.4.5. v1.4.5 users should move to the v1.5.x track.
   andium: 125662df9e5450105dc9b7957ad955cb53d7beec
-  ref: 840e3bbd87e288a17fa3a91082238ac1b5107d0e
+  ref: 078a9b343824510fcc1c087b46fa0f48969bad8f
 docs:
   hello_world: |
     -- Build a document programmatically

--- a/extensions/duck_block_utils/description.yml
+++ b/extensions/duck_block_utils/description.yml
@@ -13,7 +13,7 @@ repo:
   # v1.4.0 targets a v1.5.x tree (dropped v1.4.x support) and is not built-verified
   # against v1.4.5. v1.4.5 users should move to the v1.5.x track.
   andium: 125662df9e5450105dc9b7957ad955cb53d7beec
-  ref: a4a9a540f7988a192ed3ee9c55a2ff0c055e2010
+  ref: e10adcd111ec175caa853058f5f84554bbf4c929
 docs:
   hello_world: |
     -- Build a document programmatically


### PR DESCRIPTION
Bumps `duck_block_utils` to v1.6.0.

- **Native yyjson Pandoc AST Codecs**: Replaced bespoke hand-rolled JSON/Pandoc AST encoders and decoders with DuckDB's bundled `yyjson` engine.
- **Robust RFC 8259 Compliance**: Complete UTF-8, surrogate pairs, and C0 control character escaping out-of-the-box.
- **Maintained Recursion Limit**: Pinned depth checks (`PANDOC_MAX_NESTING_DEPTH`) across recursive block and inline AST traversals to prevent stack exhaustion on deeply nested ASTs.

Release notes: https://github.com/teaguesterling/duckdb_duck_block_utils/releases/tag/v1.6.0

`ref` is the v1.6.0 release commit (`a4a9a54`). All tests passing (571 assertions).