### PR TITLE
Update DuckFlight to 0.1.3

### DIFF
--- a/extensions/duckflight/description.yml
+++ b/extensions/duckflight/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duckflight
   description: Query DuckDB from PostgreSQL and Arrow Flight SQL clients, including psql, ADBC, and Airport
-  version: 0.1.2
+  version: 0.1.3
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: sidequery/duckflight-extension
-  ref: 379f43acbf604cf9eac3dff9b9703599a8cd6865
+  ref: 088037be08cc486beecfd98b38eec099456e7a0f
 
 docs:
   hello_world: |


### PR DESCRIPTION
Updates DuckFlight to 0.1.3. This release fixes Flight SQL preparation for data-changing statements, including INSERT ... ON CONFLICT, and pins the accepted extension entry to the corresponding immutable public commit.