### PR TITLE
Update vcpkg to 2026.06.24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,8 @@ jobs:
       COMMUNITY_EXTENSION_REQUIRES_TOOLCHAINS: ${{ steps.parse.outputs.COMMUNITY_EXTENSION_REQUIRES_TOOLCHAINS }}
       COMMUNITY_EXTENSION_TEST_CONFIG: ${{ steps.parse.outputs.COMMUNITY_EXTENSION_TEST_CONFIG }}
       COMMUNITY_EXTENSION_VCPKG_URL: ${{ steps.parse.outputs.COMMUNITY_EXTENSION_VCPKG_URL == '' && 'https://github.com/microsoft/vcpkg.git' || steps.parse.outputs.COMMUNITY_EXTENSION_VCPKG_URL }}
-      COMMUNITY_EXTENSION_VCPKG_COMMIT: ${{ steps.parse.outputs.COMMUNITY_EXTENSION_VCPKG_COMMIT == '' && '84bab45d415d22042bd0b9081aea57f362da3f35' || steps.parse.outputs.COMMUNITY_EXTENSION_VCPKG_COMMIT }}
+      # Release 2026.06.24
+      COMMUNITY_EXTENSION_VCPKG_COMMIT: ${{ steps.parse.outputs.COMMUNITY_EXTENSION_VCPKG_COMMIT == '' && 'cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3' || steps.parse.outputs.COMMUNITY_EXTENSION_VCPKG_COMMIT }}
     env:
       DUCKDB_LATEST_STABLE: 'v1.5.5'
       DUCKDB_VERSION: ${{ inputs.duckdb_version || 'v1.5.5' }}

--- a/.github/workflows/cache_warming.yml
+++ b/.github/workflows/cache_warming.yml
@@ -20,6 +20,9 @@ jobs:
       exclude_archs: 'windows_amd64_mingw' # TODO: fixme: extension template fails?
       skip_tests: true
       save_cache: true
+      # Release 2026.06.24
+      # Temporary override; remove when extension-ci-tools updates its default.
+      vcpkg_commit: cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3
     secrets: inherit
 
   parse_dependency_list:
@@ -52,4 +55,7 @@ jobs:
       save_cache: true
       vcpkg_extra_dependencies: ${{needs.parse_dependency_list.outputs.dependencies}}
       vcpkg_binary_sources: ${{ vars.VCPKG_BINARY_SOURCES }}
+      # Release 2026.06.24
+      # Temporary override; remove when extension-ci-tools updates its default.
+      vcpkg_commit: cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3
     secrets: inherit

--- a/extensions/waddle/description.yml
+++ b/extensions/waddle/description.yml
@@ -11,7 +11,7 @@ extension:
   # (Optional) param that specifies required extra toolchains
   requires_toolchains: "rust"
   # (Optional) param that specifies a precise vcpkg commit to use
-  vcpkg_commit: "84bab45d415d22042bd0b9081aea57f362da3f35"
+  vcpkg_commit: "cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3"
   # (Optional) this extension requires additional custom toolchain setup
   custom_toolchain_script: true
   # (Optional) ';' separated list of additional platforms

--- a/extensions/waddle/description.yml
+++ b/extensions/waddle/description.yml
@@ -10,8 +10,8 @@ extension:
 
   # (Optional) param that specifies required extra toolchains
   requires_toolchains: "rust"
-  # (Optional) param that specifies a precise vcpkg commit to use
-  vcpkg_commit: "cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3"
+  # (Optional) param that specifies a precise vcpkg commit to use. Uses COMMUNITY_EXTENSION_VCPKG_COMMIT by default
+  # vcpkg_commit: "cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3"
   # (Optional) this extension requires additional custom toolchain setup
   custom_toolchain_script: true
   # (Optional) ';' separated list of additional platforms


### PR DESCRIPTION
This pr updates the vcpkg version to 2026.06.24.

This is part of updating all of duckdb, therefore merging should be done in coordination with stakeholders.

References:
https://github.com/duckdb/duckdb/pull/25094
https://github.com/duckdblabs/duckdb-internal/issues/10429