### PR TITLE
duck_block_utils: v3.0.1

### DIFF
--- a/extensions/duck_block_utils/description.yml
+++ b/extensions/duck_block_utils/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duck_block_utils
   description: Build, transform, validate, and extract content from structured documents using the duck_block type
-  version: 2.0.0
+  version: 3.0.0
   language: C++
   build: cmake
   license: MIT
@@ -14,7 +14,7 @@ repo:
   # so advancing this pin would point a v1.4.5 build at a tree that cannot build for
   # it. v1.4.5 users should move to the v1.5.x track.
   andium: 125662df9e5450105dc9b7957ad955cb53d7beec
-  ref: 3f2a0f0a88325e20f4a4a0441fb7f8e3bcc9f18b
+  ref: 5bbf45c80b653e6e0a028eee7b6df43697fb4875
 docs:
   hello_world: |
     -- Build a document programmatically

--- a/extensions/duck_block_utils/description.yml
+++ b/extensions/duck_block_utils/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duck_block_utils
   description: Build, transform, validate, and extract content from structured documents using the duck_block type
-  version: 3.0.0
+  version: 3.0.1
   language: C++
   build: cmake
   license: MIT
@@ -14,7 +14,7 @@ repo:
   # so advancing this pin would point a v1.4.5 build at a tree that cannot build for
   # it. v1.4.5 users should move to the v1.5.x track.
   andium: 125662df9e5450105dc9b7957ad955cb53d7beec
-  ref: 5bbf45c80b653e6e0a028eee7b6df43697fb4875
+  ref: 959965034939352e6e6389da7c202b365d924fa5
 docs:
   hello_world: |
     -- Build a document programmatically


### PR DESCRIPTION
Builds against DuckDB 2.0.0 as well as the pinned v1.5 line.

**Breaking on the function surface.** `duck_blocks_headings`, `duck_blocks_links`, `duck_blocks_code_blocks` and `duck_blocks_toc` now return duck_blocks, with the previous shapes preserved as `_structs` siblings; `duck_blocks_get_section`, `_sections_like` and `_get_pages` likewise return duck_blocks, with `_text` siblings. **A consumer that reads fields off any of these must switch to the `_structs` or `_text` sibling** — it compiles green and fails at run time otherwise.

- duck_block gains an optional trailing `filename VARCHAR`; acceptance is keyed on the exact 8-field type, so a consumer that does not know about it refuses the struct rather than misreading it
- `SPEC_VERSION` 6.5; headings carry a computed outline number; `level` is never NULL and `element_order` is carried through unrenumbered as the recovery key
- Pandoc AST round-trip fidelity fixed for Code and Math inline content and the api-version stamp
- The Pandoc converter is deprecated — one release of warning before it moves

Release notes: https://github.com/teaguesterling/duckdb_duck_block_utils/releases/tag/v3.0.0

`ref` is `5bbf45c80b653e6e0a028eee7b6df43697fb4875`, which is the `v3.0.0` tag and is on `main`. The DuckDB-main canary is parked to `workflow_dispatch`, so it shows as skipped on the push run; it was dispatched on this tree and is green with the `Test` step included.