### PR TITLE
webbed: update to v2.9.0

### DIFF
--- a/extensions/webbed/description.yml
+++ b/extensions/webbed/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: webbed
   description: Comprehensive processing extension for web markup languages (XML and HTML) with SAX streaming for large files, intelligent schema inference, XPath-based data extraction, and HTML table parsing.
-  version: 2.8.2
+  version: 2.9.0
   language: C++
   build: cmake
   license: MIT
@@ -15,9 +15,9 @@ extension:
 repo:
   github: teaguesterling/duckdb_webbed
   andium: ddda30f11352138b2451657419640370d1612137
-  # andium (DuckDB v1.4.5 track) left at its prior commit; the v2.8.2
-  # duck_block correctness fixes ship on the v1.5.x track via ref.
-  ref: 093856b645ce4dbdfdff37b3c02ce0221b1b19d6
+  # andium (DuckDB v1.4.5 track) left at its prior commit; v2.9.0 ships on the
+  # v1.5.x track via ref and is verified against DuckDB 2.0 (main) as well.
+  ref: 73189d2712ad7296ac5f49029df11bdb8ee07d61
 docs:
   docs_url: https://duckdb-webbed.readthedocs.io
   hello_world: |
@@ -95,4 +95,4 @@ docs:
 
     See https://duckdb-webbed.readthedocs.io for comprehensive documentation and examples.
 
-    Built on libxml2 for robust, standards-compliant parsing with comprehensive error handling and memory-safe RAII implementation. 100 test suites with 3828 assertions, including DOM/SAX equivalence, adversarial/security, and multi-file parallelism testing. The extension supports mixed file systems, configurable schema inference, and efficient processing of large document collections.
+    Built on libxml2 for robust, standards-compliant parsing with comprehensive error handling and memory-safe RAII implementation. 102 test suites with 3951 assertions, including DOM/SAX equivalence, adversarial/security, and multi-file parallelism testing. The extension supports mixed file systems, configurable schema inference, and efficient processing of large document collections.


### PR DESCRIPTION
Minor release for `webbed`. Release notes: https://github.com/teaguesterling/duckdb_webbed/releases/tag/v2.9.0

## What changed

- **`capture_attributes`** on `html_to_duck_blocks`, `read_html_blocks` and `parse_html_blocks` — `'default' | 'classes' | '*' | true | false | [...]` — governs which source attributes are carried onto every element. Default `['id', 'name', 'href', 'src']`; `class` is opt-in. Fixes a defect where attributes were kept on some elements and silently dropped on most (#142).
- **`filename` column is now trailing** on `read_html_blocks`, per duck_block spec 6.4+, so the 8-field shape binds against `duck_block_utils`. Consumers accept the 8-field duck_block in turn.
- **DuckDB 2.0 ready:** every throwing scalar declares `SetFallible`, the dual-version port is in, and the canary against DuckDB `main` is green on every platform with tests passing on Linux, Windows and macOS.
- DuckDB submodule at v1.5.5; duck_block vocabulary at spec 6.5.

## Verification

- 3951 assertions across 102 test cases on v1.5.5
- DuckDB 2.0 canary: 102/102 on the legs that run tests — so `build_next` should pass
- `ref` is `73189d2`, the `v2.9.0` tag, verified reachable on `main`. `andium` (DuckDB v1.4.5 track) stays at its prior commit.
- Description assertion count corrected to 102 / 3951.