### PR TITLE
Add DuckFlight extension

### DIFF
--- a/extensions/duckflight/description.yml
+++ b/extensions/duckflight/description.yml
@@ -1,0 +1,25 @@
+extension:
+  name: duckflight
+  description: PostgreSQL wire-protocol and Arrow Flight SQL endpoints for a DuckDB database
+  version: 0.1.0
+  language: Rust
+  build: cargo
+  license: MIT
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64;windows_amd64_rtools;windows_amd64_mingw;linux_amd64_musl"
+  requires_toolchains: "rust;python3"
+  maintainers:
+    - nicosuave
+
+repo:
+  github: sidequery/duckflight-extension
+  ref: b444517f86ad7ce9a86496282499808247795680
+
+docs:
+  hello_world: |
+    -- Reports whether the embedded DuckFlight runtime loaded successfully.
+    SELECT * FROM duckflight_core_status();
+  extended_description: |
+    DuckFlight exposes PostgreSQL wire-protocol and Arrow Flight SQL servers backed by the exact
+    DuckDB database that loaded this extension. Production artifacts embed the platform-specific
+    DuckFlight core into the extension, so INSTALL and LOAD require no sidecar download. Network
+    clients authenticate through the configured authentication and TLS file.

--- a/extensions/duckflight/description.yml
+++ b/extensions/duckflight/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duckflight
   description: PostgreSQL wire-protocol and Arrow Flight SQL endpoints for a DuckDB database
-  version: 0.1.0
+  version: 0.1.1
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: sidequery/duckflight-extension
-  ref: 557155fdb10f220141eeb93b624c600cbc268350
+  ref: 10b2157e6fc62ba162c3190cb4fed5ad8e95ffbb
 
 docs:
   hello_world: |

--- a/extensions/duckflight/description.yml
+++ b/extensions/duckflight/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: sidequery/duckflight-extension
-  ref: b444517f86ad7ce9a86496282499808247795680
+  ref: 557155fdb10f220141eeb93b624c600cbc268350
 
 docs:
   hello_world: |

--- a/extensions/duckflight/description.yml
+++ b/extensions/duckflight/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duckflight
-  description: PostgreSQL wire-protocol and Arrow Flight SQL endpoints for a DuckDB database
-  version: 0.1.1
+  description: Query DuckDB from PostgreSQL and Arrow Flight SQL clients, including psql, ADBC, and Airport
+  version: 0.1.2
   language: Rust
   build: cargo
   license: MIT
@@ -12,14 +12,28 @@ extension:
 
 repo:
   github: sidequery/duckflight-extension
-  ref: 10b2157e6fc62ba162c3190cb4fed5ad8e95ffbb
+  ref: 379f43acbf604cf9eac3dff9b9703599a8cd6865
 
 docs:
   hello_world: |
-    -- Reports whether the embedded DuckFlight runtime loaded successfully.
-    SELECT * FROM duckflight_core_status();
+    -- Let PostgreSQL clients query this DuckDB database.
+    SELECT * FROM duckflight_pg_serve(
+      '127.0.0.1:5433', '/path/to/duckflight.toml'
+    );
+
+    -- Let Arrow Flight SQL clients query the same database.
+    SELECT * FROM duckflight_flight_serve(
+      '127.0.0.1:31337', '/path/to/duckflight.toml'
+    );
   extended_description: |
-    DuckFlight exposes PostgreSQL wire-protocol and Arrow Flight SQL servers backed by the exact
-    DuckDB database that loaded this extension. Production artifacts embed the platform-specific
-    DuckFlight core into the extension, so INSTALL and LOAD require no sidecar download. Network
-    clients authenticate through the configured authentication and TLS file.
+    Use DuckDB as a database server. DuckFlight lets existing PostgreSQL and Arrow Flight SQL
+    clients query the same live DuckDB database that loaded the extension—no export, copy, or
+    second database required.
+
+    Connect with PostgreSQL tools such as `psql`, Psycopg, JDBC, and BI applications; Arrow ADBC
+    Flight SQL clients; or another DuckDB instance through the Airport extension. Reads and writes
+    are immediately visible to DuckDB and every connected client.
+
+    Both listeners require authentication. A single `duckflight.toml` configures users, access
+    tokens, and optional TLS. See the
+    [quick start and authentication guide](https://github.com/sidequery/duckflight-extension/blob/main/docs/AUTHENTICATION.md).


### PR DESCRIPTION
Adds DuckFlight 0.1.2 for Linux and macOS on amd64 and arm64. 