### PR TITLE
zim: v0.9.0

### DIFF
--- a/extensions/zim/description.yml
+++ b/extensions/zim/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: zim
   description: Read and write .zim (Kiwix / openZIM) archives directly in DuckDB via libzim, from local files or remote S3/HTTP — offline Wikipedia, WikiMed, Stack Exchange, iFixit, and more, with a zim:// filesystem, full-text search, and COPY TO for building archives from any query.
-  version: 0.8.1
+  version: 0.9.0
   language: C++
   build: cmake
   license: GPL-2.0-or-later
@@ -12,7 +12,7 @@ extension:
   vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
 repo:
   github: teaguesterling/duckdb_zim
-  ref: df80e1e713b08f75e4fb8f7e0a18250486b127f7
+  ref: 2aca66d7c460c8470661bed02c9f5fe3a8db21d1
 docs:
   hello_world: |
     -- Load the extension


### PR DESCRIPTION
Builds against DuckDB 2.0.0 as well as the pinned v1.5.4 line.

- **A NULL-check bug that printed one answer and returned another.** v2.0 gives every `Vector` its own size and `Vector::SetValue` no longer advances it, so child vectors sat at size 0. Values read back correctly through the chunk count, but `IS NULL`/`IS NOT NULL` iterate the *vector's* size and wrote nothing — a column printed `NULL` while `x IS NULL` returned `false`, in the same result set. Compiles clean; only running the tests against v2.0 surfaces it.
- The remote-search CI job now pairs each extension artifact with a matching DuckDB shell and fails loudly. It had been loading a v2.0 extension into a v1.5.4 CLI, and `2>/dev/null || true` turned the resulting ABI error into an empty result reported as a missing search hit.
- COPY option names are lowercased by v2.0's PEG parser; a test pinning an error string was corrected.

Release notes: https://github.com/teaguesterling/duckdb_zim/releases/tag/v0.9.0

`ref` is `2aca66d7c460c8470661bed02c9f5fe3a8db21d1`, the commit the `v0.9.0` annotated tag points at, and it is the tip of `main`. 556 assertions on the pinned build; the DuckDB-main canary's `Build` and `Test` steps are both green.
