### PR TITLE
ducklake_cdc: v0.6.3

### DIFF
--- a/extensions/ducklake_cdc/description.yml
+++ b/extensions/ducklake_cdc/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: ducklake_cdc
   description: "Stream changes from your DuckLake — durable consumer cursors, single-reader windows, typed DDL events."
-  version: "0.6.2"
+  version: "0.6.3"
   language: C++
   build: cmake
   license: Apache-2.0
@@ -12,5 +12,5 @@ extension:
     - "ekkuleivonen"
 
 repo:
-  github: "ekkuleivonen/ducklake-cdc-extension"
-  ref: "db3a5b17b63be5316a93ce7fce32dedf97abd186"
+  github: "elei-io/ducklake-cdc-extension"
+  ref: "f909296f3fe11c95177b24796fcae683d75a9d08"


### PR DESCRIPTION
Update ducklake_cdc to [v0.6.3](https://github.com/elei-io/ducklake-cdc-extension/releases/tag/v0.6.3), commit `f909296f3fe11c95177b24796fcae683d75a9d08`, and reflect the source repository transfer to `elei-io`.

This release targets DuckDB v1.5.5 and fixes CDC changing the shared DuckDB worker-pool size during queries. Main CI, the complete distribution build matrix, and sanitizer checks passed in [release run 34134162171](https://github.com/elei-io/ducklake-cdc-extension/actions/runs/34134162171). The release includes nine platform binaries and checksums.

The descriptor preserves the existing maintainer and test configuration. Submitted manually after the release workflow's bot token could not push the fork branch due to its workflow permission scope.
