### PR TITLE
duck_block_utils 3.1.0

### DIFF
--- a/extensions/duck_block_utils/description.yml
+++ b/extensions/duck_block_utils/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: duck_block_utils
   description: Build, transform, validate, and extract content from structured documents using the duck_block type
-  version: 3.0.1
+  version: 3.1.0
   language: C++
   build: cmake
   license: MIT
@@ -14,7 +14,8 @@ repo:
   # so advancing this pin would point a v1.4.5 build at a tree that cannot build for
   # it. v1.4.5 users should move to the v1.5.x track.
   andium: 125662df9e5450105dc9b7957ad955cb53d7beec
-  ref: 959965034939352e6e6389da7c202b365d924fa5
+  ref: 6c1c2e51fdc79c18adca059d84c846cb234854ba
+  ref_next: 6c1c2e51fdc79c18adca059d84c846cb234854ba
 docs:
   hello_world: |
     -- Build a document programmatically
@@ -152,6 +153,8 @@ docs:
     | Function | Description |
     |----------|-------------|
     | `duck_blocks_validate(blocks)` | Spec conformance: valid, plus errors |
+    | `duck_blocks_repair(blocks)` | Deterministic fixes for the list-level rules: wrap orphans, rebase, renumber |
+    | `duck_block_implicit_parent(type, kind)` | The wrapper a fragment of that element gets, from the spec table |
     | `duck_blocks_lint(blocks)` | Advisory conformance warnings |
     | `duck_blocks_quality(blocks)` | Document quality, which is NOT conformance |
     | `duck_block_spec_version()` | The spec version this build implements |


### PR DESCRIPTION
Bumps duck_block_utils to v3.1.0 (tag on 6c1c2e5). Spec duck_blocks 1.2: fragments are legal input, list-level validation, `duck_blocks_repair`, `duck_block_implicit_parent`, conformance corpus; and the `duck_block_implicit_parent` build fix for DuckDB main. Release notes: https://github.com/teaguesterling/duckdb_duck_block_utils/releases/tag/v3.1.0

`ref_next` set to the same commit. `andium` pin unchanged (no v1.4.x support in this tree, as before). Same batch as the sibling duck_blocks producers moving to spec 1.2 (markdown, panduck, webbed).