### PR TITLE
Update TsFile extension source repository

### DIFF
--- a/extensions/tsfile/description.yml
+++ b/extensions/tsfile/description.yml
@@ -1,6 +1,6 @@
 extension:
   name: tsfile
-  description: Query Apache TsFile table-model files directly from DuckDB
+  description: Query and write Apache TsFile table-model files from DuckDB
   version: 0.1.0
   language: C++
   build: cmake
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: TimechoLab/tsfile-duckdb
-  ref: 0a95f6233f71b9ae3ed55ef0fe57e1791bad817f
+  ref: e741cc4741a1b00eb65078382ac3b81b8dc5375d
 
 docs:
   hello_world: |
@@ -24,10 +24,11 @@ docs:
 
   extended_description: |
     The TsFile extension exposes the read_tsfile(path, table_name) table
-    function for querying Apache TsFile table-model files. It maps TsFile
-    columns to DuckDB types, pushes projections and time predicates into the
-    reader, and streams results in DuckDB vector-sized batches.
+    function for querying Apache TsFile table-model files and supports writing
+    query results with COPY ... TO ... (FORMAT TSFILE). It maps TsFile columns
+    to DuckDB types, pushes projections, time predicates, and TAG predicates
+    into the reader, and streams results in DuckDB vector-sized batches.
 
     The initial release supports one local file and one table per scan.
     Tree-model files, multi-file scans, automatic table discovery, parallel
-    scans, and TAG/FIELD predicate pushdown are not yet implemented.
+    scans, and FIELD predicate pushdown are not yet implemented.

--- a/extensions/tsfile/description.yml
+++ b/extensions/tsfile/description.yml
@@ -10,8 +10,8 @@ extension:
     - ColinLeeo
 
 repo:
-  github: ColinLeeo/tsfile-duckdb
-  ref: 34e6865cbb251cf318cc443d8bb3a26c018e60a9
+  github: TimechoLab/tsfile-duckdb
+  ref: 0a95f6233f71b9ae3ed55ef0fe57e1791bad817f
 
 docs:
   hello_world: |

--- a/extensions/tsfile/description.yml
+++ b/extensions/tsfile/description.yml
@@ -11,7 +11,7 @@ extension:
 
 repo:
   github: TimechoLab/tsfile-duckdb
-  ref: e741cc4741a1b00eb65078382ac3b81b8dc5375d
+  ref: 9840c600fec9aefec3d9351d8ee27c643033b752
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary

- move the TsFile extension source reference to `TimechoLab/tsfile-duckdb`
- pin the self-contained static-build commit
- update the descriptor for `COPY ... (FORMAT TSFILE)` support and TAG predicate pushdown
- remove the external `TSFILE_ROOT`/runtime `libtsfile` requirement by bundling Apache TsFile and its codecs statically
- include the vcpkg and Windows MSVC/MinGW compatibility fixes required by Community Extensions CI

## Validation

Preflight PR: https://github.com/ColinLeeo/community-extensions/pull/2

The complete stable matrix passed:

- Linux x64 and ARM64
- macOS Intel and ARM64
- Windows MSVC static and MinGW static
- SQLLogicTests on all test-enabled targets

Wasm remains intentionally excluded by the extension descriptor.

Source changes: https://github.com/TimechoLab/tsfile-duckdb/pull/2