### PR TITLE
Fix `ref_next` incorrectly assuming the `ref` value when it is not explicitly defined.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,10 @@ on:
         required: false
         type: boolean
         default: false
+      require_ref_next:
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: build-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ inputs.extension_name || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.duckdb_version || '' }}
@@ -90,6 +94,7 @@ jobs:
       env:
         ALL_CHANGED_FILES: ${{ github.event_name == 'workflow_dispatch' && format('extensions/{0}/description.yml', inputs.extension_name) || steps.changed-files.outputs.all_changed_files }}
         PIP_BREAK_SYSTEM_PACKAGES: 1
+        COMMUNITY_EXTENSION_REQUIRE_REF_NEXT: ${{ inputs.require_ref_next }}
       run: |
         pip install pyyaml
         # scripts/build.py takes DUCKDB_VERSION from environment
@@ -100,7 +105,7 @@ jobs:
   build:
     needs: prepare
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5-variegata
-    if: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_NAME != '' }}
+    if: ${{ needs.prepare.outputs.COMMUNITY_EXTENSION_NAME != '' && needs.prepare.outputs.COMMUNITY_EXTENSION_REF != '' }}
     with:
       duckdb_version: ${{ inputs.duckdb_version || 'v1.5.5' }}
       duckdb_tag: ${{ inputs.duckdb_tag || '' }}

--- a/.github/workflows/build_next.yml
+++ b/.github/workflows/build_next.yml
@@ -20,3 +20,4 @@ jobs:
       duckdb_version: 'v2.0-cyanoptera'
       ci_tools_version: 'main'
       deploy: 'false'
+      require_ref_next: true

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -44,9 +44,13 @@ with open('env.sh', 'w+') as hdl:
 		if 'andium' in desc['repo']:
 			extension_ref = desc['repo']['andium']
 	elif os.environ['DUCKDB_VERSION'] != os.environ['DUCKDB_LATEST_STABLE']:
-		if 'ref_next' in desc['repo']:
+		if desc['repo'].get('ref_next'):
 			extension_ref = desc['repo']['ref_next']
-	hdl.write(f"COMMUNITY_EXTENSION_REF={extension_ref}\n")
+		elif os.environ.get('COMMUNITY_EXTENSION_REQUIRE_REF_NEXT') == 'true':
+			print("Skipping prerelease validation: repo.ref_next is not defined")
+			extension_ref = None
+	if extension_ref:
+		hdl.write(f"COMMUNITY_EXTENSION_REF={extension_ref}\n")
 	hdl.write(f"COMMUNITY_EXTENSION_NAME={desc['extension']['name']}\n")
 	excluded_platforms = desc['extension'].get('excluded_platforms')
 	opt_in_platforms = desc['extension'].get('opt_in_platforms')


### PR DESCRIPTION
In https://github.com/duckdb/community-extensions/pull/2595 we enabled validation for `v2.0.0`. This caused `ref` to be validated against `v2.0.0` when `ref_next` was not defined in the descriptor file.

This PR adds a guard so that `v2.0.0` validation only happens when `ref_next` is explicitly defined.