### PR TITLE
func_apply: v0.3.0

### DIFF
--- a/extensions/func_apply/description.yml
+++ b/extensions/func_apply/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: func_apply
   description: Dynamic function invocation - call any scalar function or macro by name at runtime
-  version: 0.2.0
+  version: 0.3.0
   language: C++
   build: cmake
   license: MIT
@@ -10,11 +10,12 @@ extension:
 repo:
   github: teaguesterling/duckdb_func_apply
   # andium (DuckDB v1.4.5 track) intentionally left at the pre-v0.2.0 commit:
-  # v0.2.0 is a DuckDB v1.5.4 tree and is not built-verified against v1.4.5.
-  # The v0.2.0 security fix (GHSA-55g5-vp25-phpg) is delivered on the v1.5.4
-  # track via `ref`; v1.4.5 users should move to the v1.5.4 track.
+  # v0.3.0, like v0.2.0 before it, is a DuckDB v1.5.4 tree and is not
+  # build-verified against v1.4.5. The v0.2.0 security fix
+  # (GHSA-55g5-vp25-phpg) is delivered on the v1.5.4 track via `ref`;
+  # v1.4.5 users should move to the v1.5.4 track.
   andium: 2013ac345d6f19e61ee78cacae161eb272cf1837
-  ref: refs/tags/v0.2.0
+  ref: ed51705a1db83eb382423aff564fe8373c2322b7
 docs:
   hello_world: |
     -- Load the extension


### PR DESCRIPTION
Builds against DuckDB 2.0.0 as well as the pinned v1.5 line.

- **DuckDB 2.0 compatibility.** `CompatName` is derived from `table_function_bind_t`'s fourth parameter with a `static_assert` pinning it, rather than probed for with `__has_include` — `identifier.hpp` was backported into `v1.5-variegata` *without* the accompanying signature change, so a header-presence probe returns the wrong answer as soon as pins advance. All four `Catalog::GetEntry` call sites are wrapped, including the templated one in `BindApplyWith`.
- **The security model is now documented.** The modes (`none`/`blacklist`/`whitelist`/`validator`) and the `func_apply_set_*` functions existed but were absent from the README, with the default being `mode = "none"` — no restrictions. The function table also named `validator` as a mode with no documented way to set it.
- **A README example that never worked is fixed.** `apply_table_with('generate_series', args := [1], kwargs := {stop: 10, step: 2})` errored on every version that shipped it — `stop`/`step` are *positional*. Replaced with examples that run, plus the first passing tests for `apply_table_with`'s kwargs; the only prior case asserted a failure.
- Return-type behaviour documented, including that `VARCHAR` is the fallback when a *constant* name fails bind-time lookup, not only for dynamic names.

Release notes: https://github.com/teaguesterling/duckdb_func_apply/releases/tag/v0.3.0

`ref` moves from the symbolic `refs/tags/v0.2.0` to the pinned commit `ed51705a1db83eb382423aff564fe8373c2322b7`, which is what the `v0.3.0` annotated tag points at and is the tip of `main`. `andium` stays pinned at its pre-v0.2.0 commit for the reason recorded in the comment: this is a v1.5.4 tree and is not build-verified against v1.4.5. Main CI is green and the DuckDB-main canary's `Build` and `Test` steps both pass.
