### PR TITLE
Add panduck: native document readers into the duck_block vocabulary

### DIFF
--- a/extensions/panduck/description.yml
+++ b/extensions/panduck/description.yml
@@ -13,7 +13,7 @@ extension:
   vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
 repo:
   github: teaguesterling/duckdb_panduck
-  ref: 67618f67290ecd35bc9ec0663e942331f22d4a5d
+  ref: dedc85c5fe0bc59aadc3019659574a7e283731e4
 docs:
   hello_world: |
     LOAD panduck;

--- a/extensions/panduck/description.yml
+++ b/extensions/panduck/description.yml
@@ -1,0 +1,125 @@
+extension:
+  name: panduck
+  description: Read documents natively into the duck_block vocabulary -- DOCX, ODT, EPUB, RTF, LaTeX, Org, RST, ipynb, MediaWiki and Textile -- and write them back as Pandoc JSON, without linking Pandoc
+  version: 0.1.1
+  language: C++
+  build: cmake
+  license: MIT
+  requires_toolchains: vcpkg
+  maintainers:
+    - teaguesterling
+  # The default pin from extension-ci-tools v1.5.5, which is what panduck's own
+  # distribution pipeline builds green against on every platform including wasm.
+  vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
+repo:
+  github: teaguesterling/duckdb_panduck
+  ref: a2fdc54d8be3132f7eb31c3bff6679418ff7cdfa
+docs:
+  hello_world: |
+    LOAD panduck;
+
+    -- Read a document straight into flattened duck_block rows
+    SELECT * FROM read_docx_blocks('report.docx');
+    SELECT * FROM read_epub_blocks('book.epub');
+    SELECT * FROM read_latex_blocks('paper.tex');
+
+    -- Or let the path pick the reader
+    SELECT * FROM panduck_read_blocks('notes.org');
+    SELECT panduck_format_for('paper.tex');       -- 'latex'
+    SELECT panduck_can_read('archive.docx');      -- true
+
+    -- Formats with no file: parse a string directly
+    SELECT * FROM read_mediawiki_blocks_string('== Heading ==');
+
+    -- Outline any supported document
+    SELECT * FROM doc_toc('report.docx');
+
+    -- Write back out as Pandoc JSON that a real pandoc accepts
+    SELECT panduck_write_pandoc_ast('doc.json',
+        (SELECT list(b) FROM read_odt_blocks('doc.odt') b)
+    );
+
+    -- Or get the AST as a struct without touching the filesystem
+    SELECT panduck_blocks_to_pandoc_ast(
+        (SELECT list(b) FROM read_rtf_blocks('memo.rtf') b)
+    );
+
+  extended_description: |
+    Panduck reads document formats natively into the `duck_block` vocabulary shared
+    with `duck_block_utils`, `markdown` and `webbed` -- so a DOCX, an EPUB and a
+    LaTeX paper all land in the same seven-column shape and can be queried together.
+
+    **It does not link Pandoc.** Pandoc is a Haskell program; the only C bindings
+    that ever existed went unmaintained in 2017, and a Cabal foreign-library request
+    has been open upstream since 2020. Linking the GHC runtime into a dlopen'd DuckDB
+    extension would be a bad neighbour even if it existed. Panduck is instead
+    compatible with Pandoc's **data model**: every reader is hand-written, and a
+    checked mapping table pins the correspondence to Pandoc's AST constructors.
+
+    ## Readers
+
+    | Function | Format |
+    |----------|--------|
+    | `read_docx_blocks(path)` | Word OOXML |
+    | `read_odt_blocks(path)` | OpenDocument Text |
+    | `read_epub_blocks(path)` | EPUB 2/3 |
+    | `read_rtf_blocks(path)` | Rich Text Format |
+    | `read_latex_blocks(path)` | LaTeX |
+    | `read_org_blocks(path)` | Org mode |
+    | `read_rst_blocks(path)` | reStructuredText |
+    | `read_ipynb_blocks(path)` | Jupyter notebooks |
+    | `read_mediawiki_blocks(path)` | MediaWiki wikitext |
+    | `read_textile_blocks(path)` | Textile |
+    | `read_pandoc_blocks(path)` | Pandoc JSON AST (reaches all 43 formats pandoc reads) |
+
+    Every text format also has a `_string` variant that parses content directly.
+    DOCX, ODT, EPUB and RTF read lists, blockquotes, tables, images and footnotes;
+    document metadata is extracted for every format that has any.
+
+    ## Dispatch
+
+    | Function | Description |
+    |----------|-------------|
+    | `panduck_read_blocks(path)` | Read any supported path, reader chosen by extension |
+    | `panduck_format_for(path)` | Which format a path resolves to |
+    | `panduck_can_read(path)` | Whether a path is supported |
+    | `panduck_supported_extensions()` | The registry, as a table |
+    | `panduck_register_doc_reader(...)` | Register a reader at runtime |
+
+    ## Document helpers
+
+    | Function | Description |
+    |----------|-------------|
+    | `doc_toc(path)` | Table of contents for any supported document |
+    | `doc_render(path)` | Render a document to text |
+
+    ## Writing Pandoc JSON
+
+    | Function | Description |
+    |----------|-------------|
+    | `panduck_blocks_to_pandoc_ast(blocks)` | duck_block list to a Pandoc AST document |
+    | `panduck_blocks_to_pandoc_blocks(blocks)` | duck_block list to a Pandoc block array |
+    | `panduck_write_pandoc_ast(path, blocks)` | Write Pandoc JSON to a file |
+    | `panduck_pandoc_ast_map()` | The constructor mapping, as a queryable table |
+
+    The governing rule is that panduck may be **more** faithful than pandoc -- richer
+    attributes, better block types, metadata pandoc does not extract -- so long as the
+    mapping back to valid Pandoc JSON stays total. Every fixture and a set of
+    hand-built constructs are round-tripped through a real pandoc in CI to hold that.
+
+    ## Scope
+
+    This is an early release. Ten readers are implemented and tested against reference
+    implementations, with 2033 test assertions, differential validation against a real
+    pandoc on every fixture, and eight checks in CI.
+
+    The readers were audited over five rounds before this release, each round asking a
+    question the previous one could not answer -- does a construct come back at all, do
+    any words go missing, do all ten readers agree on one logical document. That found
+    18 defects, including silent text loss in DOCX where a hyperlink's anchor text was
+    dropped outright. All are fixed and pinned by tests. Three findings remain open and
+    are recorded in the documentation rather than omitted.
+
+    Known divergences from pandoc are declared and reasoned in the repository's
+    roundtrip ledger rather than hidden -- including several where pandoc is the one
+    losing information.

--- a/extensions/panduck/description.yml
+++ b/extensions/panduck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: panduck
   description: Read documents natively into the duck_block vocabulary -- DOCX, ODT, EPUB, RTF, LaTeX, Org, RST, ipynb, MediaWiki and Textile -- and write them back as Pandoc JSON, without linking Pandoc
-  version: 0.1.2
+  version: 0.1.3
   language: C++
   build: cmake
   license: MIT
@@ -13,7 +13,7 @@ extension:
   vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
 repo:
   github: teaguesterling/duckdb_panduck
-  ref: e4d3115e26394c419d0ad0e12c38e471b356fa56
+  ref: 3324fc1c6b1d072ffd6f20c65ac7cda0fa808121
 docs:
   hello_world: |
     LOAD panduck;

--- a/extensions/panduck/description.yml
+++ b/extensions/panduck/description.yml
@@ -13,7 +13,7 @@ extension:
   vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
 repo:
   github: teaguesterling/duckdb_panduck
-  ref: 5195ce9e58c596c06f9869941b9d94a100be26af
+  ref: cd25d43267c180f819d81e6e166a49440a4e894c
 docs:
   hello_world: |
     LOAD panduck;

--- a/extensions/panduck/description.yml
+++ b/extensions/panduck/description.yml
@@ -13,7 +13,7 @@ extension:
   vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
 repo:
   github: teaguesterling/duckdb_panduck
-  ref: dedc85c5fe0bc59aadc3019659574a7e283731e4
+  ref: c00bf4ddd6bb153d5cfa51f9d8b20a3251f46aa0
 docs:
   hello_world: |
     LOAD panduck;

--- a/extensions/panduck/description.yml
+++ b/extensions/panduck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: panduck
   description: Read documents natively into the duck_block vocabulary -- DOCX, ODT, EPUB, RTF, LaTeX, Org, RST, ipynb, MediaWiki and Textile -- and write them back as Pandoc JSON, without linking Pandoc
-  version: 0.1.1
+  version: 0.1.2
   language: C++
   build: cmake
   license: MIT
@@ -13,7 +13,7 @@ extension:
   vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
 repo:
   github: teaguesterling/duckdb_panduck
-  ref: a2fdc54d8be3132f7eb31c3bff6679418ff7cdfa
+  ref: 5195ce9e58c596c06f9869941b9d94a100be26af
 docs:
   hello_world: |
     LOAD panduck;

--- a/extensions/panduck/description.yml
+++ b/extensions/panduck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: panduck
   description: Read documents natively into the duck_block vocabulary -- DOCX, ODT, EPUB, RTF, LaTeX, Org, RST, ipynb, MediaWiki and Textile -- and write them back as Pandoc JSON, without linking Pandoc
-  version: 0.1.3
+  version: 0.1.4
   language: C++
   build: cmake
   license: MIT

--- a/extensions/panduck/description.yml
+++ b/extensions/panduck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: panduck
   description: Read documents natively into the duck_block vocabulary -- DOCX, ODT, EPUB, RTF, LaTeX, Org, RST, ipynb, MediaWiki and Textile -- and write them back as Pandoc JSON, without linking Pandoc
-  version: 0.1.4
+  version: 0.1.5
   language: C++
   build: cmake
   license: MIT
@@ -13,7 +13,7 @@ extension:
   vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
 repo:
   github: teaguesterling/duckdb_panduck
-  ref: c00bf4ddd6bb153d5cfa51f9d8b20a3251f46aa0
+  ref: 2d9c3b2a3088b87d2cf05c62d1ae24669c5e2883
 docs:
   hello_world: |
     LOAD panduck;
@@ -110,7 +110,7 @@ docs:
     ## Scope
 
     This is an early release. Ten readers are implemented and tested against reference
-    implementations, with 2033 test assertions, differential validation against a real
+    implementations, with 2034 test assertions, differential validation against a real
     pandoc on every fixture, and eight checks in CI.
 
     The readers were audited over five rounds before this release, each round asking a

--- a/extensions/panduck/description.yml
+++ b/extensions/panduck/description.yml
@@ -13,7 +13,7 @@ extension:
   vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
 repo:
   github: teaguesterling/duckdb_panduck
-  ref: cd25d43267c180f819d81e6e166a49440a4e894c
+  ref: e4d3115e26394c419d0ad0e12c38e471b356fa56
 docs:
   hello_world: |
     LOAD panduck;

--- a/extensions/panduck/description.yml
+++ b/extensions/panduck/description.yml
@@ -13,7 +13,7 @@ extension:
   vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
 repo:
   github: teaguesterling/duckdb_panduck
-  ref: 3324fc1c6b1d072ffd6f20c65ac7cda0fa808121
+  ref: 67618f67290ecd35bc9ec0663e942331f22d4a5d
 docs:
   hello_world: |
     LOAD panduck;

--- a/extensions/panduck/description.yml
+++ b/extensions/panduck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: panduck
   description: Read documents natively into the duck_block vocabulary -- DOCX, ODT, EPUB, RTF, LaTeX, Org, RST, ipynb, MediaWiki and Textile -- and write them back as Pandoc JSON, without linking Pandoc
-  version: 0.1.5
+  version: 0.2.0
   language: C++
   build: cmake
   license: MIT
@@ -13,7 +13,7 @@ extension:
   vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
 repo:
   github: teaguesterling/duckdb_panduck
-  ref: 2d9c3b2a3088b87d2cf05c62d1ae24669c5e2883
+  ref: a57402beff9805d69c1590733224fc9a71b5b08b
 docs:
   hello_world: |
     LOAD panduck;


### PR DESCRIPTION
`panduck` reads rich document formats **natively** into the shared `duck_block`
vocabulary — no Pandoc binary required — so a Word document, an EPUB and a LaTeX
paper all land in the same seven-column shape and can be queried together.

```sql
LOAD panduck;

SELECT * FROM read_docx_blocks('report.docx');
SELECT * FROM panduck_read_blocks('notes.org');   -- reader chosen by path
SELECT * FROM doc_toc('paper.tex');

-- many documents at once, with provenance
SELECT filename, element_type, content
FROM read_panduck_doc('papers/*.docx', filename := true);

-- and back out as Pandoc JSON a real pandoc accepts
SELECT panduck_write_pandoc_ast('doc.json',
    (SELECT list(b) FROM read_odt_blocks('doc.odt') b));
```

**Eleven native readers** — DOCX, ODT, EPUB, RTF, LaTeX, Org, RST, ipynb, MediaWiki,
Textile and PDF — plus a Pandoc AST reader that reaches every format pandoc reads,
for people who already have it.

### Why not link Pandoc

Pandoc is a Haskell program. The only C bindings that ever existed went
unmaintained in 2017, and a Cabal foreign-library request has been open upstream
since 2020. Linking the GHC runtime into a `dlopen`'d DuckDB extension would be a
bad neighbour even if it existed. panduck is compatible with Pandoc's **data
model** instead: every reader is hand-written, and a checked mapping table pins
the correspondence to Pandoc's AST constructors against a real pandoc in CI.

### Ecosystem

Uses the same `duck_block` type as
[`duck_block_utils`](https://github.com/teaguesterling/duckdb_duck_block_utils),
[`markdown`](https://github.com/teaguesterling/duckdb_markdown) and
[`webbed`](https://github.com/teaguesterling/duckdb_webbed), and routes `.md`,
`.html` and `.pdf` to those rather than reimplementing them.

> **Dependency note for reviewers.** `doc_toc` requires **duck_block_utils ≥ 3.0.0**
> (spec 6.5). 3.0.x reshaped `duck_blocks_toc` to return `duck_block[]` and moved the
> projection `doc_toc` reads to `duck_blocks_toc_structs`, so against an older build
> `doc_toc` raises rather than returning wrong rows. duck_block_utils v3.0.1 is
> [#2649](https://github.com/duckdb/community-extensions/pull/2649), merged. Every
> other panduck function is independent of it.

### Testing

**2267 assertions**, 38 fixtures, eight checks, and fourteen CI jobs green across
Linux, macOS, Windows and WASM — plus a forward-compat canary that builds against
DuckDB `main` (the v2.0 line), currently green. That canary is not decoration: it
caught a v2.0 source break in this extension (`ScalarFunction::null_handling` moved
behind a setter) that the v1.5.5 pin compiles clean, which `build_next.yml` would
otherwise have found here.

CI also **inspects the built `.wasm`** for unresolved dependency symbols — CI builds
wasm but never instantiates it, so a missing `LINKED_LIBS` entry otherwise ships
green and throws on first call in the browser. Three sibling extensions shipped that
bug; this one caught it before release.

The readers were audited over five rounds before submission, each round asking a
question the previous could not answer — does a construct come back at all, do any
words go missing, do all readers agree on one logical document. That found 18
defects, including silent text loss in DOCX. All are fixed and pinned by tests.

**Known gaps, stated rather than left for discovery.** `doc_toc` has no CI coverage
on this tag: its test file is gated until the community registry actually *serves*
duck_block_utils 3.0.x, and it is verified instead against a local 3.0.0 build.
Tracked as [#22](https://github.com/teaguesterling/duckdb_panduck/issues/22). The
reader-policy settings do not cover panduck's own readers called directly; that is
[#16](https://github.com/teaguesterling/duckdb_panduck/issues/16), fixed on `main`
and shipping next. Both are documented in the extension's own docs.

### Notes on the descriptor

- Ref is [`v0.2.0`](https://github.com/teaguesterling/duckdb_panduck/releases/tag/v0.2.0)
  (`a57402b`) — an annotated tag with a published release and full changelog.
- No `andium` ref — panduck targets DuckDB v1.5.5 and has never been
  build-verified against the v1.4.5 track, so naming a commit there would claim
  something untested.
- No `docs_url` — the documentation site is not published yet, and a dead link is
  worse than none.
- `vcpkg_commit` is the `extension-ci-tools` v1.5.5 default, which this extension's
  own pipeline builds green against on every platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
