### PR TITLE
Update dplyr extension to v0.6.0

### DIFF
--- a/extensions/dplyr/description.yml
+++ b/extensions/dplyr/description.yml
@@ -8,7 +8,7 @@
 extension:
   name: dplyr
   description: R dplyr pipeline syntax support for DuckDB - transpiles dplyr verbs to SQL
-  version: 0.5.1
+  version: 0.6.0
   language: Rust & C++
   build: cmake
   license: MIT
@@ -19,7 +19,7 @@ extension:
 
 repo:
   github: mrchypark/libdplyr
-  ref: adc1c5420a477d33c57a496f292df28d83dec1bc
+  ref: 5285d3f51803d6a1a4bf7b62f40cfaf9b9215733
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary

- update the dplyr community extension from v0.5.1 to v0.6.0
- pin the source to the exact v0.6.0 release commit

## Validation

- confirmed `v0.6.0^{}` resolves to `5285d3f51803d6a1a4bf7b62f40cfaf9b9215733`
- confirmed the v0.6.0 release workflow completed successfully with 25 published assets
- parsed the descriptor and ran `scripts/build.py` for DuckDB v1.5.5
- verified the change is limited to the version and source ref