### PR TITLE
oracle_scanner: bump to 0.2.2

### DIFF
--- a/extensions/oracle_scanner/description.yml
+++ b/extensions/oracle_scanner/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: oracle_scanner
   description: Read and write Oracle Database with no Oracle client
-  version: '0.2.1'
+  version: '0.2.2'
   language: C++
   build: cmake
   license: Apache-2.0
@@ -12,5 +12,5 @@ extension:
 
 repo:
   github: krokozyab/quack-oracle
-  # The commit tagged v0.2.1, pinned by SHA so what is built cannot move.
-  ref: 9f20a57db690a7033b22ac8ca6423e749608d262
+  # The commit tagged v0.2.2, pinned by SHA so what is built cannot move.
+  ref: 8a368747f710366fd69bb715089e69165292e685


### PR DESCRIPTION
Databases whose character set is not AL32UTF8 were refused at connect. The ref is the commit tagged v0.2.2, whose matrix is green on Linux amd64/arm64, macOS arm64/x86_64 and Windows.