### PR TITLE
panduck: update to v0.4.1

### DIFF
--- a/extensions/panduck/description.yml
+++ b/extensions/panduck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: panduck
   description: Read documents natively into the duck_block vocabulary -- DOCX, ODT, EPUB, RTF, LaTeX, Org, RST, ipynb, MediaWiki and Textile -- and write them back as Pandoc JSON, without linking Pandoc
-  version: 0.2.0
+  version: 0.3.1
   language: C++
   build: cmake
   license: MIT
@@ -13,7 +13,11 @@ extension:
   vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
 repo:
   github: teaguesterling/duckdb_panduck
-  ref: a57402beff9805d69c1590733224fc9a71b5b08b
+  ref: dc3007d1b5eb31b73cbb7e6eabd501fc68865c39
+  # SAME COMMIT AS `ref`, deliberately. Without ref_next, scripts/build.py prints
+  # "Skipping prerelease validation" and the PR passes green having never built against
+  # DuckDB v2.0 -- a green that means "did not look". panduck v0.2.0 merged that way.
+  ref_next: dc3007d1b5eb31b73cbb7e6eabd501fc68865c39
 docs:
   hello_world: |
     LOAD panduck;
@@ -109,9 +113,12 @@ docs:
 
     ## Scope
 
-    This is an early release. Ten readers are implemented and tested against reference
-    implementations, with 2034 test assertions, differential validation against a real
-    pandoc on every fixture, and eight checks in CI.
+    This is an early release. Ten native readers are implemented and tested against
+    reference implementations -- RTF, DOCX, ODT, EPUB, LaTeX, Org, RST, ipynb, MediaWiki,
+    Textile -- plus a Pandoc AST reader, with 2384 test assertions, differential validation
+    against a real pandoc on every fixture, and eight checks in CI. PDF, Markdown and HTML
+    are read by delegating to the pdf, markdown and webbed extensions rather than by a
+    reader here.
 
     The readers were audited over five rounds before this release, each round asking a
     question the previous one could not answer -- does a construct come back at all, do

--- a/extensions/panduck/description.yml
+++ b/extensions/panduck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: panduck
   description: Read documents natively into the duck_block vocabulary -- DOCX, ODT, EPUB, RTF, LaTeX, Org, RST, ipynb, MediaWiki and Textile -- and write them back as Pandoc JSON, without linking Pandoc
-  version: 0.3.1
+  version: 0.4.0
   language: C++
   build: cmake
   license: MIT
@@ -13,11 +13,11 @@ extension:
   vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
 repo:
   github: teaguesterling/duckdb_panduck
-  ref: dc3007d1b5eb31b73cbb7e6eabd501fc68865c39
+  ref: 6932fab5aca47d89d0af02da8256c2d344aab9d1
   # SAME COMMIT AS `ref`, deliberately. Without ref_next, scripts/build.py prints
   # "Skipping prerelease validation" and the PR passes green having never built against
   # DuckDB v2.0 -- a green that means "did not look". panduck v0.2.0 merged that way.
-  ref_next: dc3007d1b5eb31b73cbb7e6eabd501fc68865c39
+  ref_next: 6932fab5aca47d89d0af02da8256c2d344aab9d1
 docs:
   hello_world: |
     LOAD panduck;
@@ -37,6 +37,16 @@ docs:
 
     -- Outline any supported document
     SELECT * FROM doc_toc('report.docx');
+
+    -- Pull one section out, by heading or by a fragment of one
+    SELECT * FROM doc_section('report.docx', 'Methods');
+    SELECT * FROM doc_section('report.docx', 'Meth', match := 'contains');
+
+    -- ...or find the section by what it SAYS rather than what it is called
+    SELECT * FROM doc_search_sections('report.docx', 'p < 0.05');
+
+    -- Render one back out (md, html or text)
+    SELECT doc_render('report.docx', 'md');
 
     -- Write back out as Pandoc JSON that a real pandoc accepts
     SELECT panduck_write_pandoc_ast('doc.json',

--- a/extensions/panduck/description.yml
+++ b/extensions/panduck/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: panduck
   description: Read documents natively into the duck_block vocabulary -- DOCX, ODT, EPUB, RTF, LaTeX, Org, RST, ipynb, MediaWiki and Textile -- and write them back as Pandoc JSON, without linking Pandoc
-  version: 0.4.0
+  version: 0.4.1
   language: C++
   build: cmake
   license: MIT
@@ -13,11 +13,11 @@ extension:
   vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
 repo:
   github: teaguesterling/duckdb_panduck
-  ref: 6932fab5aca47d89d0af02da8256c2d344aab9d1
+  ref: c8aee8a04204d3e91a7932eef7de8c7d0dca7750
   # SAME COMMIT AS `ref`, deliberately. Without ref_next, scripts/build.py prints
   # "Skipping prerelease validation" and the PR passes green having never built against
   # DuckDB v2.0 -- a green that means "did not look". panduck v0.2.0 merged that way.
-  ref_next: 6932fab5aca47d89d0af02da8256c2d344aab9d1
+  ref_next: c8aee8a04204d3e91a7932eef7de8c7d0dca7750
 docs:
   hello_world: |
     LOAD panduck;


### PR DESCRIPTION
Updates panduck from v0.3.0 to **v0.4.1**.

*(Opened as v0.3.1 and updated in place as newer releases superseded it, rather than reopening.)*

## Why not v0.4.0

**This PR's own `test_against_latest` job rejected it.** v0.4.0's ref does not build against DuckDB v2.0:

```
src/reader_registry.cpp:686: error: no matching function for call to
  Catalog::GetEntry(ClientContext&, CatalogType, const char[1], const char[5], std::string)
```

v2.0 takes `Identifier` where v1.5.5 takes `string`, and `Identifier` is **explicit** from a runtime `std::string` while **implicit** from a `const char *` — so one spelling binds in both. The break has been present since **v0.3.1**, so an earlier merge of this PR would have shipped it.

The same job then found a second, **silent** v2.0 defect: `doc_search_sections` returned **zero rows for every pattern**, including the empty pattern that must return the whole document. The `b` CTE wraps a table function, is scanned twice, and the final projection touches every one of its columns; `MATERIALIZED` fixes it. Verified against a local `v2.0-cyanoptera` build, where the full suite now passes.

## `ref_next` paid for itself twice in one release cycle

Both v2.0 defects were found **only** because the descriptor sets `ref_next`. Without it, `scripts/build.py` prints `Skipping prerelease validation` and this PR passes green having never built against v2.0 — which is how panduck v0.2.0 merged.

`ref` and `ref_next` are the same commit deliberately, unchanged since the first submission.

## Also in this release

Install guidance that named a command which 404s: `pdf` and `duck_block_utils` are community extensions, so a bare `INSTALL` looks in the core repository. Fixed in the README and in three error messages — one of which had no guidance at all, on the path panduck's own docs recommend. Reported by `l1t1`.

## Since v0.3.0

- `doc_render` now composes with `panduck_resolved_format`
- `doc_section(..., match := 'contains')` — substring matching with containment dedup
- `doc_search_sections(src, pattern, format)` — find a section by its content
- pre-parsed `duck_block` fixtures at the pdf/markdown/webbed boundary, with a CI drift check

## Verification

`c8aee8a` is simultaneously the `v0.4.1` tag's commit, the head of `main`, and what `panduck_version()` reports from a build configured there.

- upstream CI green across linux_amd64, linux_arm64, osx_arm64, osx_amd64, windows_amd64, wasm_mvp, wasm_threads
- panduck's own DuckDB-`main` canary green on the architecture that runs tests
- v1.5.5: 2524 assertions, 26 test cases; v2.0: 2245 assertions, 19 cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019nkprWWWSkwuWNmAEoVUs2
