### PR TITLE
Updates cozip to 2.0.0

### DIFF
--- a/extensions/cozip/description.yml
+++ b/extensions/cozip/description.yml
@@ -1,31 +1,40 @@
 extension:
   name: cozip
   description: Cloud-Optimized ZIP reader for DuckDB
-  version: 1.2.0
+  version: 2.0.0
   language: C++
   build: cmake
   license: MIT
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads"
   maintainers:
     - csaybar
     - ryali93
 repo:
   github: asterisk-labs/cozip_reader
-  ref: 593d2853a294c33dc1c505c5d7c504159b332489
+  ref: 774210364dbceab03564fb6d9db4cb3c17678c13
 docs:
   hello_world: |
     INSTALL cozip FROM community;
     LOAD cozip;
 
-    SELECT *
-    FROM read_cozip('https://huggingface.co/datasets/Major-TOM/Core-VIIRS-Nighttime-Light/resolve/main/2024/MAJORTOM-VIIRS-NTL_2024_median_000.zip')
-    LIMIT 10;
+    -- One row per sample, one column per file, ready for a dataloader.
+    SELECT * FROM read_taco('https://example.org/cloudsen12.zip') LIMIT 10;
+
+    -- A Flat-profile archive is a plain manifest instead.
+    SELECT * FROM read_flat('https://example.org/dataset.zip') LIMIT 10;
+
   extended_description: |
-    cozip replaces the ZIP Central Directory scan with a Parquet metadata
-    file located through a fixed 51-byte header at byte 0 of the archive.
-    read_cozip(path) reads that Parquet directly through a virtual
-    cozip-subfile filesystem, so range requests flow lazily through the
-    underlying transport. Works on local files and remote URLs (HTTPS, S3,
-    GCS, Azure, HuggingFace), on native and WebAssembly. Every row gets
-    an extra cozip:gdal_vsi column with a /vsisubfile/ path that opens
-    the referenced inner file in GDAL or rasterio without re-downloading
-    the archive.
+    cozip puts an index at byte 0 of a ZIP archive, so a reader reaches any
+    file inside it in one range request instead of scanning the Central
+    Directory. This extension reads both cozip profiles without downloading
+    the archive, over HTTPS, S3, GCS, Azure or HuggingFace.
+
+    read_flat(path) returns the Flat-profile manifest: one row per entry with
+    name, offset, size and whatever columns the writer added.
+
+    read_taco(path) returns one row per sample with one column per file in the
+    contract. Pass pivoted := false for one row per file. It reads .zip,
+    FOLDER, and TACOCAT datasets.
+
+    Every data column holds a GDAL /vsisubfile/ path that opens the referenced
+    file in GDAL, rasterio or terra without extracting the archive.


### PR DESCRIPTION
Added

- read_taco(path) reads a hierarchical dataset stored in a cozip archive, returning one row per sample with one column per file, each column holding a GDAL /vsisubfile/ pointer. Pass pivoted := false for one row per file.
- The same function handles the three container shapes, a .zip archive, a plain directory, and a directory with consolidated metadata.
- idx, files and level narrow the scan before the pivot, and taco_contract(), taco_structure(), taco_levels() and taco_collection() expose the dataset layout without loading the json extension.
- Test fixtures for flat, hierarchical, variable-leaf and null-structure archives, plus the directory containers.

Changed

- read_cozip is now read_flat. The old name stays as a deprecated alias and will be removed in 3.0.
- read_flat reports which profile it found when handed the wrong kind of archive.
- The byte-0 index parser now returns every entry from a single read and rejects entries whose byte range falls outside the archive.
- COLLECTION.json is parsed with the yyjson DuckDB already vendors, instead of a hand-written scanner.

Removed

- WebAssembly builds.
