### PR TITLE
read_lines: v0.4.0

### DIFF
--- a/extensions/read_lines/description.yml
+++ b/extensions/read_lines/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: read_lines
   description: Read line-based text files with line numbers and efficient subset extraction. Supports glob patterns, line selection with context, and GitHub-style '#L12-24' fragments so a line range can be attached to any path, including URIs served by other extensions.
-  version: 0.3.0
+  version: 0.4.0
   language: C++
   build: cmake
   license: MIT
@@ -10,9 +10,9 @@ extension:
 repo:
   github: teaguesterling/duckdb_read_lines
   # andium (DuckDB v1.4.5 track) intentionally left at its prior commit; ref is a
-  # v1.5.4 tree, so v0.3.0 ships on the v1.5.x track only.
+  # v1.5.4 tree, so v0.4.0 ships on the v1.5.x track only.
   andium: 8075509bc21b936c228879ada22c8a46657109aa
-  ref: 2426d08add6b0242572af2a75437aa6c67d4c970
+  ref: de60f5dab22b4c40aacfa1af58977600b89bd98a
 docs:
   hello_world: |
     -- Read all lines from a file


### PR DESCRIPTION
Builds against DuckDB 2.0.0 as well as the pinned v1.5 line. No new public surface — the function list is unchanged.

- Build against both DuckDB v1.5 and DuckDB main (v2.0)
- Convert `input_table_names` through `CompatNameStr`
- Derive `CompatName` from DuckDB rather than probing for a header

Release notes: https://github.com/teaguesterling/duckdb_read_lines/releases/tag/v0.4.0

`ref` is `de60f5dab22b4c40aacfa1af58977600b89bd98a`, which is the `v0.4.0` tag and is on `main`.