### PR TITLE
trino_parity: bump to 0.4.0 (reject empty HMAC keys like Trino)

### DIFF
--- a/extensions/trino_parity/description.yml
+++ b/extensions/trino_parity/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: trino_parity
   description: Native Trino-compatible scalar functions (trino_*) for the cases where DuckDB's built-ins diverge from Trino on Unicode and byte-level inputs — Trino's simple per-code-point case mapping, code-point reverse, Java-whitespace trim, NFC normalize, and raw-bytes xxhash64/sha512/hmac_sha256
-  version: 0.3.0
+  version: 0.4.0
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: brikk/duckdb-trino-parity-extension
-  ref: b181c61c165b9f79e7902ee73de509f14b391299
+  ref: 3d6b049b936527f3b451eeec3ce8dc69bba8c054
 
 docs:
   hello_world: |
@@ -28,6 +28,10 @@ docs:
 
     -- Code-point reverse (DuckDB's built-in reverse is grapheme-aware):
     SELECT trino_reverse('a😀b');     -- 'b😀a'
+
+    -- HMAC uses raw bytes; empty data is valid, but an empty key throws
+    -- "Empty key" to match Trino's SecretKeySpec API contract:
+    SELECT hex(trino_hmac_sha256('data'::BLOB, 'key'::BLOB));
 
     -- The catalog of functions this extension provides:
     SELECT trino_name, arg_count, category FROM trino_meta();  -- 10 rows
@@ -69,7 +73,9 @@ docs:
       DuckDB build).
     - **Hash (vendored):** `trino_xxhash64/1`, `trino_sha512/1`,
       `trino_hmac_sha256/2` — over raw `VARBINARY`, self-contained (no
-      dependency on the `crypto` / `hashfuncs` community extensions).
+      dependency on the `crypto` / `hashfuncs` community extensions). HMAC
+      rejects an empty key with `Empty key`, matching Trino (empty data remains
+      valid; binary-NUL and >64-byte keys are supported).
 
     Aligned Trino functions (e.g. `length`, `abs`, `year`, `substring`,
     `regexp_extract`) are intentionally NOT shipped — a caller emits them as

--- a/extensions/trino_parity/description.yml
+++ b/extensions/trino_parity/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: brikk/duckdb-trino-parity-extension
-  ref: e93c6b78f460db4f1fc93b78f4b771a8665e3ec0
+  ref: 0059004e24d7cfc2b84ae1788efae7c075a1b690
 
 docs:
   hello_world: |

--- a/extensions/trino_parity/description.yml
+++ b/extensions/trino_parity/description.yml
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: brikk/duckdb-trino-parity-extension
-  ref: 3d6b049b936527f3b451eeec3ce8dc69bba8c054
+  ref: e93c6b78f460db4f1fc93b78f4b771a8665e3ec0
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps `trino_parity` to `e93c6b78f460db4f1fc93b78f4b771a8665e3ec0`
(version 0.4.0).

### Fix

`trino_hmac_sha256(data, key)` now rejects a zero-byte key with
`InvalidInputException("Empty key")`, matching Trino's `SecretKeySpec` API
contract. RFC 2104 itself permits an empty key, so the previous implementation
returned a digest where Trino fails. This became user-reachable once duckbridge
added BLOB→VARBINARY table-column mapping.

Empty **data** remains valid. Sqllogic also pins binary-NUL keys/messages,
>64-byte keys (hash-the-key path), and NULL propagation on either argument.
No catalog/function signatures changed.

### DuckDB latest compatibility

The first `test_against_latest` run exposed dead pre-0.2 scalar-macro machinery:
the extension had no scalar macros after its native-function shrink, but still
compiled a sentinel-only `DefaultMacro` array and no-op registration loop.
DuckDB latest changed that unused API. Commit `e93c6b7` deletes the empty array,
loop and dependency rather than adding a version shim. `trino_meta()` remains on
its separate `DefaultTableMacro` path; all ten `trino_*` functions remain native
scalars.

### CI

The HMAC change's upstream MainDistributionPipeline is green across Linux
amd64/arm64, macOS amd64/arm64, Windows MSVC + MinGW, Wasm mvp/eh/threads,
Format and Tidy:
https://github.com/brikk/duckdb-trino-parity-extension/actions/runs/33933840257

The final ref reruns that matrix. Local pinned-DuckDB v1.5.5 format/build/tests:
82/82 assertions.
