### PR TITLE
Update anofox_forecast to a9328e1 (v0.9.0)

### DIFF
--- a/extensions/anofox_forecast/description.yml
+++ b/extensions/anofox_forecast/description.yml
@@ -1,13 +1,13 @@
 extension:
   name: anofox_forecast
-  description: Statistical timeseries forecasting in DuckDB. Support ARIMA, SARIMA, ETS, TBATS, MFLES, MSTL, and other models.
+  description: Statistical timeseries forecasting in DuckDB. Supports ARIMA, ETS, Theta, TBATS, MFLES, MSTL, Croston, GARCH, and other models.
   language: C++
   build: cmake
-  excluded_platforms: "windows_amd64_rtools;windows_amd64_mingw;"
+  excluded_platforms: "windows_amd64;windows_amd64_rtools;windows_amd64_mingw;"
   license: BSL 1.1
   requires_toolchains: rust
   maintainers:
     - sipemu
 repo:
   github: DataZooDE/anofox-forecast
-  ref: ebe4a822ae170d25f83ebef8c160ac297c015825
+  ref: a9328e1cb26a190ab2160d59225a1abfd647dd95


### PR DESCRIPTION
Bumps the pinned ref to the v0.9.0 release (adds the DuckDB-Wasm runtime harness + CI gating and the ensemble surface).

Also excludes windows_amd64: the community build_all LTS leg uses ci_tools_version v1.4-andium, whose vcpkg baseline pins an OpenSSL dependency with a now-404 upstream download ('Download failed, halting portfile'). Excluding windows_amd64 keeps the deploy pipeline green; the v1.5.x windows_amd64 build works and is unaffected upstream.
