### PR TITLE
geography: bump to 05dcc8f — restores publishing on DuckDB v1.5.2+

### DIFF
--- a/extensions/geography/description.yml
+++ b/extensions/geography/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: geography
   description: Global spatial data processing on the sphere
-  version: 0.1.0
+  version: 0.1.1
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: paleolimbot/duckdb-geography
-  ref: ceaf2dcbd5f690b0048efc20f413b540271d6188
+  ref: 05dcc8fd1df597907135e62a72a7b63aff3289cd
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps `geography` from `ceaf2dc` (DuckDB v1.5.0, March) to `05dcc8f`, current `main`.

`geography` has 404'd on every platform since DuckDB v1.5.2 — v1.5.0 and v1.5.1 still serve, everything after does not (paleolimbot/duckdb-geography#33).

The issue was arm64 link failure. `geography.duckdb_extension` itself linked fine; the build then died on `tools/plan_serializer` with `multiple definition of duckdb::BufferedFileWriter::DEFAULT_OPEN_FLAGS` under gcc-toolset-14/aarch64 — duckdb/duckdb#22097, where DuckDB configures C++11 and that `static constexpr` class-type member isn't implicitly inline. `plan_serializer` arrived in DuckDB v1.5.2, exactly where publishing stopped. paleolimbot/duckdb-geography#34 fixed it with `set(CMAKE_CXX_STANDARD 17 CACHE STRING ... FORCE)`, the same fix used in #2170.

Two upstream commits are picked up here:
- `2e40f33` — update to DuckDB v1.5.5
- `05dcc8f` — the C++17 / arm64 link fix

All build jobs are green at `05dcc8f` ([run 33290956541](https://github.com/paleolimbot/duckdb-geography/actions/runs/33290956541)): linux_amd64, linux_arm64, osx_amd64, osx_arm64, both Windows, and Format Check. The one red job is `pre-commit`, a `cmake-format` reflow of the comment block that same commit added — cosmetic, no effect on the build; fix in paleolimbot/duckdb-geography#35.

Version bumped 0.1.0 → 0.1.1 to match the convention of bumping alongside the ref; the upstream repo carries no tags, so the number is descriptor-side only. Happy to drop that hunk if the maintainer would rather choose it.

I'm not the extension maintainer — cc @paleolimbot, who tracked this in paleolimbot/duckdb-geography#33 and merged the fix. I opened this because [geoparquet-io](https://github.com/geoparquet/geoparquet-io) depends on `geography` for its S2 commands and has had them disabled since v1.5.2. Please close if you'd rather it come from the maintainer.
