### PR TITLE
mssql: v0.2.5

### DIFF
--- a/extensions/mssql/description.yml
+++ b/extensions/mssql/description.yml
@@ -21,7 +21,10 @@ extension:
 
 repo:
   github: "hugr-lab/mssql-extension"
-  ref: "v0.2.5"
+  # v0.2.5. A SHA rather than the tag name, at the maintainers' request:
+  # a tag can be moved, and this one was -- after v0.2.5 was tagged and before
+  # it was submitted here, to pick up a fix.
+  ref: d35b617c16587e02b4d6e62057ead8f84c1568bf
 
 docs:
   hello_world: |

--- a/extensions/mssql/description.yml
+++ b/extensions/mssql/description.yml
@@ -1,12 +1,13 @@
 extension:
   name: mssql
   description: "Connect DuckDB to Microsoft SQL Server via native TDS (including TLS)."
-  version: "0.2.4"
+  version: "0.2.5"
   language: "C++"
   build: "cmake"
   licence: "MIT"
   maintainers:
     - "VGSML"
+    - "oluies"
   excluded_platforms:
     - "osx_amd64"
     - "windows_arm64"
@@ -20,7 +21,7 @@ extension:
 
 repo:
   github: "hugr-lab/mssql-extension"
-  ref: "v0.2.4"
+  ref: "v0.2.5"
 
 docs:
   hello_world: |


### PR DESCRIPTION
Bumps `mssql` to **v0.2.5**, and adds [@oluies](https://github.com/oluies) as a maintainer.

Built against DuckDB **v1.5.5** — this release comes from the extension's `duckdb-v1.5.5` maintenance branch rather than its `main`, which has already moved to the DuckDB 2.0 pre-release line.

`vcpkg_commit` is unchanged (`52c9e08c`), and still matches the extension's own `builtin-baseline`.

## What is in it

Two fixes that a generic catalog consumer hits immediately. Both surfaced while building a DuckLake catalog manager over an attached SQL Server database, but neither is specific to that — they are about the extension behaving like a catalog rather than like a query function.

- **The catalog's default schema is `dbo`, not DuckDB's `main`** ([#129](https://github.com/hugr-lab/mssql-extension/issues/129)). `MSSQLCatalog` did not override `Catalog::GetDefaultSchema()`, so the base answer `main` came back — a schema no SQL Server database has. Anything resolving an unqualified name through the catalog default failed with `Schema 'main' not found in MSSQL database`; the workaround in the wild was to `CREATE` a schema literally called `main` on the server.

- **Two catalog scans of one catalog inside an explicit transaction no longer break the pinned connection** ([#239](https://github.com/hugr-lab/mssql-extension/issues/239)). A transaction pins one TDS connection per catalog and routes every read to it, while a scan holds that connection from init until its last row is drained — and DuckDB does not promise to drain one source before initializing the next. Such plans are now materialized into a buffer-managed collection as each scan starts, releasing the connection immediately. Autocommit is unchanged.

Release notes: https://github.com/hugr-lab/mssql-extension/blob/v0.2.5/CHANGELOG.md

## Verification

Release workflow green on the tagged commit across all built platforms, with the Linux integration suite against a live SQL Server.