### PR TITLE
Add rustyconover as maintainer of chsql_native

### DIFF
--- a/extensions/chsql_native/description.yml
+++ b/extensions/chsql_native/description.yml
@@ -10,6 +10,7 @@ extension:
   maintainers:
     - lmangani
     - adubovikov
+    - rustyconover
 
 repo:
   github: Query-farm/duckdb-extension-clickhouse-native


### PR DESCRIPTION
The `chsql_native` extension is published from the Query-farm GitHub org, but `rustyconover` was not listed in its `maintainers` field. This adds that entry alongside the existing maintainers; no other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ahi2AwNiG2Udbpmc2ZzTWG