### PR TITLE
Update duck_dggs to v0.1.9

### DIFF
--- a/extensions/duck_dggs/description.yml
+++ b/extensions/duck_dggs/description.yml
@@ -2,7 +2,7 @@ extension:
   name: duck_dggs
   description: DuckDB extension for discrete global grid systems (DGGS) powered by DGGRID v8.
   
-  version: 0.1.8
+  version: 0.1.9 # x-release-please-version
   language: C++
   build: cmake
   license: MIT
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: am2222/duckdb-dggs
-  ref: bbcfb2518e6950b8d30bdae1e9c4280fb98bcfb1
+  ref: 998d9a9f749f427a31cb83a1f237fd11dc899579
 
 docs:
   hello_world: |
@@ -138,3 +138,4 @@ docs:
     - `igeo7_is_valid` — false only for the `UINT64_MAX` invalid-neighbour sentinel
     - `igeo7_decode_str` — verbose `base-d1.d2…d20` form showing all 20 slots (SQL macro)
     - `igeo7_string_parent` / `igeo7_string_local_pos` / `igeo7_string_is_center` — compact-string helpers (SQL macros)
+    - `igeo7_geo_to_authalic` / `igeo7_authalic_to_geo` — remap each vertex's latitude in a `GEOMETRY` between WGS84 geodetic and authalic (equal-area sphere) using the Karney 2022 order-6 polynomial Fourier series; useful before equal-area binning of lon/lat data


### PR DESCRIPTION
Bumps `duck_dggs` to v0.1.9 (`998d9a9f749f427a31cb83a1f237fd11dc899579`).

Release notes: https://github.com/am2222/duckdb-dggs/releases/tag/v0.1.9

Opened automatically by the release workflow in am2222/duckdb-dggs.