### PR TITLE
Update motorsport_telemetry to 1.3.4

### DIFF
--- a/extensions/motorsport_telemetry/description.yml
+++ b/extensions/motorsport_telemetry/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: motorsport_telemetry
   description: Query AiM MP4, Cosworth PDS, MoTeC LD, Racelogic VBOX and .telemetry recordings directly in DuckDB, with stint-aware laps
-  version: 1.3.1
+  version: 1.3.2
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: tobi/duckdb_motorsport_telemetry
-  ref: 9008f045e53bb6f42f7bb4e8a93668a627faed33
+  ref: f86b572e8ea6e50454d21ca3bcafd0b113d546de
 
 docs:
   hello_world: |

--- a/extensions/motorsport_telemetry/description.yml
+++ b/extensions/motorsport_telemetry/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: motorsport_telemetry
-  description: Query AiM MP4, Cosworth PDS, MoTeC LD, and Racelogic VBOX telemetry directly in DuckDB
-  version: 0.8.0
+  description: Query AiM MP4, Cosworth PDS, MoTeC LD, Racelogic VBOX and .telemetry recordings directly in DuckDB, with stint-aware laps
+  version: 1.3.0
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: tobi/duckdb_motorsport_telemetry
-  ref: e59091ede5322ac5e0f5a75971d273f04e6b461e
+  ref: 030b42a9130f6d88b410d6ab4e4eb5d26caac84c
 
 docs:
   hello_world: |
@@ -35,8 +35,13 @@ docs:
       channels := 'RPM,GPS Speed,GPS Latitude,GPS Longitude');
   extended_description: |
     `motorsport_telemetry` reads AiM `aimd` telemetry embedded in MP4, Pi
-    Research/Cosworth PDS, MoTeC i2 LD, and Racelogic VBOX VBO files without an
-    export step. AiM MP4 support is native-only; the DuckDB-Wasm build does not
+    Research/Cosworth PDS, MoTeC i2 LD, Racelogic VBOX VBO, and
+    motorsport-telemetry-rs `.telemetry` recordings (zstd MTJ JSONL or the
+    legacy zip, detected by content) without an export step.
+    `telemetry_laps` returns each lap with a session-monotonic virtual lap
+    number, stint index, the dash's own stint lap counter, and a normalized
+    kind (flying, out, in, out-in, pit); `telemetry_file_metadata` reports
+    flying-lap and stint counts and picks the fastest flying lap. AiM MP4 support is native-only; the DuckDB-Wasm build does not
     link the AiM parser, so `.mp4` inputs and the `read_aim`/`read_aimd`
     functions are unavailable in the browser. The native reader exposes scalar
     `CHS` channels and expands each valid 56-byte `GPS0` aggregate into 16 GPS

--- a/extensions/motorsport_telemetry/description.yml
+++ b/extensions/motorsport_telemetry/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: motorsport_telemetry
   description: Query AiM MP4, Cosworth PDS, MoTeC LD, Racelogic VBOX and .telemetry recordings directly in DuckDB, with stint-aware laps
-  version: 1.3.0
+  version: 1.3.1
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: tobi/duckdb_motorsport_telemetry
-  ref: 030b42a9130f6d88b410d6ab4e4eb5d26caac84c
+  ref: 9008f045e53bb6f42f7bb4e8a93668a627faed33
 
 docs:
   hello_world: |

--- a/extensions/motorsport_telemetry/description.yml
+++ b/extensions/motorsport_telemetry/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: motorsport_telemetry
   description: Query AiM MP4, Cosworth PDS, MoTeC LD, Racelogic VBOX and .telemetry recordings directly in DuckDB, with stint-aware laps
-  version: 1.3.3
+  version: 1.3.4
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: tobi/duckdb_motorsport_telemetry
-  ref: 0f7b0472e6a2356c477228cd4b86f308d85afdd8
+  ref: e9d941d7f3a88a7bb279ceada8555c3c90e611d1
 
 docs:
   hello_world: |

--- a/extensions/motorsport_telemetry/description.yml
+++ b/extensions/motorsport_telemetry/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: motorsport_telemetry
   description: Query AiM MP4, Cosworth PDS, MoTeC LD, Racelogic VBOX and .telemetry recordings directly in DuckDB, with stint-aware laps
-  version: 1.3.2
+  version: 1.3.3
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: tobi/duckdb_motorsport_telemetry
-  ref: f86b572e8ea6e50454d21ca3bcafd0b113d546de
+  ref: 0f7b0472e6a2356c477228cd4b86f308d85afdd8
 
 docs:
   hello_world: |


### PR DESCRIPTION
Updates `motorsport_telemetry` from 0.8.0 to 1.3.4 (source: https://github.com/tobi/duckdb_motorsport_telemetry, ref `e9d941d7f3a88a7bb279ceada8555c3c90e611d1`, tag `v1.3.4`). The extension now shares its version number with the `motorsport-telemetry-rs` parser workspace it is built from (v1.3.4).

Changes since 0.8.0:
- `.telemetry` recordings (motorsport-telemetry-rs output: a zstd-compressed MTJ JSONL document, or the earlier zip container, detected by content) and `.telemetry.jsonl[.zstd]` open in every table function; `telemetry_file_metadata.source_format` reports the vendor format they were converted from.
- New `telemetry_laps(path)`: one row per lap with a session-monotonic virtual `lap_number`, `stint`, the dash's own `stint_lap` counter, a normalized `kind` (`flying`/`out`/`in`/`out-in`/`pit`), `label`, `flying`, `complete`, and nanosecond bounds. Vendor lap counters restart per stint (AiM resets to 0 in the pit box, Cosworth counts through a stop), so the raw counter cannot identify a lap; the classified model can.
- `telemetry_file_metadata` adds `flying_lap_count`, `stint_count`, `fastest_lap_label`, `source_format`; the fastest lap is the shortest plausible flying lap (an in-lap fragment or a lap containing a pit stop is never a candidate).
- Parser robustness from motorsport-telemetry-rs 1.3.4: a Cosworth PDS whose definition index was never written is reported as such; a single malformed AiM `aimd` packet is skipped and counted instead of rejecting the file.
- New `read_telemetry_normalized(path, rate := …)`: the library's blessed channels in SQL - speed m/s, pedals 0-1, brake pressure bar, steering deg, gear, rpm, virtual lap number / stint / label, lap progress, lap time, GPS, clocks - resolved per file from names, declared units and, for unitless dash channels, value ranges.
- Glob brace groups accept any `{a,b,c}` extension alternation (e.g. `{pds,ld,vbo,mp4,telemetry}`).

Unit and SQL integration tests pass on linux_amd64 against DuckDB 1.5.5; excluded platforms are unchanged from 0.8.0.