### PR TITLE
sitting_duck: bump to v1.11.0

### DIFF
--- a/extensions/sitting_duck/description.yml
+++ b/extensions/sitting_duck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: sitting_duck
   description: Parse and analyze source code ASTs from 27 programming languages with tree-sitter grammars, pattern matching, and structural search
-  version: 1.10.2
+  version: 1.11.0
   language: C++
   build: cmake
   license: Apache-2.0
@@ -9,7 +9,7 @@ extension:
     - teaguesterling
 repo:
   github: teaguesterling/sitting_duck
-  ref: 6bff057cbf1e9b475029068e41e9a4ebfcb92797
+  ref: b8c06a843193a84065ae24cc95c6a4052f3c84ec
 docs:
   hello_world: |
     -- Parse Python code and find function definitions


### PR DESCRIPTION
Bumps `sitting_duck` from v1.10.2 → **v1.11.0** (ref `b8c06a84`).

Highlights:
- **DuckDB v2.0 (cyanoptera) build+test compatibility** — the extension is now cross-version (v1.5.4 and v2.0), verified green on Linux + macOS in CI.
- **duck_blocks 6.5** vendored vocabulary/conformance sync; `ast_to_blocks` emits `level >= 1` per the current spec.
- **13 tree-sitter grammars** bumped to latest tags + parsers regenerated.

Release: https://github.com/teaguesterling/sitting_duck/releases/tag/v1.11.0