### PR TITLE
trino_parity: bump to 0.5.0 (Unicode 16 parity)

### DIFF
--- a/extensions/trino_parity/description.yml
+++ b/extensions/trino_parity/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: trino_parity
   description: Native Trino-compatible scalar functions (trino_*) for the cases where DuckDB's built-ins diverge from Trino on Unicode and byte-level inputs — Trino's simple per-code-point case mapping, code-point reverse, Java-whitespace trim, NFC normalize, and raw-bytes xxhash64/sha512/hmac_sha256
-  version: 0.3.0
+  version: 0.5.0
   language: C++
   build: cmake
   license: MIT
@@ -10,7 +10,7 @@ extension:
 
 repo:
   github: brikk/duckdb-trino-parity-extension
-  ref: b181c61c165b9f79e7902ee73de509f14b391299
+  ref: dbdb85c502f82ddecab0779df092a6d1817f0b5a
 
 docs:
   hello_world: |
@@ -21,6 +21,9 @@ docs:
     -- (Character.toUpperCase(int)), so German sharp-S is unchanged —
     -- DuckDB's built-in upper() gives 'STRAẞE' (U+1E9E):
     SELECT trino_upper('straße');     -- 'STRAßE'
+
+    -- Unicode 16 data includes case pairs absent from older ICU snapshots:
+    SELECT trino_lower(chr(11311)) = chr(11359) AS glagolitic_unicode16; -- true
 
     -- Java whitespace trim: tab / LF / CR / FF / VT are stripped
     -- (DuckDB's built-in trim() only strips spaces):
@@ -35,6 +38,11 @@ docs:
     `trino_parity` provides native `trino_<name>(...)` scalar functions for the
     specific cases where DuckDB's built-ins diverge from Trino's documented
     behaviour on Unicode and byte-level inputs.
+
+    Version 0.5.0 vendors ICU 76.1 / Unicode 16.0, fixing newer case mappings
+    and NFC normalization data missing from the previous Unicode 13 snapshot.
+    The compatibility target is Trino 483 on JDK 25. Matching version labels
+    alone does not guarantee parity with other Trino/JDK combinations.
 
     It is designed to be loaded server-side by anything that pushes Trino-shaped
     predicates down to DuckDB. If a Trino connector naively pushes
@@ -64,12 +72,20 @@ docs:
       `trino_trim/1`, `trino_ltrim/1`, `trino_rtrim/1`, `trino_normalize/1` —
       simple per-code-point case mapping (Trino's `Character.toUpperCase(int)`
       model — no `SpecialCasing` expansions or final-sigma rule), code-point
-      reverse, and `Character.isWhitespace` trim, via statically-linked ICU
+      reverse, and `Character.isWhitespace` trim, via statically-linked ICU 76.1
       vendored into the binary (so Unicode behaviour is independent of the host
       DuckDB build).
     - **Hash (vendored):** `trino_xxhash64/1`, `trino_sha512/1`,
       `trino_hmac_sha256/2` — over raw `VARBINARY`, self-contained (no
       dependency on the `crypto` / `hashfuncs` community extensions).
+      Empty HMAC keys are rejected with `Empty key`, matching Trino; empty
+      messages and nonempty binary keys remain supported.
+
+    The ten-function catalog and three-column `trino_meta()` schema are
+    unchanged. Validation against pinned OpenJDK 25 covers all 1,112,064 valid
+    Unicode scalar values and 99,825 NFC conformance column checks, with zero
+    mismatches. See the [Unicode 16 validation report](https://github.com/brikk/duckdb-trino-parity-extension/blob/main/docs/REPORT-unicode16-validation.md)
+    for provenance, commands, and the limits of that validation.
 
     Aligned Trino functions (e.g. `length`, `abs`, `year`, `substring`,
     `regexp_extract`) are intentionally NOT shipped — a caller emits them as


### PR DESCRIPTION
## Summary

Update `trino_parity` to [v0.5.0](https://github.com/brikk/duckdb-trino-parity-extension/releases/tag/v0.5.0), pinned at `dbdb85c502f82ddecab0779df092a6d1817f0b5a`.

- Upgrade the statically vendored ICU from 66.1 / Unicode 13 to 76.1 / Unicode 16.0. This fixes newer case mappings and NFC normalization missing from the old data (EV-E3), including Glagolitic U+2C2F/U+2C5F and Vithkuqi.
- Preserve the ten native functions and the three-column `trino_meta()` catalog. Simple per-code-point case mapping, Java whitespace, and the NFC-only public API remain unchanged.
- Keep the dependency self-contained, checksum-pinned, symbol-isolated, and offline at build/load time. No new vcpkg packages or runtime extension dependencies.
- Include the empty-HMAC-key rejection from 0.4.0 and document the targeted Trino 483 / JDK 25 compatibility profile.

## Validation

- [Full extension CI passed](https://github.com/brikk/duckdb-trino-parity-extension/actions/runs/33966957697) on DuckDB 1.5.5: Linux amd64/arm64, macOS amd64/arm64, Windows MSVC/MinGW, Wasm mvp/eh/threads, and Format/Tidy. Runtime tests run on the platforms supported by that reusable workflow; Wasm validation is build-only.
- SQL regressions: 94 assertions across the existing suite and new Unicode 14/16 canaries.
- The actual CI-built Linux binary passes an independent pinned OpenJDK 25 oracle across all 1,112,064 valid Unicode scalar values and 99,825 NFC conformance column checks, with zero mismatches.
- The descriptor passes this repository's `scripts/build.py` parser.
- DuckDB 2 preview `e3946f2327` compiles locally in extensions-only/dynamic-symbol mode; runtime compatibility and the preview distribution matrix are not claimed by this release.

[Detailed validation report](https://github.com/brikk/duckdb-trino-parity-extension/blob/v0.5.0/docs/REPORT-unicode16-validation.md)

## Related Update

#2614 (0.4.0) was still awaiting merge when this PR was prepared. This release includes that fix; the PR is left intact for maintainer sequencing. If 0.4.0 lands first, this update advances it to 0.5.0. No consumer flag-day coordination is needed because the ten-function catalog is unchanged.
