### PR TITLE
scalarfs: v1.6.0

### DIFF
--- a/extensions/scalarfs/description.yml
+++ b/extensions/scalarfs/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: scalarfs
   description: A collection of virtual filesystems for working with scalars
-  version: 1.5.1
+  version: 1.6.0
   language: C++
   build: cmake
   license: MIT
@@ -10,8 +10,8 @@ extension:
 repo:
   github: teaguesterling/duckdb_scalarfs
   andium: 68faa6c72054123a6c6521dd41c12f929431da50
-  ref: 03a7d8e23178a2c9fcb3a16292dd60a23e059a8d
-  ref_next: 03a7d8e23178a2c9fcb3a16292dd60a23e059a8d
+  ref: 4863e4e33cf80792bcd0ebd72e6d5580aacd0e2a
+  ref_next: 4863e4e33cf80792bcd0ebd72e6d5580aacd0e2a
 docs:
   hello_world: |
     LOAD scalarfs;


### PR DESCRIPTION
Builds against DuckDB 2.0.0 as well as the pinned v1.5 line. The v2.0 canary had been commented out in this repo (`# duckdb_version: main`), so it had never been built against DuckDB 2.0 in CI at all — re-enabling it is what surfaced the `DirectoryExists` break below.

- **Binary formats can be written to variables.** `Close()` passed a `std::string` to `Value::BLOB(const string &)` — the *parsing* constructor, which expects hex-escaped text rather than raw bytes — so no binary format could be written to a variable at all.
- **Positioned exact reads no longer under-read silently.** All three memory filesystems returned short instead of raising when a positioned read could not be satisfied.
- **An empty write no longer leaves a stale value.** `Close()` skipped the write when the buffer was empty, leaving the previous value in place.
- **`DirectoryExists` implemented on all five filesystems.** DuckDB 2.0's `COPY TO` probes its target before writing and the base implementation throws — ten test cases failed at run time after a clean compile.

Release notes: https://github.com/teaguesterling/duckdb_scalarfs/releases/tag/v1.6.0

`ref` is `4863e4e33cf80792bcd0ebd72e6d5580aacd0e2a`, which is the `v1.6.0` tag and is on `main`. `ref_next` advances with it, since this is the release that makes the extension build against DuckDB 2.0. On that commit the DuckDB-main canary's linux_amd64 leg is green with its `Test` step run, and the stable linux_amd64 leg passed both `Test extension (inside docker)` and `Test extension (outside docker)`.