### PR TITLE
Update DuckFlight to 0.1.5

### DIFF
--- a/extensions/duckflight/description.yml
+++ b/extensions/duckflight/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duckflight
   description: Query DuckDB from PostgreSQL and Arrow Flight SQL clients, including psql, ADBC, and Airport
-  version: 0.1.4
+  version: 0.1.5
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: sidequery/duckflight-extension
-  ref: 4c5b10e9e920d095eb9fa6f7c0b890155dea6c89
+  ref: 24f4b3ca9d30cb688cf168ca50bbf733eeb70181
 
 docs:
   hello_world: |


### PR DESCRIPTION
Update DuckFlight to 0.1.5 with PostgreSQL client/catalog compatibility and Flight SQL schema fixes. The public shim embeds checksum-pinned core-v0.1.4 binaries for the existing four supported platforms.
