### PR TITLE
luajit: bump to v0.32.3 — fix(bridge) LIST-of-STRUCT/LIST-of-LIST params all-nil + agg OVER window tests

### DIFF
--- a/extensions/luajit/description.yml
+++ b/extensions/luajit/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: luajit
   description: "In-process LuaJIT UDFs for DuckDB — JIT-compiled, parallel (per-thread states), trusted sandbox, GROUP BY aggregates, LIST/STRUCT/MAP bridges, embedded Fennel compiler"
-  version: 0.32.2
+  version: 0.32.3
   language: C
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: alitrack/duckdb-luajit
-  ref: 7dc1ada394605fc1f62401d4a0d60613d0e920d0
+  ref: dbdfd5e1e93a1929934c7b9555dc4e0075770161
 
 docs:
   hello_world: |


### PR DESCRIPTION
## luajit v0.32.3

- **fix(bridge)**: `push_list_to_lua` LIST-of-STRUCT / LIST-of-LIST branches — records params previously arrived in Lua as all-nil (missing STRUCT/LIST cases in element loop; struct bridge + nested recursion wired in, plus write direction `write_lua_to_struct` dispatch)
- **test(agg)**: luajit_agg OVER window regression — partition totals (PARTITION BY) + rolling frame (ROWS UNBOUNDED PRECEDING..CURRENT ROW); aggregate-as-window previously had zero sqllogictest coverage

Local: `make test_release SKIP_TESTS=0` → 4/4 SUCCESS. CI on v0.32.3 tag: ✅ success (7m35s).

ref pinned to commit SHA `dbdfd5e1` (per maintainer request, no tag refs).