### PR TITLE
plinking_duck: v0.9.0

### DIFF
--- a/extensions/plinking_duck/description.yml
+++ b/extensions/plinking_duck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: plinking_duck
   description: Read PLINK 2 genomics file formats and run common genetic analyses directly in SQL
-  version: 0.8.2
+  version: 0.9.0
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: teaguesterling/plinking_duck
-  ref: b32b0cde755ee261ad4e25ca6634e9bc1c560786
+  ref: 0859a3c3c38daef417d666313516074a375f6631
 
 docs:
   hello_world: |


### PR DESCRIPTION
Builds against DuckDB 2.0.0 as well as the pinned v1.5 line.

- **A SIGSEGV in the logistic path.** plink-ng's float kernels use aligned AVX loads (`_mm256_load_ps`), which fault on anything less than 32-byte alignment, and `LogisticBuffers` held its scratch in `std::vector<float>` — which guarantees only 16. Latent: it crashed on one DuckDB build and passed on another from identical source.
- **Ploidy-aware `plink_score` and `plink_missing` on sex chromosomes.** Haploid calls on chrY/chrMT now contribute one allele rather than two, and chrY excludes females and unknown-sex samples instead of mean-imputing a score for a chromosome they lack. `plink_glm`'s chrX handling is documented rather than silently assumed.
- **Signed LD and population-weighted LD**, contributed by @sounkou-bioinfo, rebased onto current main with authorship preserved.
- Under-allocated Hessian scratch corrected to plink-ng's own floors (`p * MAXV(p, 7)` and `p * MAXV(p, 3)`).

Release notes: https://github.com/teaguesterling/plinking_duck/releases/tag/v0.9.0

`ref` is `0859a3c3c38daef417d666313516074a375f6631`, the commit the `v0.9.0` annotated tag points at, and it is the tip of `main`. 4751 assertions; the DuckDB-main canary's `Build` and `Test` steps are both green.
