### PR TITLE
yaml: v1.9.0

### DIFF
--- a/extensions/yaml/description.yml
+++ b/extensions/yaml/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: yaml
   description: Read YAML files into DuckDB with native YAML type support, comprehensive extraction functions, and seamless JSON interoperability
-  version: 1.8.0
+  version: 1.9.0
   language: C++
   build: cmake
   license: MIT
@@ -13,8 +13,8 @@ extension:
   
 repo:
   github: teaguesterling/duckdb_yaml
-  andium: 55ebe5ef4b6d3d191f2f709494bb09271b3016c7
-  ref: 55ebe5ef4b6d3d191f2f709494bb09271b3016c7
+  andium: 0bdc812c064fa7b85617f75680d9c1177263f741
+  ref: 0bdc812c064fa7b85617f75680d9c1177263f741
 
 docs:
   hello_world: |


### PR DESCRIPTION
Builds against DuckDB 2.0.0 as well as the pinned v1.5.4 line.

- Frontmatter extraction no longer swallows the document body. An immediately-closed block (`---` then `---`) was never matched, so the scan ran on and latched onto a `---` **in the body**, promoting body text to frontmatter and silently discarding the real content.
- `yaml_to_json` key-escaping coverage extended to newline, tab, control characters and non-ASCII. The escaping itself was already correct; only the tests were narrow.
- Duplicate keys and the Norway problem documented: `yaml_to_json` emits every occurrence, while `read_yaml` keeps only the first.
- Dead `yaml_reader_column_bind_old.cpp` removed.

Release notes: https://github.com/teaguesterling/duckdb_yaml/releases/tag/v1.9.0

`ref` is `0bdc812c064fa7b85617f75680d9c1177263f741`, which is the `v1.9.0` tag and is on `main`. The DuckDB-main canary is green on that commit across all nine legs, `Test` step included.