### PR TITLE
markdown: v1.7.0

### DIFF
--- a/extensions/markdown/description.yml
+++ b/extensions/markdown/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: markdown
   description: Read, analyze, and write Markdown files with block-level document representation and inline element support
-  version: 1.6.0
+  version: 1.7.0
   language: C++
   build: cmake
   license: MIT
@@ -14,7 +14,7 @@ repo:
   # change since -- v1.5.1 structured inline blocks, the v1.5.2 UTF-8 truncation
   # fix, and v1.6.0 -- ships on the v1.5.x track via ref, which is a v1.5.4 tree.
   andium: c9e1a4d3b98a814c86295ecb2ed760be286242ba
-  ref: 3e8e0d59abce16c227f5d52d26fd094c9448917a
+  ref: 43d31fd26ac03ccc0e2998288a5bec6aefc0ae34
 docs:
   hello_world: |
     -- Load the extension

--- a/extensions/markdown/description.yml
+++ b/extensions/markdown/description.yml
@@ -14,7 +14,7 @@ repo:
   # change since -- v1.5.1 structured inline blocks, the v1.5.2 UTF-8 truncation
   # fix, and v1.6.0 -- ships on the v1.5.x track via ref, which is a v1.5.4 tree.
   andium: c9e1a4d3b98a814c86295ecb2ed760be286242ba
-  ref: 43d31fd26ac03ccc0e2998288a5bec6aefc0ae34
+  ref: 39148ec0d28de2c1333ab056d195a036cb255bde
 docs:
   hello_world: |
     -- Load the extension

--- a/extensions/markdown/description.yml
+++ b/extensions/markdown/description.yml
@@ -14,7 +14,7 @@ repo:
   # change since -- v1.5.1 structured inline blocks, the v1.5.2 UTF-8 truncation
   # fix, and v1.6.0 -- ships on the v1.5.x track via ref, which is a v1.5.4 tree.
   andium: c9e1a4d3b98a814c86295ecb2ed760be286242ba
-  ref: 39148ec0d28de2c1333ab056d195a036cb255bde
+  ref: 340c0cd59701f74e9ec29d7e4515c4c3b1bf27b1
 docs:
   hello_world: |
     -- Load the extension


### PR DESCRIPTION
Bumps `markdown` to v1.7.0.

- **Native yyjson Codecs for Lists & Tables**: Replaced bespoke hand-rolled JSON string/array unescaping, list parsers, and Pandoc table extractors with DuckDB's bundled `yyjson` API.
- **Robust RFC 8259 Compliance**: Upstream RFC 8259 escaping, surrogate pairs, and UTF-8 multi-byte decoding without bespoke manual decoders.

Release notes: https://github.com/teaguesterling/duckdb_markdown/releases/tag/v1.7.0

`ref` is the v1.7.0 release commit (`43d31fd`). All tests passing (1,499 assertions).