### PR TITLE
ossie: bump to 0.1.1

### DIFF
--- a/extensions/ossie/description.yml
+++ b/extensions/ossie/description.yml
@@ -3,7 +3,7 @@ extension:
   description: The Apache Ossie (incubating) reference implementation for DuckDB. Reads Ossie
     semantic model files in YAML or JSON and answers semantic queries against the tables in DuckDB,
     from a single binary, with no infrastructure. Also exposes the semantic layer via MCP.
-  version: 0.1.0
+  version: 0.1.1
   language: C++
   build: cmake
   license: MIT
@@ -13,7 +13,7 @@ extension:
 
 repo:
   github: iqea-ai/duckdb-ossie
-  ref: ef995aa581455840c7adc4e24d30220b047962a3
+  ref: 5180c67299ca14fde9d46806c7d35f9f53c2f1a9
 
 docs:
   hello_world: |
@@ -91,12 +91,14 @@ docs:
 
     **Conformance**
 
-    Models are validated against the format's own `core-spec/osi-schema.json`. The test suite
+    Models are validated against the format's own `core-spec/ossie-schema.json`. The test suite
     includes five models published by other Ossie implementers -- Databricks, GoodData, NVIDIA,
     Omni and OrionBelt -- vendored verbatim from apache/ossie; four load and answer queries, and
     the fifth carries only DATABRICKS expressions, which this extension does not execute.
-    Generated SQL is checked against hand-written TPC-DS SQL at sf=1 across every metric and every
-    dimension, so correctness is measured against the numbers rather than against our own output.
+    Generated SQL is diffed against hand-written TPC-DS equivalents with symmetric EXCEPT over
+    dsdgen(sf = 0.01) data, so correctness is measured against the numbers rather than against our
+    own output. That currently covers total_sales and books_sales. The remaining metrics are
+    exercised by golden-SQL, grain or vocabulary tests, none of which can catch a wrong number.
 
     Current limits are documented rather than hidden: ANSI_SQL expressions only, one semantic model
     per file, table-backed sources only, all joins emitted as INNER, and metrics spanning more than
@@ -106,8 +108,14 @@ docs:
 
     `examples/server.sql` publishes a model over MCP via the duckdb_mcp community extension, giving
     an agent a `semantic_query` tool plus `metrics` and `dimensions` resources to discover names
-    from. The agent can reach nothing but the model's own vocabulary: filters are allowlisted,
-    subqueries are refused outright, and no argument lets a caller widen that.
+    from. Within that tool the agent reaches nothing but the model's own vocabulary: filters are
+    allowlisted, subqueries are refused outright, and no argument lets a caller widen that.
+
+    That holds for the connection, not just the tool: server.sql disables every built-in duckdb_mcp
+    tool -- query, export, list_tables, describe, database_info -- so tools/list returns only
+    semantic_query and calling anything else is refused. Disabling query alone would not be enough,
+    because export takes an arbitrary SQL argument and reaches the same data. A CI job asserts both
+    directions of this on every push.
 
     This is an independent implementation of the Apache Ossie file format. It is not affiliated
     with, endorsed by, or an official product of the Apache Software Foundation.


### PR DESCRIPTION
Bumps `ossie` to 0.1.1 and points `ref` at the [v0.1.1](https://github.com/iqea-ai/duckdb-ossie/releases/tag/v0.1.1) tag (`5180c67`).

A patch follows 0.1.0 quickly because **0.1.0's `extended_description` contained a security claim that was false**, and I would rather correct it than leave it rendered on the extension page.

### What was wrong

0.1.0 said an agent connected over MCP *"can reach nothing but the model's own vocabulary."* `duckdb_mcp` also publishes generic `query`, `export`, `list_tables`, `describe` and `database_info` tools; calling `query` returned 7,212 rows from a table the semantic model never declares.

`examples/server.sql` now disables all five when it starts the server, so `tools/list` returns only `semantic_query` and calling anything else is refused with *Tool not found*. That makes the original claim true, and a CI job asserts it on every push — including a control server started *without* the flags, so the assertion cannot pass merely because the built-ins stopped being published.

Reported upstream as teaguesterling/duckdb_mcp#75; the per-tool flags existed but were missing from that project's tool table, which the maintainer has since fixed. Worth noting for anyone else publishing a curated tool: disabling `query` alone is not sufficient, because `export` takes an arbitrary SQL argument and reaches the same data.

### Also in this release

- `examples/server.sql` never loaded the extension it demonstrates — it loaded `duckdb_mcp` but not `ossie`, and called `dsdgen` without `tpcds`, so it only worked from a build tree. Following the README after a registry install hit `Catalog Error: Table Function with name ossie_load does not exist!`
- Dropped `-unsigned` from the documented invocation and the Claude Desktop config snippet; community extensions are signed, so it only disabled signature verification for the whole session
- CI now loads the built `.duckdb_extension` on `linux_amd64` and `osx_arm64` and runs a 40-assertion end-to-end check against it, rather than only testing inside the build tree

### Two documentation claims also corrected

While verifying everything in this descriptor before submitting, two statements turned out to be wrong:

- `core-spec/osi-schema.json` → `core-spec/ossie-schema.json`. Apache renamed it; the old path 404s
- *"checked against hand-written TPC-DS SQL at sf=1 across every metric and every dimension"* — the differential tests run `dsdgen(sf = 0.01)` and cover 2 of 5 metrics. Now stated accurately

### Verification

- Built from `5180c67` through this repo's own pipeline on a fork: 11/14 jobs success, 0 failures (`deploy`/`archive`/`doc_test` skipped off `main`) — https://github.com/iqea-ai/community-extensions/actions/runs/34392215844
- `scripts/build.py` run against this descriptor resolves to `COMMUNITY_EXTENSION_REF=5180c67299ca14fde9d46806c7d35f9f53c2f1a9`
- `hello_world` executed by hand: returns `US|350.00`, `DE|75.00`
- Upstream `iqea-ai/duckdb-ossie`: 16/16 CI green at the tagged commit