### PR TITLE
Add rustyconover as maintainer of chsql

### DIFF
--- a/extensions/chsql/description.yml
+++ b/extensions/chsql/description.yml
@@ -8,6 +8,7 @@ extension:
   maintainers:
     - lmangani
     - akvlad
+    - rustyconover
   excluded_platforms: "windows_amd64_rtools;windows_amd64_mingw;windows_amd64;"
 
 repo:


### PR DESCRIPTION
The `chsql` extension is published from the Query-farm GitHub org, but `rustyconover` was not listed in its `maintainers` field. This adds that entry alongside the existing maintainers; no other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ahi2AwNiG2Udbpmc2ZzTWG