### PR TITLE
ai: bump to v0.4.25

### DIFF
--- a/extensions/ai/description.yml
+++ b/extensions/ai/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: ai
   description: AI functions for SQL — completions, classification, extraction, embeddings, and read-only SQL generation across local and hosted model providers
-  version: 0.4.14
+  version: 0.4.24
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: leonardovida/duckdb-ai
-  ref: 9b7b16a5d5bfa97180b8be48d69bd9a4a4106419
+  ref: 4e58db579d50ccc63fcfe786fb86672245e0e2df
 
 docs:
   hello_world: |

--- a/extensions/ai/description.yml
+++ b/extensions/ai/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: ai
   description: AI functions for SQL — completions, classification, extraction, embeddings, and read-only SQL generation across local and hosted model providers
-  version: 0.4.24
+  version: 0.4.25
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: leonardovida/duckdb-ai
-  ref: 4e58db579d50ccc63fcfe786fb86672245e0e2df
+  ref: d7348163604ecc21396d5991b1991b6127cb2a47
 
 docs:
   hello_world: |


### PR DESCRIPTION
Update the `ai` extension to v0.4.25 so community installs include the current Databricks completion and provider maintenance fixes.