### PR TITLE
duck_hunt: v1.12.0

### DIFF
--- a/extensions/duck_hunt/description.yml
+++ b/extensions/duck_hunt/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duck_hunt
   description: Parse and analyze test results, build outputs, and CI/CD pipeline logs from 110+ formats with severity filtering, format auto-detection, and context extraction
-  version: 1.11.1
+  version: 1.12.0
   language: C++
   build: cmake
   license: Apache-2.0
@@ -15,8 +15,8 @@ extension:
 
 repo:
   github: teaguesterling/duck_hunt
-  andium: fbb85006d832846a4a0fbf6b6437908e252ce95a
-  ref: fbb85006d832846a4a0fbf6b6437908e252ce95a
+  andium: 68ca1c4676f706980a6503c19b789f5224596b4d
+  ref: 68ca1c4676f706980a6503c19b789f5224596b4d
 
 docs:
   readme: https://duck-hunt.readthedocs.io/


### PR DESCRIPTION
Builds against DuckDB 2.0.0 as well as the pinned v1.5 line.

- **Malformed JSON in `structured_data`.** 20 parsers still built JSON by concatenating raw runtime strings — a quote, backslash or control character in a log produced invalid JSON. All now escape through `SafeParsing::EscapeJsonString`, and captures landing in JSON *number* slots go through a new `JsonNumberOrString`.
- **Auto-detect routed to the wrong parser.** 74 of 110 parsers share priority 80, so the winner among them was registration order: a RuboCop log containing one embedded `[  FAILED  ]` line was parsed as gtest, and a Maven build with the same line went to junit and yielded **zero** events. Detection now collects every claimant at the highest claiming priority and skips any that extracts nothing from the sniff window.
- Format coverage smoke tests close the gap from 93/110 named formats to 110/110.

Release notes: https://github.com/teaguesterling/duck_hunt/releases/tag/v1.12.0

`ref` is `68ca1c4676f706980a6503c19b789f5224596b4d`, which is the `v1.12.0` tag and is on `main`. The DuckDB-main canary is green on that commit across every leg it builds, `Test` step included.