### PR TITLE
orc: bump ref to e2bb83e — projection pushdown + CI metadata fix

### DIFF
--- a/extensions/orc/description.yml
+++ b/extensions/orc/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: orc
   description: A DuckDB extension for reading Apache ORC files, written in pure Rust. Supports all ORC primitives, struct, list, map types and all compression codecs (Zlib, Snappy, LZO, LZ4, ZSTD).
-  version: 0.2.0
+  version: 0.2.1
   language: Rust
   build: cargo
   license: MIT

--- a/extensions/orc/description.yml
+++ b/extensions/orc/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: alitrack/duckdb_orc
-  ref: 6f064f81410b83a51aed433999f66fecc8be9423
+  ref: e2bb83eb1f50531dddf3074b14eb56d85401b8f3
 
 docs:
   hello_world: |

--- a/extensions/orc/description.yml
+++ b/extensions/orc/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: alitrack/duckdb_orc
-  ref: 891ecbdc8a5802b16a364909cb295dcd8694932c
+  ref: 6f064f81410b83a51aed433999f66fecc8be9423
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary

Bump `alitrack/duckdb_orc` ref from `891ecbd` to `6f064f8`.

## What's new in `6f064f8`

### 1. `FROM 'file.orc'` syntax (replacement scan)
Any `.orc`-suffixed path or glob in a `FROM` clause now resolves automatically — no need to spell out `read_orc(...)`:

```sql
SELECT * FROM 'data/sales.orc';
SELECT count(*) FROM './dir/*.orc';
SELECT * FROM 'relative/path.orc';
```

Implemented via `duckdb_add_replacement_scan` (the same mechanism DuckDB uses for parquet/csv/json). Non-ORC table names and other file formats pass through untouched.

### 2. Sequential reader state leak fix
`read_sequential` kept its `ArrowReader` in a process-global `static`. A query that ended early (e.g. `LIMIT 1`) left the reader mid-file, and the *next* query on the same connection silently resumed from that position — dropping rows (10000 → 7952 after a `LIMIT 1`, verified). The reader now lives in per-scan state, so every query starts clean.

### Tests
- `replacement_scan` (absolute / relative / glob / data correctness / non-ORC passthrough)
- LIMIT-poisoning regression scenario
