### PR TITLE
webbed: v2.8.1

### DIFF
--- a/extensions/webbed/description.yml
+++ b/extensions/webbed/description.yml
@@ -17,7 +17,7 @@ repo:
   andium: ddda30f11352138b2451657419640370d1612137
   # andium (DuckDB v1.4.5 track) left at its prior commit; the v2.8.0
   # correctness fixes ship on the v1.5.x track via ref.
-  ref: 5b446b5e47a4cef651d5ceb4272cb8c3da1cb33b
+  ref: f55e0bd9355813eeebf3e4b3bc4477f8d62685b1
 docs:
   docs_url: https://duckdb-webbed.readthedocs.io
   hello_world: |

--- a/extensions/webbed/description.yml
+++ b/extensions/webbed/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: webbed
   description: Comprehensive processing extension for web markup languages (XML and HTML) with SAX streaming for large files, intelligent schema inference, XPath-based data extraction, and HTML table parsing.
-  version: 2.7.0
+  version: 2.8.0
   language: C++
   build: cmake
   license: MIT
@@ -15,9 +15,9 @@ extension:
 repo:
   github: teaguesterling/duckdb_webbed
   andium: ddda30f11352138b2451657419640370d1612137
-  # andium (DuckDB v1.4.5 track) left at its prior commit; the v2.7.0
+  # andium (DuckDB v1.4.5 track) left at its prior commit; the v2.8.0
   # correctness fixes ship on the v1.5.x track via ref.
-  ref: c1b32efa4b8106d04ae74d0d898d9a650461792f
+  ref: 5b446b5e47a4cef651d5ceb4272cb8c3da1cb33b
 docs:
   docs_url: https://duckdb-webbed.readthedocs.io
   hello_world: |


### PR DESCRIPTION
Bumps `webbed` to v2.8.0.

- **Native yyjson Codecs for HTML Tables & JSON-to-XML**: Replaced regex-based string extraction, bracket counting, and custom JSON parsers with DuckDB's bundled `yyjson` engine.
- **Robust RFC 8259 Compliance**: Upstream UTF-8, surrogate pairs, and escaping for HTML ↔ table JSON and JSON-to-XML operations.

Release notes: https://github.com/teaguesterling/duckdb_webbed/releases/tag/v2.8.0

`ref` is the v2.8.0 release commit (`5b446b5`). All tests passing (3,155 assertions).