### PR TITLE
fix: add indent for the description

### DIFF
--- a/extensions/dynamodb/description.yml
+++ b/extensions/dynamodb/description.yml
@@ -30,7 +30,7 @@ docs:
     WHERE createdAt::timestamp > '2026-05-01 00:00:00'::TIMESTAMP;
     
 
-extended_description: |
+  extended_description: |
     This extension adds support for querying DynamoDB tables directly from DuckDB. 
     It implements filter pushdown on partition keys, sort keys, and GSIs to minimize read capacity consumption, with remaining filtering and all aggregation handled by DuckDB's execution engine.
     For a detailed description take a look at the [extension repository](https://github.com/lukaswelsch/duckdb-dynamodb). 


### PR DESCRIPTION
Hello,

thanks for approving my PR and merging!

I noticed that I forgot an indent in front of the extended_description block, which leads to the description not showing up in the community_extension webpage. 