### PR TITLE
duckdb_mcp: v2.3.0

### DIFF
--- a/extensions/duckdb_mcp/description.yml
+++ b/extensions/duckdb_mcp/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duckdb_mcp
   description: Model Context Protocol (MCP) extension for DuckDB that enables seamless integration between SQL databases and MCP servers. Provides both client capabilities for accessing remote MCP resources via SQL and server capabilities for exposing database content as MCP resources.
-  version: 2.2.0
+  version: 2.3.0
   language: C++
   build: cmake
   license: Apache-2.0
@@ -10,7 +10,7 @@ extension:
     - teaguesterling
 repo:
   github: teaguesterling/duckdb_mcp
-  ref: 7db1650a1b4c04914ae724dd43244e690094ffc0
+  ref: a6b8648e4e0ec121da534b704b962ac41e2638bf
 
 docs:
   hello_world: |


### PR DESCRIPTION
Builds against DuckDB 2.0.0 as well as the pinned v1.5 line.

- **`builtin_tools` flag** to suppress the built-in tool set in one switch (#75). An explicit per-tool `enable_*_tool` still overrides it in either key order, and `builtin_tools: true` restores the *default* set — it never enables `execute`.
- **mcpfs resource content is parsed as JSON**, not scanned for the literal `"text":"`. The old scan picked a decoy `text` key earlier in the payload, silently dropped every content part after the first, and returned the entire JSON-RPC result as the file body for binary `blob` parts.
- **A security recipe corrected**: the "custom read-only tools" example disabled `enable_query_tool` alone, leaving `export` — which itself takes an arbitrary SQL argument — plus three schema-disclosing tools.
- Per-tool flags documented in the README's tool table, the actual cause of #75.

Release notes: https://github.com/teaguesterling/duckdb_mcp/releases/tag/v2.3.0

`ref` is `a6b8648e4e0ec121da534b704b962ac41e2638bf`, the commit the `v2.3.0` annotated tag points at, and it is the tip of `main` (17 commits ahead of the v2.2.0 ref). 1189 assertions; the DuckDB-main canary's `Build` and `Test` steps are both green.
