### PR TITLE
webbed: update to v2.8.2

### DIFF
--- a/extensions/webbed/description.yml
+++ b/extensions/webbed/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: webbed
   description: Comprehensive processing extension for web markup languages (XML and HTML) with SAX streaming for large files, intelligent schema inference, XPath-based data extraction, and HTML table parsing.
-  version: 2.8.1
+  version: 2.8.2
   language: C++
   build: cmake
   license: MIT
@@ -15,9 +15,9 @@ extension:
 repo:
   github: teaguesterling/duckdb_webbed
   andium: ddda30f11352138b2451657419640370d1612137
-  # andium (DuckDB v1.4.5 track) left at its prior commit; the v2.8.1
-  # correctness fixes ship on the v1.5.x track via ref.
-  ref: 9823acc1514ac017b26ca6cd85ac9ba7b8295755
+  # andium (DuckDB v1.4.5 track) left at its prior commit; the v2.8.2
+  # duck_block correctness fixes ship on the v1.5.x track via ref.
+  ref: 093856b645ce4dbdfdff37b3c02ce0221b1b19d6
 docs:
   docs_url: https://duckdb-webbed.readthedocs.io
   hello_world: |
@@ -95,4 +95,4 @@ docs:
 
     See https://duckdb-webbed.readthedocs.io for comprehensive documentation and examples.
 
-    Built on libxml2 for robust, standards-compliant parsing with comprehensive error handling and memory-safe RAII implementation. 95 test suites with 3261 assertions, including DOM/SAX equivalence, adversarial/security, and multi-file parallelism testing. The extension supports mixed file systems, configurable schema inference, and efficient processing of large document collections.
+    Built on libxml2 for robust, standards-compliant parsing with comprehensive error handling and memory-safe RAII implementation. 100 test suites with 3828 assertions, including DOM/SAX equivalence, adversarial/security, and multi-file parallelism testing. The extension supports mixed file systems, configurable schema inference, and efficient processing of large document collections.


### PR DESCRIPTION
Bugfix release for `webbed`. No new public surface — the function list is unchanged.

Release notes: https://github.com/teaguesterling/duckdb_webbed/releases/tag/v2.8.2

## What changed

`html_to_duck_blocks()` selected blocks with an XPath descendant query, which cannot express containment. That produced a family of defects — `<blockquote>` and `<figure>` emitting their children *and* themselves, `<dl>` producing zero blocks, `<section>`/`<details>` flattening, `<img>` inside `<p>` emitted twice, `<title>`/`<meta>` dropped entirely. The XPath is replaced by a recursive walk with a container/leaf distinction.

Metadata position now follows the source (duck_block spec v1.1): frontmatter opening a document is emitted first, frontmatter closing one is appended as `tailmatter`, and `<head>` title/meta — which the source never positioned — is appended with no role.

The vendored `duck_block` vocabulary moves to SPEC_VERSION 6.3, aligned with the `markdown` and `panduck` extensions at 83 constants.

## Verification

- 3828 assertions across 100 test cases
- CI green across the full matrix on the release commit (Linux amd64/arm64, macOS amd64/arm64, Windows, Wasm mvp/eh/threads)
- documentation examples executed rather than eyeballed: 105 examples, 99 clean, 0 broken

`ref` is `093856b645ce4dbdfdff37b3c02ce0221b1b19d6`, which is the `v2.8.2` tag and is on `main`. `andium` (DuckDB v1.4.5 track) stays at its prior commit; these fixes ship on the v1.5.x track via `ref`.

The description's assertion count is updated to match the release (was 95 suites / 3261 assertions).