### PR TITLE
Add rustyconover as maintainer of quackscale

### DIFF
--- a/extensions/quackscale/description.yml
+++ b/extensions/quackscale/description.yml
@@ -9,6 +9,7 @@ extension:
   maintainers:
     - lmangani
     - smithclay
+    - rustyconover
 
 repo:
   github: Query-farm/quackscale


### PR DESCRIPTION
The `quackscale` extension is published from the Query-farm GitHub org, but `rustyconover` was not listed in its `maintainers` field. This adds that entry alongside the existing maintainers; no other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ahi2AwNiG2Udbpmc2ZzTWG