### PR TITLE
paimon: update to v0.1.1

### DIFF
--- a/extensions/paimon/description.yml
+++ b/extensions/paimon/description.yml
@@ -1,18 +1,18 @@
 extension:
   name: paimon
   description: Query Apache Paimon tables directly from DuckDB
-  version: 0.1.0
+  version: 0.1.1
   language: C++
   build: cmake
   license: Apache-2.0
-  excluded_platforms: "linux_amd64_gcc4;linux_amd64_musl;osx_amd64;osx_arm64;windows_amd64;windows_amd64_mingw;windows_amd64_rtools;windows_arm64;windows_arm64_mingw;wasm_mvp;wasm_eh;wasm_threads"
+  excluded_platforms: "linux_amd64_gcc4;linux_amd64_musl;osx_amd64;windows_amd64;windows_amd64_mingw;windows_amd64_rtools;windows_arm64;windows_arm64_mingw;wasm_mvp;wasm_eh;wasm_threads"
   maintainers:
     - mrdrivingduck
 
 repo:
   github: polardb/duckdb-paimon
-  andium: d1bba0fa7767e3761de45521f3ecdaf465807c57
-  ref: 0764988fac3c37161ae465dd9232ff95213db329
+  andium: 543e43a91edf05ab796e67e19a3cb7240e52bcf6
+  ref: 5e89198235c8be6a402f2b02ef54f249914eee29
 
 docs:
   hello_world: |


### PR DESCRIPTION
Update the Paimon extension metadata to v0.1.1: track DuckDB v1.4.5 and v1.5.5, and enable the linux_amd64, linux_arm64, and osx_arm64 release platforms. Upstream releases: https://github.com/polardb/duckdb-paimon/releases/tag/v0.1.1-andium and https://github.com/polardb/duckdb-paimon/releases/tag/v0.1.1-variegata.