### PR TITLE
Bump anofox_statistics to v0.10.0

### DIFF
--- a/extensions/anofox_statistics/description.yml
+++ b/extensions/anofox_statistics/description.yml
@@ -9,4 +9,4 @@ extension:
   requires_toolchains: rust
 repo:
   github: DataZooDE/anofox-statistics
-  ref: v0.9.0
+  ref: v0.10.0

--- a/extensions/anofox_statistics/description.yml
+++ b/extensions/anofox_statistics/description.yml
@@ -9,4 +9,4 @@ extension:
   requires_toolchains: rust
 repo:
   github: DataZooDE/anofox-statistics
-  ref: v0.10.0
+  ref: 8b1a138797f00ea8a479eb17328b0bb2607861c2


### PR DESCRIPTION
Bumps `anofox_statistics` to **v0.10.0** (tag [`v0.10.0`](https://github.com/DataZooDE/anofox-statistics/releases/tag/v0.10.0)).

**v0.10.0 — Performance & Polish**
- FFI refactor + benchmarking pass (inference-array allocation, hot-path cleanup)
- API ergonomics: registration names dropped the `anofox_stats_` prefix (breaking renames)
- Improved error surfacing from the Rust core through the FFI boundary
- Docs restructure + a CI gate that validates the SQL in the docs/guides

Note: the function-name renames are a breaking change for users of prior versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)