### PR TITLE
markdown: v1.7.1

### DIFF
--- a/extensions/markdown/description.yml
+++ b/extensions/markdown/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: markdown
   description: Read, analyze, and write Markdown files with block-level document representation and inline element support
-  version: 1.7.0
+  version: 1.7.1
   language: C++
   build: cmake
   license: MIT
@@ -14,7 +14,7 @@ repo:
   # change since -- v1.5.1 structured inline blocks, the v1.5.2 UTF-8 truncation
   # fix, and v1.6.0 -- ships on the v1.5.x track via ref, which is a v1.5.4 tree.
   andium: c9e1a4d3b98a814c86295ecb2ed760be286242ba
-  ref: 340c0cd59701f74e9ec29d7e4515c4c3b1bf27b1
+  ref: 0e58dfcbfa9b881e5cf3e5cac682ffaa906fbdec
 docs:
   hello_world: |
     -- Load the extension
@@ -105,4 +105,4 @@ docs:
 
     Real-world benchmark: Processing 287 Markdown files (2,699 sections, 1,137 code blocks, 1,174 links) in 603ms.
 
-    Full test suite with 1190 passing assertions across 24 test files.
+    Full test suite with 1800 passing assertions across 49 test files.


### PR DESCRIPTION
Bug-fix release: **v1.7.1**.

Twelve defects that silently destroyed document content, plus alignment with the duck_blocks v1.1 spec.

- **Lists** discarded nesting and inline formatting — items were packed into a JSON array via a text flattener, so `**bold**` came back as `bold`, a second paragraph in an item vanished, and nested sublists were dropped outright. Lists are now structural (`list` → `list_item` → the item's own blocks).
- **Blockquotes** concatenated their block children with no separator (`quoted para` + `second para` → `quoted parasecond para`).
- **`hr`, `page_break` and `generic`** deleted the inline run that followed them.
- **Headings** discarded their own inline formatting; `# **Bold** t` and `# Bold t` produced byte-identical output.
- **Backslash escapes** were lost, so `\# not a heading` became a heading on the next parse.
- **Raw inline HTML** (`<span>`, `<br/>`, comments) was dropped.
- **TOML (`+++`) frontmatter** was flattened into unparseable prose; it's now recognised with `encoding='toml'`.
- Plus a duplicated figure caption, four container types dropping their content, a `kind='value'` metadata leak, and a parser race under parallelism.

Full notes: https://github.com/teaguesterling/duckdb_markdown/releases/tag/v1.7.1

**Output-shape note for existing users:** frontmatter is now `element_type='metadata'` with `attributes['role']='frontmatter'` (the old name is still accepted on write), and a `list`'s items are `list_item` children rather than a JSON array in `content`. These changes are confined to the duck_block reader surface, which is versioned in step with the other duck_block tools; `read_markdown_sections`, `md_extract_frontmatter`, `md_extract_metadata` and `md_stats` are unchanged for existing inputs.

`andium` is intentionally left at its prior commit, as in previous releases.

Verified at `0e58dfc`: 49 test files, 1800 assertions, 14/14 CI jobs green.
