### PR TITLE
Add apple_health extension (macOS first)

### DIFF
--- a/extensions/apple_health/description.yml
+++ b/extensions/apple_health/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: apple_health
   description: Read Apple Health export.zip / export.xml as typed DuckDB tables (records, workouts, activity rings, workout routes and GPX points)
-  version: 0.1.0
+  version: 0.1.1
   language: C
   build: cmake
   license: Apache-2.0
@@ -13,7 +13,8 @@ extension:
 
 repo:
   github: Mjboothaus/duckdb-apple-health
-  ref: 092eed0d46eda0926697212abb6a1bd5975aa71a
+  # v0.1.1 — stable C extension API stamp v1.2.0 (community CI load fix)
+  ref: c447fa60d56b445da430c3f8472794dde9c79ec2
 
 docs:
   hello_world: |

--- a/extensions/apple_health/description.yml
+++ b/extensions/apple_health/description.yml
@@ -1,0 +1,54 @@
+extension:
+  name: apple_health
+  description: Read Apple Health export.zip / export.xml as typed DuckDB tables (records, workouts, activity rings, workout routes and GPX points)
+  version: 0.1.0
+  language: C
+  build: cmake
+  license: Apache-2.0
+  requires_toolchains: "python3"
+  maintainers:
+    - Mjboothaus
+  # Start with macOS; widen after CI is proven
+  excluded_platforms: "linux_amd64;linux_arm64;linux_amd64_musl;linux_arm64_musl;windows_amd64;windows_amd64_mingw;windows_amd64_rtools;windows_arm64;wasm_mvp;wasm_eh;wasm_threads"
+
+repo:
+  github: Mjboothaus/duckdb-apple-health
+  ref: 092eed0d46eda0926697212abb6a1bd5975aa71a
+
+docs:
+  hello_world: |
+    -- After INSTALL apple_health FROM community; LOAD apple_health;
+    -- Use a Health export.zip (or test fixture path when developing from source)
+    SELECT type_short, count(*) AS n
+    FROM read_apple_health('export.zip')
+    GROUP BY 1
+    ORDER BY n DESC
+    LIMIT 10;
+  extended_description: |
+    **apple_health** is a DuckDB scanner for [Apple Health](https://www.apple.com/ios/health/) exports
+    (the zip the Health app produces). It is written in **C** on DuckDB's **stable C API**
+    ([extension-template-c](https://github.com/duckdb/extension-template-c)).
+
+    ### Table functions
+    - `read_apple_health(path)` — top-level Health records
+    - `apple_health_workouts(path)` — workouts
+    - `apple_health_activity_summaries(path)` — daily activity rings
+    - `apple_health_workout_routes(path)` — route metadata + GPX path
+    - `apple_health_workout_route_points(path)` — GPX track points
+
+    `path` may be `export.zip`, a directory containing `export.xml`, or `export.xml` itself.
+
+    ### Design notes
+    Large exports are a full **scan** (first pass can be memory-heavy). Prefer materialising
+    slices with `COPY … TO '….parquet'` for day-to-day analytics.
+
+    Top-level `<Record>` only — nested Correlation children are skipped (same samples usually
+    also appear top-level).
+
+    ### Platform
+    Initial community builds target **macOS** (Apple Silicon / Intel). Other platforms may
+    follow once CI is green.
+
+    ### Source
+    https://github.com/Mjboothaus/duckdb-apple-health — optional Python helpers in-repo are
+    **not** part of this extension binary.


### PR DESCRIPTION
## Extension
**apple_health** — read Apple Health `export.zip` / `export.xml` as typed DuckDB tables.

| | |
|--|--|
| Source | https://github.com/Mjboothaus/duckdb-apple-health |
| Ref | `092eed0d46eda0926697212abb6a1bd5975aa71a` (git tag **v0.1.0**) |
| Language | C (stable C API / extension-template-c) |
| Licence | Apache-2.0 |
| Maintainer | @Mjboothaus |

### Functions
- `read_apple_health`
- `apple_health_workouts`
- `apple_health_activity_summaries`
- `apple_health_workout_routes`
- `apple_health_workout_route_points`

### Platforms
**macOS only for the initial submission** (`excluded_platforms` lists linux/windows/wasm). Happy to widen once CI is proven.

### Notes
- No network I/O / telemetry in the extension
- Synthetic fixtures only in the source repo
- Optional Python helpers in the same monorepo are **not** part of the extension build

### Local verification (source repo)
- SQLLogic: 3/3 pass
- pytest extension smoke: 17 passed / 1 skipped

Please let me know if the C-API monorepo layout needs adjustments for community CI.