### PR TITLE
markdown: v1.8.0

### DIFF
--- a/extensions/markdown/description.yml
+++ b/extensions/markdown/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: markdown
   description: Read, analyze, and write Markdown files with block-level document representation and inline element support
-  version: 1.7.0
+  version: 1.8.0
   language: C++
   build: cmake
   license: MIT
@@ -11,10 +11,9 @@ extension:
 repo:
   github: teaguesterling/duckdb_markdown
   # andium (DuckDB v1.4.5 track) intentionally left at its prior commit; every
-  # change since -- v1.5.1 structured inline blocks, the v1.5.2 UTF-8 truncation
-  # fix, and v1.6.0 -- ships on the v1.5.x track via ref, which is a v1.5.4 tree.
+  # change since ships on the v1.5.x track via ref, which is a v1.5.4 tree.
   andium: c9e1a4d3b98a814c86295ecb2ed760be286242ba
-  ref: 340c0cd59701f74e9ec29d7e4515c4c3b1bf27b1
+  ref: 75e9d0bc00549d9af7d140920843ecc539f9ac44
 docs:
   hello_world: |
     -- Load the extension
@@ -105,4 +104,4 @@ docs:
 
     Real-world benchmark: Processing 287 Markdown files (2,699 sections, 1,137 code blocks, 1,174 links) in 603ms.
 
-    Full test suite with 1190 passing assertions across 24 test files.
+    Full test suite with 1818 passing assertions across 50 test files.


### PR DESCRIPTION
Builds against DuckDB 2.0.0 as well as the pinned v1.5 line.

- **duck_block spec 6.5.** The provenance column is now `filename` and is **trailing**, after `element_order`. Position is load-bearing rather than stylistic: consumers read struct children by index, so a leading provenance field put the file path where `kind` was expected and shifted every canonical field by one — the 8-field struct did not bind against `duck_block_utils` at all. markdown now also *accepts* the widened shape, via two implicit casts.
- `include_filepath` still works as a deprecated alias producing an identical shape. Only the boolean form is accepted; core's string form renames the column, which would produce a struct no consumer accepts.
- **Content-loss fixes** across the block reader and writer: metadata leaking into rendered output, lists rendering as nothing, four container types dropping their contents, `hr`/`page_break` absorbing inline runs, TOML frontmatter flattening, nested lists discarded, blockquote concatenation, heading formatting loss, backslash escapes lost, and inline HTML dropped.
- **DuckDB 2.0 compatibility by feature detection**, not version macros: `CompatName` is derived from `table_function_bind_t`'s fourth parameter with a `static_assert` pinning it, because `identifier.hpp` was backported into `v1.5-variegata` *without* the accompanying signature change — so a `__has_include` probe returns the wrong answer as soon as pins advance.

Release notes: https://github.com/teaguesterling/duckdb_markdown/releases/tag/v1.8.0

`ref` is `75e9d0bc00549d9af7d140920843ecc539f9ac44`, which is the `v1.8.0` tag and is on `main`. On that commit the DuckDB-main canary is green with its `Test` step run, and the separate WASM integration checks pass as well.