### PR TITLE
duckdb_rphonetic: update to v0.2.0

### DIFF
--- a/extensions/duckdb_rphonetic/description.yml
+++ b/extensions/duckdb_rphonetic/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duckdb_rphonetic
   description: Phonetic algorithms for German and European name matching
-  version: 0.1.0
+  version: 0.2.0
   language: Rust
   build: cmake
   license: Apache-2.0
@@ -11,9 +11,9 @@ extension:
     - guizmaii
 
 repo:
-  github: guizmaii-opensource/duckdb-rphonetic
-  # v0.1.0
-  ref: b74284d0dfc71c94859468aef6ac4bbd0981dd19
+  github: guizmaii-opensource/duckdb_rphonetic
+  # v0.2.0
+  ref: ac89f6debd3f5339df18553fc504b682f05d1185
 
 docs:
   hello_world: |
@@ -50,7 +50,9 @@ docs:
     `rphonetic`, which yields `cologne_phonetic('Dieter') = '227'`; Apache
     Commons Codec yields `27`. The two differ on 36 of a 279-name test corpus.
     Every divergence is committed to the repository and pinned by a test, so the
-    output cannot change silently. The published reference vectors
+    output cannot change silently. An `H` carries no code at all and, since
+    0.2.0, never breaks a run: `cologne_phonetic('Mülhler') = '657'`, the same
+    as `Müller`, on which both implementations agree. The published reference vectors
     (`Müller-Lüdenscheidt` -> `65752682`, `Wikipedia` -> `3412`,
     `Breschnew` -> `17863`) are unaffected. Daitch-Mokotoff agrees with
     Commons Codec on all 279 names.


### PR DESCRIPTION
Updates `duckdb_rphonetic` to v0.2.0 (https://github.com/guizmaii-opensource/duckdb_rphonetic/releases/tag/v0.2.0).

- `ref` → `ac89f6d`, the v0.2.0 tag. The release updates the `rphonetic` crate to 4.0.0, which fixes one Kölner Phonetik edge case: an `H` (which has no code) no longer keeps two identical codes apart, so `cologne_phonetic('Mülhler')` is now `657`, the same as `Müller`. All other output is unchanged.
- `repo.github` → `guizmaii-opensource/duckdb_rphonetic`, the repository's current name (the old `duckdb-rphonetic` still redirects).
- One sentence added to the behavioural note in `extended_description` for the `H` case.

Tests run on Linux, macOS and Windows in the extension's own CI: https://github.com/guizmaii-opensource/duckdb_rphonetic/actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sb3cc1RssqQLLB7MDW4in
