### PR TITLE
duck_tails: v1.6.0

### DIFF
--- a/extensions/duck_tails/description.yml
+++ b/extensions/duck_tails/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duck_tails
   description: Smart Development Intelligence for DuckDB - Git-aware data analysis capabilities that allow querying git history, accessing files at any revision, and performing version-aware data analysis with SQL.
-  version: 1.5.0
+  version: 1.6.0
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
     - teaguesterling
 repo:
   github: teaguesterling/duck_tails
-  ref: aac04047feb111f087c416e488bb2625955b0d79
+  ref: 742af7b0e916806958257e65fdd717377282d7e0
 
 docs:
   hello_world: |


### PR DESCRIPTION
DuckDB 2.0.0 compatibility.

- `GitFileSystem` implements the positional `Read(handle, buffer, nr_bytes, location)`. It previously overrode only the sequential form; v1.5's readers call the sequential one and v2.0's call the positional one, so every read through `git://` failed on v2.0. 13 of 59 test files failed before, 59 pass after.
- Fixture setup gated on `SKIP_TESTS`, since linux runs `make test_<type>` twice.
- Retired a temporary `post_build_command` that hooked a target extension-ci-tools no longer defines.
- CI: the duckdb-main canary was failing at repository discovery and masking the above; fixed by declaring git `safe.directory` at system level, which libgit2 resolves without `$HOME`.
