### PR TITLE
orc: bump to v0.2.0 — write support (COPY ... TO FORMAT orc)

### DIFF
--- a/extensions/orc/description.yml
+++ b/extensions/orc/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: orc
   description: A DuckDB extension for reading Apache ORC files, written in pure Rust. Supports all ORC primitives, struct, list, map types and all compression codecs (Zlib, Snappy, LZO, LZ4, ZSTD).
-  version: 0.1.3
+  version: 0.2.0
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: alitrack/duckdb_orc
-  ref: 1ad1adbfd6196c40e3c071c3878d2eebe409a89b
+  ref: 891ecbdc8a5802b16a364909cb295dcd8694932c
 
 docs:
   hello_world: |
@@ -50,8 +50,9 @@ docs:
 
     ### Known Limitations
 
-    - **Write support**: `orc-rust` 0.8+ has `ArrowWriter` but compression is not yet implemented (uncompressed only). Write support will be added to `duckdb_orc` once `orc-rust` supports compressed writes.
-    - **Single-threaded scan**: currently single-threaded sequential scan. ~5x slower than DuckDB's native Parquet reader on large single files. Multi-file globs also read sequentially. Stripe-level parallelism is planned.
+    - **Write support**: `COPY tbl TO 'file.orc' (FORMAT orc)` writes with ZSTD compression. Supported types: bool, int8-64, float32/64, date, timestamp, varchar, blob. List/Struct/Map/Decimal rejected cleanly (upstream `orc-rust` writer doesn't encode them yet).
+    - **Write column names**: output columns are `column_N` — the DuckDB C API COPY bind does not expose source column names.
+    - **Parallel scan**: multi-stripe files read in parallel across threads (caps at CPU count).
     - **No filter pushdown**: blocked by missing DuckDB C API
       (`duckdb_table_function_supports_filter_pushdown` not exposed)
     - **No union type**: not supported by `orc-rust` upstream

--- a/extensions/orc/description.yml
+++ b/extensions/orc/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: alitrack/duckdb_orc
-  ref: 1dab6ffc2f2b401b765c87727a31e00a502152e6
+  ref: 1ad1adbfd6196c40e3c071c3878d2eebe409a89b
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary

Bump the `orc` extension (`alitrack/duckdb_orc`) from ref `1dab6ff` (v0.1.3) to `891ecbd` (**v0.2.0**).

## What changed upstream

### v0.1.3 (previous)
- **feat: stripe-level parallel ORC reading** (`367e51f`) — `read_orc` reads ORC stripes in parallel across threads (caps at CPU count).

### v0.2.0 (this bump) — **Write support**
- **`COPY tbl TO 'file.orc' (FORMAT orc)`** — write any query result to ORC via the DuckDB C API COPY function interface (bind → global_init → sink → finalize)
- **ZSTD compression** by default (requires `orc-rust` ≥ `2060e243`, where compressed writes landed upstream 2026-08-18)
- Supported types: bool, int8/16/32/64, float32/64, date, timestamp, varchar, blob
- Unsupported types (List/Struct/Map/Decimal) rejected with a clean binder error — upstream `orc-rust` writer would otherwise panic and abort the process
- Custom C entrypoint (the `duckdb_entrypoint_c_api` macro doesn't expose the raw `duckdb_connection` needed to register a COPY function)
- Roundtrip integration tests: write → read back with count/sum/date/timestamp assertions

### Known limitations
- Output columns are named `column_0, column_1, ...` — the DuckDB C API's COPY bind does not expose source column names
- Writer type coverage limited to upstream `orc-rust` writer support (no List/Struct/Map/Decimal yet)
