### PR TITLE
duck_block_utils: v2.0.0

### DIFF
--- a/extensions/duck_block_utils/description.yml
+++ b/extensions/duck_block_utils/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duck_block_utils
   description: Build, transform, validate, and extract content from structured documents using the duck_block type
-  version: 1.6.1
+  version: 2.0.0
   language: C++
   build: cmake
   license: MIT
@@ -9,40 +9,42 @@ extension:
     - teaguesterling
 repo:
   github: teaguesterling/duckdb_duck_block_utils
-  # andium (DuckDB v1.4.5 track) intentionally left at the v1.2.1 commit:
-  # v1.4.0 targets a v1.5.x tree (dropped v1.4.x support) and is not built-verified
-  # against v1.4.5. v1.4.5 users should move to the v1.5.x track.
+  # andium (DuckDB v1.4.5 track) intentionally left at the v1.2.1 commit. The tree
+  # this release is built from targets DuckDB v1.5.5 and carries no v1.4.x support,
+  # so advancing this pin would point a v1.4.5 build at a tree that cannot build for
+  # it. v1.4.5 users should move to the v1.5.x track.
   andium: 125662df9e5450105dc9b7957ad955cb53d7beec
-  ref: 078a9b343824510fcc1c087b46fa0f48969bad8f
+  ref: 3f2a0f0a88325e20f4a4a0441fb7f8e3bcc9f18b
 docs:
   hello_world: |
     -- Build a document programmatically
-    SELECT db_assemble([
-        db_heading(1, 'Hello World'),
-        db_paragraph([
-            db_text('This is '),
-            db_bold('important'),
-            db_text(' content.')
+    SELECT duck_blocks_assemble([
+        duck_block_heading(1, 'Hello World'),
+        duck_block_paragraph([
+            duck_block_text('This is '),
+            duck_block_bold('important'),
+            duck_block_text(' content.')
         ]),
-        db_code('sql', 'SELECT * FROM documents')
+        duck_block_code('sql', 'SELECT * FROM documents')
     ]);
 
-    -- Works with markdown extension for reading/writing files
+    -- Render it as plain text
+    SELECT duck_blocks_to_text(duck_blocks_assemble([
+        duck_block_heading(1, 'Hello World'),
+        duck_block_paragraph('Some prose.')
+    ]));
+
+    -- Works with the markdown extension for reading and writing files
     LOAD markdown;
     LOAD duck_block_utils;
 
-    -- Extract table of contents from markdown
-    SELECT * FROM db_blocks_toc(
+    -- Table of contents from a markdown file
+    SELECT * FROM duck_blocks_toc_rows(
         (SELECT list(b) FROM read_markdown_blocks('README.md') b)
     );
 
-    -- Convert blocks to plain text
-    SELECT db_blocks_to_text(
-        (SELECT list(b) FROM read_markdown_blocks('doc.md') b)
-    );
-
     -- Validate document structure
-    SELECT db_blocks_validate(
+    SELECT duck_blocks_validate(
         (SELECT list(b) FROM read_markdown_blocks('doc.md') b)
     );
 
@@ -53,116 +55,141 @@ docs:
 
     **Documentation:** [duck-block-utils.readthedocs.io](https://duck-block-utils.readthedocs.io)
 
+    ## 2.0.0 is a breaking rename
+
+    Every `db_*` function was renamed to `duck_block_*` (builders) or `duck_blocks_*`
+    (operations on a list). 54 names present in 1.6.1 are gone and there is no alias
+    path, so 1.6.1 queries must be updated. The mapping is mechanical:
+
+    ```sql
+    db_heading(1, 'Title')      ->  duck_block_heading(1, 'Title')
+    db_assemble(blocks)         ->  duck_blocks_assemble(blocks)
+    db_blocks_to_text(blocks)   ->  duck_blocks_to_text(blocks)
+    db_page                     ->  page_break
+    ```
+
     ## The duck_block Type
 
-    A unified struct for both block-level and inline elements:
+    A unified struct for block-level, inline and metadata-value elements:
 
     ```sql
     STRUCT(
-        kind VARCHAR,                       -- 'block' or 'inline'
+        kind VARCHAR,                       -- 'block', 'inline' or 'value'
         element_type VARCHAR,               -- 'heading', 'paragraph', 'bold', 'link', etc.
-        content VARCHAR,                    -- Text content (NULL if element has children)
-        level INTEGER,                      -- Structural depth (1=block, 2+=inline children)
-        encoding VARCHAR,                   -- 'text', 'json', 'html', etc.
-        attributes MAP(VARCHAR, VARCHAR),   -- Element-specific metadata
-        element_order INTEGER               -- Position in document
+        content VARCHAR,                    -- text, iff the element has a single text child
+        level INTEGER,                      -- depth in a depth-first ordering; top is 1
+        encoding VARCHAR,                   -- 'text', 'json', 'yaml', 'html', 'xml',
+                                            --   'latex', 'markdown', 'toml'
+        attributes MAP(VARCHAR, VARCHAR),   -- element-specific metadata
+        element_order INTEGER               -- position in the document
     )
     ```
 
-    ## V2 API Design
+    `level` is structural depth, never a heading rank - a heading's rank lives in
+    `attributes['heading_level']`. `content` is populated if and only if an element has
+    a single text child; a heading additionally keeps a flattened title alongside its
+    rich children.
 
-    All builder functions return `LIST(duck_block)` for uniform composition:
+    ## Builders
+
+    All builder functions return `LIST(duck_block)` so they compose by nesting:
 
     ```sql
-    -- Builders can be nested naturally
-    SELECT db_paragraph([
-        db_text('Click '),
-        db_link('https://example.com', 'here'),
-        db_text(' for more.')
+    SELECT duck_block_paragraph([
+        duck_block_text('Click '),
+        duck_block_link('https://example.com', 'here'),
+        duck_block_text(' for more.')
     ]);
     ```
 
-    ## Block Builders
+    | Function | Description |
+    |----------|-------------|
+    | `duck_block_heading(level, content)` | Heading (h1-h6) |
+    | `duck_block_paragraph(content)` | Paragraph |
+    | `duck_block_code(language, content)` | Fenced code block |
+    | `duck_block_blockquote(content)` | Block quote |
+    | `duck_block_list_block(ordered, items[])` | Ordered or unordered list |
+    | `duck_block_hr()` | Horizontal rule |
+    | `duck_block_image(src, alt, title)` | Image |
+    | `duck_block_metadata(content)` | Metadata blob (YAML frontmatter) |
+    | `duck_block_raw(format, content)` | Raw content block |
+    | `duck_block_text(content)` | Plain text |
+    | `duck_block_bold(content)` | Bold |
+    | `duck_block_italic(content)` | Italic |
+    | `duck_block_link(href, content)` | Hyperlink |
+    | `duck_block_inline_code(content)` | Inline code |
+    | `duck_block_math(content)` | Math |
+    | `duck_block_strikethrough(content)` | Strikethrough |
+    | `duck_block_superscript(content)` / `duck_block_subscript(content)` | Super/subscript |
+
+    ## Assembly
 
     | Function | Description |
     |----------|-------------|
-    | `db_heading(level, content)` | Create heading (h1-h6) |
-    | `db_paragraph(content)` | Create paragraph |
-    | `db_code(language, content)` | Create fenced code block |
-    | `db_blockquote(content)` | Create block quote |
-    | `db_list_block(ordered, items[])` | Create ordered/unordered list |
-    | `db_hr()` | Create horizontal rule |
-    | `db_image(src, alt, title)` | Create image block |
-    | `db_metadata(content)` | Create YAML frontmatter |
-    | `db_raw(format, content)` | Create raw content block |
+    | `duck_blocks_assemble(blocks[])` | Combine blocks into a document |
+    | `duck_blocks_document(blocks[])` | Alias for assemble |
+    | `duck_block_section(level, title, children[])` | Section with a heading |
+    | `duck_blocks_concat(a, b)` | Concatenate block lists |
+    | `duck_blocks_rebase_levels(blocks, offset)` | Shift heading levels |
 
-    ## Inline Builders
+    ## Query and extraction
 
     | Function | Description |
     |----------|-------------|
-    | `db_text(content)` | Plain text |
-    | `db_bold(content)` | Bold/strong text |
-    | `db_italic(content)` | Italic/emphasis text |
-    | `db_link(href, content)` | Hyperlink |
-    | `db_inline_code(content)` | Inline code |
-    | `db_math(content)` | Math expression |
-    | `db_strikethrough(content)` | Strikethrough text |
-    | `db_superscript(content)` | Superscript |
-    | `db_subscript(content)` | Subscript |
-
-    ## Assembly Functions
-
-    | Function | Description |
-    |----------|-------------|
-    | `db_assemble(blocks[])` | Combine blocks into document |
-    | `db_document(blocks[])` | Alias for db_assemble |
-    | `db_section(level, title, children[])` | Create section with heading |
-    | `db_concat(blocks1, blocks2)` | Concatenate block lists |
-    | `db_rebase_levels(blocks, offset)` | Adjust heading levels |
-
-    ## Extraction Functions
-
-    | Function | Description |
-    |----------|-------------|
-    | `db_blocks_to_text(blocks)` | Extract plain text |
-    | `db_blocks_headings(blocks)` | Extract heading hierarchy |
-    | `db_blocks_toc(blocks)` | Generate table of contents |
+    | `duck_blocks_to_text(blocks)` | Plain text |
+    | `duck_blocks_headings(blocks)` | Heading hierarchy |
+    | `duck_blocks_toc_rows(blocks)` | Table of contents, one row per entry |
+    | `duck_blocks_get_section(blocks, pattern)` | One section by title or id |
+    | `duck_blocks_sections_like(blocks, term)` | Sections whose text matches |
+    | `duck_blocks_page_rows(blocks)` | Page boundaries, separate from the outline |
+    | `duck_blocks_get_pages(blocks, first, last)` | A page range |
+    | `duck_blocks_links(blocks)` | Every link |
+    | `duck_blocks_stats(blocks)` / `duck_blocks_structure(blocks)` | Document shape |
+    | `duck_blocks_diff(before, after)` | ADDED / REMOVED / MOVED between two versions |
 
     ## Validation
 
     | Function | Description |
     |----------|-------------|
-    | `db_blocks_validate(blocks)` | Validate document structure |
+    | `duck_blocks_validate(blocks)` | Spec conformance: valid, plus errors |
+    | `duck_blocks_lint(blocks)` | Advisory conformance warnings |
+    | `duck_blocks_quality(blocks)` | Document quality, which is NOT conformance |
+    | `duck_block_spec_version()` | The spec version this build implements |
 
-    ## Pandoc Integration
-
-    Convert between Pandoc JSON AST and duck_block without requiring Pandoc:
+    ## Rendering
 
     | Function | Description |
     |----------|-------------|
-    | `pandoc_inlines_to_db_inlines(json)` | Parse Pandoc inline AST |
-    | `db_inlines_to_pandoc(blocks)` | Convert to Pandoc inline AST |
+    | `duck_blocks_render_ansi(blocks, width)` | Terminal rendering with themes |
 
-    ## Ecosystem Integration
+    ## Pandoc integration
 
-    Duck Block Utils works seamlessly with other DuckDB document extensions:
+    Convert between Pandoc's JSON AST and `duck_block` without invoking Pandoc:
 
-    - **[duckdb_markdown](https://github.com/teaguesterling/duckdb_markdown)** - Read markdown files with `read_markdown_blocks()`, write with `COPY ... TO ... (FORMAT markdown, MARKDOWN_MODE duck_block)`
+    | Function | Description |
+    |----------|-------------|
+    | `pandoc_ast_to_blocks(json)` | Parse a Pandoc AST |
+    | `duck_blocks_to_pandoc_ast(blocks)` | Emit a full Pandoc document |
+    | `duck_blocks_to_pandoc_blocks(blocks)` | Emit just the block list |
+    | `read_pandoc_ast(path)` / `write_pandoc_ast(path, blocks)` | Read and write AST files |
+
+    ## Ecosystem
+
+    - **[duckdb_markdown](https://github.com/teaguesterling/duckdb_markdown)** - `read_markdown_blocks()`, and `COPY ... TO ... (FORMAT markdown, MARKDOWN_MODE duck_block)`
     - **[duckdb_webbed](https://github.com/teaguesterling/duckdb_webbed)** - HTML parsing and generation
 
     ```sql
-    -- Read markdown, manipulate with duck_block_utils, write back
+    -- Read markdown, append to it, write it back
     LOAD markdown;
     LOAD duck_block_utils;
 
-    -- Add a disclaimer to all documents
     COPY (
-        SELECT block.* FROM (
-            SELECT unnest(db_assemble([
-                (SELECT list(b) FROM read_markdown_blocks('doc.md') b),
-                db_hr(),
-                db_paragraph('Generated by DuckDB')
-            ])) as block
-        )
+        SELECT unnest(duck_blocks_concat(
+            (SELECT list(b) FROM read_markdown_blocks('doc.md') b),
+            duck_blocks_assemble([
+                duck_block_hr(),
+                duck_block_paragraph('Generated by DuckDB')
+            ])
+        )) AS block
     ) TO 'output.md' (FORMAT markdown, MARKDOWN_MODE duck_block);
     ```


### PR DESCRIPTION
MAJOR release. Every `db_*` function was renamed to `duck_block_*` (builders) or `duck_blocks_*` (operations on a list). 54 names present in 1.6.1 are gone with no alias path, so existing queries must be updated. The mapping is mechanical — `db_heading` → `duck_block_heading`, `db_assemble` → `duck_blocks_assemble`, and `db_page` → `page_break`.

**The listing docs needed rewriting, not just the pin.** `hello_world` called `db_assemble`, `db_heading`, `db_paragraph`, `db_text`, `db_bold`, `db_code` and `db_blocks_toc` — none of which exist in 2.0.0 — and the extended description named several dozen more. Both are rewritten, the runnable statements were executed against the built extension rather than transcribed, and every function the listing names was checked to exist: 44 of 44.

Also corrected in the type description, which had drifted from the spec: `kind` is `'block'`, `'inline'` or `'value'` (the third was missing), `level` is depth in a depth-first ordering rather than a heading rank, `content` is populated iff the element has a single text child, and there are eight encodings rather than five.

**andium is deliberately left at its v1.2.1 pin.** The tree this release builds from targets DuckDB v1.5.5 and carries no v1.4.x support, so advancing that pin would point a v1.4.5 build at a tree that cannot build for it.

Highlights beyond the rename — a page axis (`duck_blocks_page_rows`, `duck_blocks_get_pages`) so page boundaries are addressable without synthesising headings; `duck_blocks_diff` and `duck_blocks_quality`; and fixes for a native table exporting a shape pandoc refuses, inline images losing their alt text, and a flattener that emptied formatted table cells.

Release notes: https://github.com/teaguesterling/duckdb_duck_block_utils/releases/tag/v2.0.0