### PR TITLE
Bump gdrive to v2026.09.01

### DIFF
--- a/extensions/gdrive/description.yml
+++ b/extensions/gdrive/description.yml
@@ -16,7 +16,7 @@ extension:
 
 repo:
   github: DataZooDE/duckdb-gdrive
-  ref: e4d78a732f38225a9690e99828cc5c5e72a8a8d1
+  ref: 73b8a5e729f29338d883b5277b99644be66c8c4b
 
 docs:
   hello_world: |
@@ -78,6 +78,14 @@ docs:
     rather than whole files. Path resolution is cached per secret and per
     drive, because Drive has no path addressing and each segment otherwise
     costs an API call.
+
+    Credentials come from Application Default Credentials by default, which
+    now includes **workload identity federation** — so a workload running in
+    Kubernetes or another federated environment authenticates with the
+    short-lived token its platform provides, and needs no downloaded
+    service-account key to store, mount or rotate. A key file
+    (`PROVIDER service_account`) and an interactive user credential
+    (`gcloud auth application-default login`) both still work.
 
     Two behaviours are deliberately strict. Drive permits two files with the
     same name in one folder, so a path is not a unique identifier: rather than


### PR DESCRIPTION
Updates `gdrive` to [`v2026.09.01`](https://github.com/DataZooDE/duckdb-gdrive/releases/tag/v2026.09.01).

## What changed

**Workload identity federation for `credential_chain`.** `external_account` credentials were previously recognised and refused, which meant the extension could not be used from a cluster without a downloaded service-account key to store, mount and rotate. It now performs the exchange directly (STS token exchange, then service-account impersonation with the Drive scope), consistent with how the existing RFC 7523 path is implemented rather than pulling in `google-cloud-cpp`.

Only file-sourced subject tokens are supported — a projected Kubernetes token, for example. `url`-sourced tokens (AWS/Azure/GCE metadata) keep the previous "recognised but unsupported" behaviour with a named error, rather than being accepted and failing later.

The key-file (`PROVIDER service_account`) and interactive (`gcloud auth application-default login`) paths are unchanged.

## Docs

`extended_description` gains a short paragraph on this. The published docs previously showed only the key-file and interactive paths, which is exactly what this release makes unnecessary for a server.

## Verification

Tested against real Google Drive, no test doubles — the upstream repo builds against live Drive by policy:

- A real projected Kubernetes token → real STS → real service-account impersonation → listing a real Shared Drive
- Pure-logic parsing covered by Catch2 (944 assertions, 195 cases); the network exchange is covered live, not mocked
- `gdrive_version()` and the release tag verified in agreement by the repo's stamp check

Full build matrix green on both DuckDB lines at the tagged commit.