### PR TITLE
Add mssql_ducklake: DuckLake with its catalog in SQL Server / Azure SQL (v0.1.0)

### DIFF
--- a/extensions/mssql_ducklake/description.yml
+++ b/extensions/mssql_ducklake/description.yml
@@ -19,7 +19,7 @@ extension:
 
 repo:
   github: "hugr-lab/mssql-ducklake"
-  ref: "v0.1.0"
+  ref: "a37cbfd8ed84f20f450996306e8ae2555dc20ea9"
 
 docs:
   hello_world: |

--- a/extensions/mssql_ducklake/description.yml
+++ b/extensions/mssql_ducklake/description.yml
@@ -31,22 +31,10 @@ docs:
     SELECT count(*) FROM lake.t;
 
   extended_description: |
-    Runs [DuckLake](https://ducklake.select) with its **catalog in Microsoft SQL Server or
-    Azure SQL**. The extension embeds the complete, unmodified DuckLake source at a pinned
-    release and adds a SQL Server metadata manager beside DuckLake's built-in PostgreSQL and
-    SQLite ones; it talks to the server through the mssql extension (native TDS, no ODBC), which
-    must be installed too. Everything DuckLake does - snapshots, time travel, schema evolution,
-    data inlining, partitioning, the maintenance functions, `ducklake:postgres:` catalogs as
-    well - works as in the stock extension; the data files live wherever DuckLake puts them.
+    Runs [DuckLake](https://ducklake.select) with its **catalog in Microsoft SQL Server or Azure SQL**. The extension embeds the complete, unmodified DuckLake source at a pinned release and adds a SQL Server metadata manager beside DuckLake's built-in PostgreSQL and SQLite ones; it talks to the server through the mssql extension (native TDS, no ODBC), which must be installed too. Everything DuckLake does - snapshots, time travel, schema evolution, data inlining, partitioning, the maintenance functions, `ducklake:postgres:` catalogs as well - works as in the stock extension; the data files live wherever DuckLake puts them.
 
     Documentation: https://hugr-lab.github.io/mssql-ducklake/
 
-    **Mutually exclusive with the stock `ducklake` extension**: both provide the same functions
-    and the same `ducklake:` attach prefix - load one or the other, and load `mssql_ducklake`
-    before the first `ATTACH 'ducklake:...'`. Needs the mssql extension v0.2.5 or newer, and a
-    SQL Server 2019+ or Azure SQL database (a UTF-8 collation).
+    **Mutually exclusive with the stock `ducklake` extension**: both provide the same functions and the same `ducklake:` attach prefix - load one or the other, and load `mssql_ducklake` before the first `ATTACH 'ducklake:...'`. Needs the mssql extension v0.2.5 or newer, and a SQL Server 2019+ or Azure SQL database (a UTF-8 collation).
 
-    Experimental. The catalog is shaped for SQL Server on creation (primary keys, UTF-8 binary
-    collation, indexes, forced parameterization), commits go to the server as T-SQL, and the
-    1000-table benchmark runs at 1.5x of the PostgreSQL backend's time with commits at parity;
-    what is not there yet is on the limitations page.
+    Experimental. The catalog is shaped for SQL Server on creation (primary keys, UTF-8 binary collation, indexes, forced parameterization), commits go to the server as T-SQL, and the 1000-table benchmark runs at 1.5x of the PostgreSQL backend's time with commits at parity; what is not there yet is on the limitations page.

--- a/extensions/mssql_ducklake/description.yml
+++ b/extensions/mssql_ducklake/description.yml
@@ -1,0 +1,52 @@
+extension:
+  name: mssql_ducklake
+  description: "DuckLake with its catalog in Microsoft SQL Server or Azure SQL - embedded DuckLake, native TDS through the mssql extension."
+  version: "0.1.0"
+  language: "C++"
+  build: "cmake"
+  licence: "MIT"
+  maintainers:
+    - "VGSML"
+  # the same set as mssql's: the manager is nothing without the mssql extension at runtime, and
+  # there is no mssql on these platforms (no wasm at all - raw TDS sockets)
+  excluded_platforms:
+    - "osx_amd64"
+    - "windows_arm64"
+    - "wasm_mvp"
+    - "wasm_eh"
+    - "wasm_threads"
+  test_config: '{"test_env_variables": {"SKIP_TESTS": "1"}}'
+
+repo:
+  github: "hugr-lab/mssql-ducklake"
+  ref: "v0.1.0"
+
+docs:
+  hello_world: |
+    INSTALL mssql FROM community;
+    INSTALL mssql_ducklake FROM community;
+    LOAD mssql_ducklake;
+    ATTACH 'ducklake:mssql:Server=localhost,1433;Database=lake_meta;User Id=sa;Password=...' AS lake (DATA_PATH 's3://bucket/lake/');
+    CREATE TABLE lake.t AS SELECT range AS i FROM range(100);
+    SELECT count(*) FROM lake.t;
+
+  extended_description: |
+    Runs [DuckLake](https://ducklake.select) with its **catalog in Microsoft SQL Server or
+    Azure SQL**. The extension embeds the complete, unmodified DuckLake source at a pinned
+    release and adds a SQL Server metadata manager beside DuckLake's built-in PostgreSQL and
+    SQLite ones; it talks to the server through the mssql extension (native TDS, no ODBC), which
+    must be installed too. Everything DuckLake does - snapshots, time travel, schema evolution,
+    data inlining, partitioning, the maintenance functions, `ducklake:postgres:` catalogs as well
+    - works as in the stock extension; the data files live wherever DuckLake puts them.
+
+    Documentation: https://hugr-lab.github.io/mssql-ducklake/
+
+    **Mutually exclusive with the stock `ducklake` extension**: both provide the same functions
+    and the same `ducklake:` attach prefix - load one or the other, and load `mssql_ducklake`
+    before the first `ATTACH 'ducklake:...'`. Needs the mssql extension v0.2.5 or newer, and a
+    SQL Server 2019+ or Azure SQL database (a UTF-8 collation).
+
+    Experimental. The catalog is shaped for SQL Server on creation (primary keys, UTF-8 binary
+    collation, indexes, forced parameterization), commits go to the server as T-SQL, and the
+    1000-table benchmark runs at 1.5x of the PostgreSQL backend's time with commits at parity;
+    what is not there yet is on the limitations page.

--- a/extensions/mssql_ducklake/description.yml
+++ b/extensions/mssql_ducklake/description.yml
@@ -36,8 +36,8 @@ docs:
     release and adds a SQL Server metadata manager beside DuckLake's built-in PostgreSQL and
     SQLite ones; it talks to the server through the mssql extension (native TDS, no ODBC), which
     must be installed too. Everything DuckLake does - snapshots, time travel, schema evolution,
-    data inlining, partitioning, the maintenance functions, `ducklake:postgres:` catalogs as well
-    - works as in the stock extension; the data files live wherever DuckLake puts them.
+    data inlining, partitioning, the maintenance functions, `ducklake:postgres:` catalogs as
+    well - works as in the stock extension; the data files live wherever DuckLake puts them.
 
     Documentation: https://hugr-lab.github.io/mssql-ducklake/
 


### PR DESCRIPTION
Adds **mssql_ducklake** — [DuckLake](https://ducklake.select) with its catalog in Microsoft SQL Server or Azure SQL.

The extension embeds the complete, unmodified DuckLake source at a pinned release (`v1.5-variegata`) and adds a SQL Server metadata manager beside DuckLake's built-in PostgreSQL and SQLite ones; it talks to the server through the `mssql` community extension (native TDS), which it needs at runtime (v0.2.5 or newer). Everything DuckLake does works on the SQL Server catalog; the data files live wherever DuckLake puts them.

Two things a reviewer will want to know, both stated in the description:

- it is **mutually exclusive with the stock `ducklake` extension** — same functions, same `ducklake:` attach prefix — and refuses to load beside it with a message naming the choice;
- `excluded_platforms` is the `mssql` extension's set plus wasm: the manager is nothing where `mssql` does not exist.

The build runs the repository's `extension_config.cmake`, which also builds `mssql` beside the extension for its test suite — the same build the repository's distribution workflow runs on every push. The server-backed tests are skipped here (`SKIP_TESTS`).

- Repository: https://github.com/hugr-lab/mssql-ducklake — release [v0.1.0](https://github.com/hugr-lab/mssql-ducklake/releases/tag/v0.1.0)
- Documentation: https://hugr-lab.github.io/mssql-ducklake/
- License: MIT (DuckLake is MIT as well)
